### PR TITLE
Build: Version aus RELEASE-Datei übernehmen; URLs für openjverein

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -11,9 +11,9 @@ define.package                  = de.jost_net.JVerein
 define.java.version             = 1.7
 
 project.releaseCurrent          = ${release.dir}/current
-project.release                 = ${release.dir}/${plugin.version}-${build.number}
+project.release                 = ${release.dir}/${plugin_version}-${build.number}
 project.tmp                     = ${project.release}/tmp
 project.javadoc                 = ${project.release}/javadoc
 project.zipdir                  = ${project.release}/${plugin.name}
-project.zipfilename             = ${plugin.name}.${plugin.version}-${build.number}.zip
+project.zipfilename             = ${plugin.name}.${plugin_version}.zip
 project.zipfilenameCurrent      = ${plugin.name}.zip

--- a/build/build.xml
+++ b/build/build.xml
@@ -10,6 +10,11 @@
 		<tstamp>
 			<format property="build.timestamp" pattern="yyyyMMdd" />
 		</tstamp>
+		<loadfile property="plugin_version" srcFile="${build.dir}/RELEASE">
+			<filterchain>
+				<striplinebreaks/>
+			</filterchain>
+		</loadfile>
 		<buildnumber file="${build.dir}/BUILD" />
 
 		<loadproperties srcfile="${build.dir}/build.properties" />
@@ -62,7 +67,7 @@
 				<attribute name="Built-By" value="${user.name}" />
 				<attribute name="Built-Date" value="${DSTAMP}" />
 				<attribute name="Implementation-Title" value="${plugin.name}" />
-				<attribute name="Implementation-Version" value="${plugin.version}" />
+				<attribute name="Implementation-Version" value="${plugin_version}" />
 				<attribute name="Implementation-Buildnumber" value="${build.number}" />
 				<attribute name="Class-Path" value="lang help lib" />
 			</manifest>
@@ -76,6 +81,10 @@
 			<fileset dir="${lib.dir}" />
 		</copy>
 		<copy todir="${project.zipdir}" file="plugin.xml" />
+		<replace file="${project.zipdir}/plugin.xml">
+			<replacefilter token="[VERSION]" value="${plugin_version}"/>
+			<replacefilter token="[PLUGIN_ZIP]" value="${project.zipfilename}"/>
+		</replace>
 		<!-- Jetzt muessen wir noch das ZIP-File erzeugen -->
 		<zip destfile="${project.release}/${project.zipfilename}">
 			<fileset dir="${project.release}">

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,16 +1,16 @@
 <plugin xmlns="http://www.willuhn.de/schema/jameica-plugin"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.willuhn.de/schema/jameica-plugin http://www.willuhn.de/schema/jameica-plugin-1.2.xsd"
-        name="jverein" version="2.8.19" class="de.jost_net.JVerein.JVereinPlugin">
+        name="jverein" version="[VERSION]" class="de.jost_net.JVerein.JVereinPlugin">
 
   <description>OpenSource-Vereinsverwaltung</description>
-  <url>https://www.jverein.de/updates/2.8/jverein.2.8.19.zip</url>
-  <homepage>https://www.jverein.de</homepage>
+  <url>https://openjverein.github.io/jameica-repository/[PLUGIN_ZIP]</url>
+  <homepage>https://openjverein.github.io/</homepage>
   <license>GPL - http://www.gnu.org/copyleft/gpl.html</license>
   <icon>jverein-icon-64x64.png</icon>
   <menu>
     <item name="JVerein" >
-  	  <item name="&amp;Über" 
+      <item name="&amp;Über"
             action="de.jost_net.JVerein.gui.action.AboutAction" 
             icon="gtk-info.png"  />
       <item name="-" />
@@ -25,21 +25,20 @@
   </classfinder>
 
   <navigation>
-    <item name="JVerein"		
-	  icon-close="folder.png" 
-	  icon-open="folder-open.png" 	
+    <item name="JVerein"
+      icon-close="folder.png"
+      icon-open="folder-open.png"
     id="jverein.main">
     </item>
   </navigation>
-   
+
   <services>
     <service name="database" depends="" autostart="true"
-	  class="de.jost_net.JVerein.server.JVereinDBServiceImpl" />
+      class="de.jost_net.JVerein.server.JVereinDBServiceImpl" />
   </services>
-	
+
   <requires jameica="2.8+">
     <import plugin="hibiscus" version="2.8.7+"/>
   </requires>
-	
-</plugin>
 
+</plugin>

--- a/repository.xml
+++ b/repository.xml
@@ -5,7 +5,7 @@
   name="JVerein Repository">
 
   <plugins name="JVerein"> 
-     <plugin url="http://www.jverein.de/updates/2.8/"/>
+     <plugin url="https://openjverein.github.io/jameica-repository"/>
   </plugins>
 </repository>
 


### PR DESCRIPTION
Für einen Build muss jetzt nur noch die Version in build/RELEASE eingetragen werden. Anschließend kann das Plugin zusammen mit der erzeugten plugin.xml (ist im Plugin-ZIP enthalten) in das Jameica-Repository von openjverein hochgeladen werden.