### PR TITLE
Abrechnungslauf Abbuchungsausgabe DATEI umgestellt auf hbci4java (hibiscus)

### DIFF
--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.Queries;
 import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.List;
+import java.util.HashMap;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.Suchbetrag;
@@ -50,20 +51,26 @@ public class BuchungQuery
   private List<Buchung> ergebnis;
 
   private Boolean hasMitglied;
+  
+  private HashMap<String, String> sortValues = new HashMap<String, String>();
 
-  private static final int ORDER_UMSATZID = 0;
-
-  private static final int ORDER_DATUM = 1;
-
-  private static final int ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER = 2;
-
-  private static final int ORDER_DATUM_NAME = 3;
-
-  private static final int ORDER_ID = 4;
-
-  private static final int ORDER_DATUM_ID = 5;
-
-  private int order = ORDER_UMSATZID;
+  private void SortHashMap() {
+	  sortValues.put("ORDER_ID","order by id");
+	  sortValues.put("ORDER_DATUM","order by datum");
+	  sortValues.put("ORDER_DATUM_NAME","order by datum, name");
+	  sortValues.put("ORDER_DATUM_ID","order by datum, id");
+	  sortValues.put("ORDER_DATUM_ID_NAME","order by datum, id, name");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER","order by datum, auszugsnummer");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_NAME","order by datum, auszugsnummer, name");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER","order by datum, blattnummer");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER_NAME","order by datum, blattnummer, name");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_ID","order by datum, auszugsnummer, id");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER_ID","order by datum, blattnummer, id");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER_ID","order by datum, auszugsnummer, blattnummer, id");
+	  sortValues.put("DEFAULT","order by datum, auszugsnummer, blattnummer, id");
+  }
+  
+  public String ordername = null;
 
   public BuchungQuery(Date datumvon, Date datumbis, Konto konto,
       Buchungsart buchungsart, Projekt projekt, String text, String betrag,
@@ -79,9 +86,24 @@ public class BuchungQuery
     this.hasMitglied = hasMitglied;
   }
 
-  public void setOrderID()
+  public String getOrder(String value) {
+	  SortHashMap();
+	  String newvalue = null;
+	  if ( ordername != null ) {
+		  newvalue = value.replaceAll(", ", "_");
+		  newvalue = newvalue.toUpperCase();
+		  newvalue = "ORDER_" + newvalue;
+          return sortValues.get(newvalue);
+	  } else {
+		  return sortValues.get("DEFAULT");
+	  }
+  }
+  
+  public void setOrdername(String value)
   {
-    order = ORDER_ID;
+    if ( value != null ) {
+    	ordername = value;
+    }
   }
 
   public Boolean getHasMitglied()
@@ -92,26 +114,6 @@ public class BuchungQuery
   public void setHasMitglied(Boolean hasMitglied)
   {
     this.hasMitglied = hasMitglied;
-  }
-
-  public void setOrderDatum()
-  {
-    order = ORDER_DATUM;
-  }
-
-  public void setOrderDatumID()
-  {
-    order = ORDER_DATUM_ID;
-  }
-
-  public void setOrderDatumAuszugsnummerBlattnummer()
-  {
-    order = ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER;
-  }
-
-  public void setOrderDatumName()
-  {
-    order = ORDER_DATUM_NAME;
   }
 
   public Date getDatumvon()
@@ -245,41 +247,12 @@ public class BuchungQuery
           "(upper(name) like ? or upper(zweck) like ? or upper(kommentar) like ?) ",
           ttext, ttext, ttext);
     }
-    switch (order)
-    {
-      case ORDER_UMSATZID:
-      {
-        it.setOrder("ORDER BY umsatzid DESC");
-        break;
-      }
-      case ORDER_DATUM:
-      {
-        it.setOrder("ORDER BY datum");
-        break;
-      }
-      case ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER:
-      {
-        it.setOrder("ORDER BY datum, auszugsnummer, blattnummer, id");
-        break;
-      }
-      case ORDER_DATUM_NAME:
-      {
-        it.setOrder("ORDER BY datum, name, id");
-        break;
-      }
-      case ORDER_ID:
-      {
-        it.setOrder("ORDER BY id");
-        break;
-      }
-      case ORDER_DATUM_ID:
-      {
-        it.setOrder("ORDER BY datum, id");
-        break;
-      }
- 
-    }
-
+         
+    // 20220808: sbuer: Neue Sortierfelder
+    String orderString = getOrder(ordername);
+    System.out.println("ordername : " + ordername + " ,orderString : " + orderString);
+    it.setOrder(orderString);
+    
     this.ergebnis = PseudoIterator.asList(it);
     return ergebnis;
   }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1313,18 +1313,26 @@ public class BuchungsControl extends AbstractControl
       BuchungsjournalSortDialog djs = new BuchungsjournalSortDialog(
           BuchungsjournalSortDialog.POSITION_CENTER);
       String sort = djs.open();
-      if (sort.equals(BuchungsjournalSortDialog.DATUM))
-      {
-        query.setOrderDatumAuszugsnummerBlattnummer();
-      }
-      else if (sort.equals(BuchungsjournalSortDialog.DATUM_NAME))
-      {
-        query.setOrderDatumName();
-      }
-      else
-      {
-        query.setOrderID();
-      }
+      query.setOrdername(sort);
+      
+      
+      // 20220807: sbuer: Ausgewaehlter Sortierwert zwischenspeichern
+      System.out.println("sort : " + sort);
+     
+         
+      //if (sort.equals(BuchungsjournalSortDialog.DATUM))
+      //      {
+      //   query.setOrderDatumAuszugsnummerBlattnummer();
+      // }
+      //else if (sort.equals(BuchungsjournalSortDialog.DATUM_NAME))
+      // {
+      //  query.setOrderDatumName();
+      // }
+      //else
+      // {
+      //  query.setOrderID();
+      // }     
+      
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
       fd.setText("Ausgabedatei wählen.");
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
@@ -35,15 +35,24 @@ import de.willuhn.jameica.system.OperationCanceledException;
 public class BuchungsjournalSortDialog extends AbstractDialog<String>
 {
 
+  public final static String ID = "Id";
   public final static String DATUM = "Datum";
-
-  public final static String DATUM_NAME = "Datum, Name, Buchungsnummer";
-
-  public final static String BUCHUNGSNUMMER = "Buchungsnummer";
+  public final static String DATUM_NAME = "Datum, Name";
+  public final static String DATUM_ID = "Datum, Id";
+  public final static String DATUM_ID_NAME = "Datum, Id, Name";
+  public final static String DATUM_AUSZUGSNUMMER = "Datum, Auszugsnummer";
+  public final static String DATUM_AUSZUGSNUMMER_NAME = "Datum, Auszugsnummer, Name";
+  public final static String DATUM_BLATTNUMMER = "Datum, Blattnummer";
+  public final static String DATUM_BLATTNUMMER_NAME = "Datum, Blattnummer, Name";
+  public final static String DATUM_AUSGZUGSNUMMER_ID = "Datum, Auszugsnummer, Id";
+  public final static String DATUM_BLATTNUMMER_ID = "Datum, Blattnummer, Id";
+  public final static String DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID = "Datum, Auszugsnumme, Blattnummer, Id";
 
   private String selected = DATUM;
 
   private SelectInput sortierung = null;
+  
+  public String selectedValue = DATUM;
 
   public BuchungsjournalSortDialog(int position)
   {
@@ -90,8 +99,13 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
     {
       return this.sortierung;
     }
-    this.sortierung = new SelectInput(new Object[] { DATUM, DATUM_NAME,
-        BUCHUNGSNUMMER }, DATUM);
+    this.sortierung = new SelectInput(new Object[] 
+    		{ ID,DATUM,
+    		  DATUM_NAME,DATUM_ID,DATUM_ID_NAME,
+    		  DATUM_AUSZUGSNUMMER,DATUM_AUSZUGSNUMMER_NAME,
+    		  DATUM_BLATTNUMMER,DATUM_BLATTNUMMER_NAME,
+    		  DATUM_AUSGZUGSNUMMER_ID,DATUM_BLATTNUMMER_ID,
+    		  DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID }, DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID);
     this.sortierung.setName("Sortierung");
     this.sortierung.addListener(new Listener()
     {

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -1,23 +1,15 @@
-/**********************************************************************
- * Copyright (c) by Heiner Jostkleigrewe
- * This program is free software: you can redistribute it and/or modify it under the terms of the 
- * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
- * License, or (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
- *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
- *  the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along with this program.  If not, 
- * see <http://www.gnu.org/licenses/>.
- * 
- * heiner@jverein.de
- * www.jverein.de
- **********************************************************************/
 package de.jost_net.JVerein.io;
 
-import java.io.File;
-import java.io.IOException;
+// Datum          : 20220803
+// Modifziert von : Stefan Bürger
+// Funktion       : Anpassung Abrechungslauf Ausgabe DATEI (kein Hibiscus)
+//   Diese Klasse nutzt die hbci4java Komponente aus hibiscus. Abrechnungsläufe die die Ausgabe DATEI nutzen, können somit 
+//   die aktuellen SEPA-XML Schematas verwenden
+//            
+// -------------------------------------------------
+// Aenderungshistorie:
+// 20220804 : sbuer: Erstes Release
+
 import java.math.BigDecimal;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
@@ -26,9 +18,26 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.datatype.DatatypeConfigurationException;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.String;
+
+import org.apache.commons.lang.StringUtils;
+import org.kapott.hbci.GV.SepaUtil;
+import org.kapott.hbci.GV.generators.ISEPAGenerator;
+import org.kapott.hbci.GV.generators.SEPAGeneratorFactory;
+import org.kapott.hbci.manager.HBCIUtils;
+import org.kapott.hbci.sepa.SepaVersion;
+import org.kapott.hbci.sepa.SepaVersion.Type;
 
 import com.itextpdf.text.DocumentException;
 
@@ -66,10 +75,11 @@ import de.jost_net.OBanToo.SEPA.Basislastschrift.Basislastschrift;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.Basislastschrift2Pdf;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.MandatSequence;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.Zahler;
-import de.jost_net.OBanToo.StringLatin.Zeichen;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.internal.action.Program;
+import de.willuhn.jameica.hbci.HBCIProperties;
+import de.willuhn.jameica.hbci.gui.dialogs.PainVersionDialog;
 import de.willuhn.jameica.hbci.io.SepaLastschriftMerger;
 import de.willuhn.jameica.hbci.rmi.SepaLastSequenceType;
 import de.willuhn.jameica.hbci.rmi.SepaLastType;
@@ -81,897 +91,1007 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class AbrechnungSEPA
-{
-  private Calendar sepagueltigkeit;
+public class AbrechnungSEPA {
+	
+	private Calendar sepagueltigkeit;
+    
+	private int counter = 0;
+	private int counter_all = 0;
+	private int counter_frst = 0;
+	private int counter_rcur = 0;
+	private int counter_index = 0;
+		
+    // Initialisierung der lastschrift properties FRST und RCUR
+	Properties lastschriftFRST = new Properties();
+	Properties lastschriftRCUR = new Properties();
+    // Datumsformatierung fuer Lastschrift
+	DateFormat ISO_DATE = new SimpleDateFormat(SepaUtil.DATE_FORMAT);
 
-  private int counter = 0;
+	String creditorid = Einstellungen.getEinstellung().getGlaeubigerID();
+	
+	  // Funktion um Property LastschriftFRST und LastschriftRCUR zu fuellen
+	  private void lastschrift_fillup(JVereinZahler zahler) throws Exception {
+		 String betrag = zahler.getBetrag().toString();
+         if (zahler.getMandatsequence().toString().equals("Folgelastschrift")) {
+        	    // System.out.println("rcur: counter: " + counter_rcur + ", name : " + zahler.getName() + ", wert : " + zahler.getBetrag());
+                // Jetzt die Daten vom Zahler in das Lastschrift Property schreiben
+     	 	    counter_rcur++;
+     	 	    counter_index=counter_rcur-1;
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("dst.bic",counter_index),      StringUtils.trimToEmpty(zahler.getBic()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("dst.iban",counter_index),     StringUtils.trimToEmpty(zahler.getIban()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("dst.name",counter_index),     StringUtils.trimToEmpty(zahler.getName()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("btg.value",counter_index),    betrag);
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("btg.curr",counter_index),     HBCIProperties.CURRENCY_DEFAULT_DE);
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("usage",counter_index),        StringUtils.trimToEmpty(zahler.getVerwendungszweck()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("endtoendid",counter_index),   "NOTPROVIDED");        
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("creditorid",counter_index),   creditorid);
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("mandateid",counter_index),    StringUtils.trimToEmpty(zahler.getMandatid()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("manddateofsig",counter_index),ISO_DATE.format(zahler.getMandatdatum()));
+                lastschriftRCUR.setProperty(SepaUtil.insertIndex("purposecode",counter_index),  "OHTR");
+        	} else {
+        		// System.out.println("frst: counter: " + counter_frst + ", name : " + zahler.getName() + ", wert : " + zahler.getBetrag());
+        		counter_frst++;
+        		counter_index=counter_frst-1;
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("dst.bic",counter_index),      StringUtils.trimToEmpty(zahler.getBic()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("dst.iban",counter_index),     StringUtils.trimToEmpty(zahler.getIban()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("dst.name",counter_index),     StringUtils.trimToEmpty(zahler.getName()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("btg.value",counter_index),    betrag);
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("btg.curr",counter_index),     HBCIProperties.CURRENCY_DEFAULT_DE);
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("usage",counter_index),        StringUtils.trimToEmpty(zahler.getVerwendungszweck()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("endtoendid",counter_index),   "NOTPROVIDED");        
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("creditorid",counter_index),   creditorid);
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("mandateid",counter_index),    StringUtils.trimToEmpty(zahler.getMandatid()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("manddateofsig",counter_index),ISO_DATE.format(zahler.getMandatdatum()));
+                lastschriftFRST.setProperty(SepaUtil.insertIndex("purposecode",counter_index),  "OHTR");
+        	}
+         counter_all++;
+	  }
 
-  public AbrechnungSEPA(AbrechnungSEPAParam param, ProgressMonitor monitor)
-      throws Exception
-  {
-    if (Einstellungen.getEinstellung().getName() == null
-        || Einstellungen.getEinstellung().getName().length() == 0
-        || Einstellungen.getEinstellung().getIban() == null
-        || Einstellungen.getEinstellung().getIban().length() == 0)
-    {
-      throw new ApplicationException(
-          "Name des Vereins oder Bankverbindung fehlt. Bitte unter Administration|Einstellungen erfassen.");
-    }
+	  // Hauptfunktion für die SEPA-Lastschrift
+	  public AbrechnungSEPA(AbrechnungSEPAParam param, ProgressMonitor monitor)
+	      throws Exception
+	  {
+	    if (Einstellungen.getEinstellung().getName() == null
+	        || Einstellungen.getEinstellung().getName().length() == 0
+	        || Einstellungen.getEinstellung().getIban() == null
+	        || Einstellungen.getEinstellung().getIban().length() == 0)
+	    {
+	      throw new ApplicationException(
+	          "Name des Vereins oder Bankverbindung fehlt. Bitte unter Administration|Einstellungen erfassen.");
+	    }
 
-    if (Einstellungen.getEinstellung().getGlaeubigerID() == null
-        || Einstellungen.getEinstellung().getGlaeubigerID().length() == 0)
-    {
-      throw new ApplicationException(
-          "Gläubiger-ID fehlt. Gfls. unter https://extranet.bundesbank.de/scp/ oder http://www.oenb.at/idakilz/cid?lang=de beantragen und unter Administration|Einstellungen|Allgemein eintragen.\n"
-              + "Zu Testzwecken kann DE98ZZZ09999999999 eingesetzt werden.");
-    }
+	    if (Einstellungen.getEinstellung().getGlaeubigerID() == null
+	        || Einstellungen.getEinstellung().getGlaeubigerID().length() == 0)
+	    {
+	      throw new ApplicationException(
+	          "Gläubiger-ID fehlt. Gfls. unter https://extranet.bundesbank.de/scp/ oder http://www.oenb.at/idakilz/cid?lang=de beantragen und unter Administration|Einstellungen|Allgemein eintragen.\n"
+	              + "Zu Testzwecken kann DE98ZZZ09999999999 eingesetzt werden.");
+	    }
 
-    Abrechnungslauf abrl = getAbrechnungslauf(param);
+	    Abrechnungslauf abrl = getAbrechnungslauf(param);
 
-    sepagueltigkeit = Calendar.getInstance();
-    sepagueltigkeit.add(Calendar.MONTH, -36);
-    JVereinBasislastschrift lastschrift = new JVereinBasislastschrift();
-    // Vorbereitung: Allgemeine Informationen einstellen
-    lastschrift.setBIC(Einstellungen.getEinstellung().getBic());
-    lastschrift
-        .setGlaeubigerID(Einstellungen.getEinstellung().getGlaeubigerID());
-    lastschrift.setIBAN(Einstellungen.getEinstellung().getIban());
-    lastschrift.setKomprimiert(param.kompakteabbuchung.booleanValue());
-    lastschrift
-        .setName(Zeichen.convert(Einstellungen.getEinstellung().getName()));
+	    sepagueltigkeit = Calendar.getInstance();
+	    sepagueltigkeit.add(Calendar.MONTH, -36);
+	    JVereinBasislastschrift lastschrift = new JVereinBasislastschrift();
+	    
+	    // 20220803: sbuer: Anpassungen für hbci4java
+	    PainVersionDialog d = new PainVersionDialog(org.kapott.hbci.sepa.SepaVersion.Type.PAIN_008);
+	    final SepaVersion version = (SepaVersion) d.open();
+	    
+	    // Epochtime als sepaid und pmtinfid
+	    Long epochtime = Calendar.getInstance().getTimeInMillis();
+	    String epochtime_string = epochtime.toString();
+	    
+	    // Eigene Kontodaten
+		lastschriftFRST.setProperty("src.bic", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getBic()));
+		lastschriftFRST.setProperty("src.iban", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getIban()));
+		lastschriftFRST.setProperty("src.name", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getName()));
+		lastschriftFRST.setProperty("sepaid", epochtime_string);
+		lastschriftFRST.setProperty("pmtinfid", epochtime_string);
+	    lastschriftFRST.setProperty("sequencetype", "FRST");
+	    lastschriftFRST.setProperty("targetdate", abrl.getStichtag() != null ? ISO_DATE.format(abrl.getStichtag()) : SepaUtil.DATE_UNDEFINED);
+	    lastschriftFRST.setProperty("type", "CORE");
+	    lastschriftFRST.setProperty("batchbook", "");
+	  
+		lastschriftRCUR.setProperty("src.bic", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getBic()));
+		lastschriftRCUR.setProperty("src.iban", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getIban()));
+		lastschriftRCUR.setProperty("src.name", StringUtils.trimToEmpty(Einstellungen.getEinstellung().getName()));
+		lastschriftRCUR.setProperty("sepaid", epochtime_string);
+		lastschriftRCUR.setProperty("pmtinfid", epochtime_string);
+		lastschriftRCUR.setProperty("sequencetype", "RCUR");
+	    lastschriftRCUR.setProperty("targetdate", abrl.getStichtag() != null ? ISO_DATE.format(abrl.getStichtag()) : SepaUtil.DATE_UNDEFINED);
+	    lastschriftRCUR.setProperty("type", "CORE");
+	    lastschriftRCUR.setProperty("batchbook", "");
+	    
+	    // Konto ermitteln
+	    Konto konto = getKonto();
+	    
+	    abrechnenMitglieder(param, lastschrift, monitor, abrl, konto);
 
-    Konto konto = getKonto();
+	    if (param.zusatzbetraege)
+	    {
+	      abbuchenZusatzbetraege(param, lastschrift, abrl, konto, monitor);
+	    }
+	    if (param.kursteilnehmer)
+	    {
+	      abbuchenKursteilnehmer(param, lastschrift);
+	    }
 
-    abrechnenMitglieder(param, lastschrift, monitor, abrl, konto);
+	    monitor.log(counter_all + " abgerechnete Fälle, davon " + counter_frst + " FRST, " + counter_rcur + " RCUR");
+        // 20220804: sbuer: Anpassung fur hbci4java
+	    // lastschrift.setMessageID(abrl.getID());
+	    // lastschrift.write(param.sepafileFRST, param.sepafileRCUR);
+	    
+	    // Lastschrift Datei RCUR erzeugen: Aber nur wenn auch welche gezaehlt wurden
+	    if ( counter_frst > 0 ) {
+	    	final OutputStream os = new FileOutputStream(param.sepafileFRST);
+		    System.setProperty("sepa.pain.formatted","true");
+		    ISEPAGenerator sepagenerator = SEPAGeneratorFactory.get("LastSEPA",version);
+		    try
+		    {
+			    sepagenerator.generate(lastschriftFRST,os,true);
+		    }
+	        catch (IOException e)
+	        {
+	          Logger.error("Generieren der SEPA-XML FRST fehlgeschlagen!", e);
+	        }
+		    Logger.info("Genieren der SEPA-XML FRST erfolgreich : " + param.sepafileFRST);
+		    monitor.log("Genieren der SEPA-XML FRST erfolgreich : " + param.sepafileFRST);
+	    }
+	    
+	    // Lastschrift Datei RCUR erzeugen: Aber nur wenn auch welche gezaehlt wurden	    
+	    if ( counter_rcur > 0 ) {
+	    	final OutputStream os = new FileOutputStream(param.sepafileRCUR);
+		    System.setProperty("sepa.pain.formatted","true");
+		    ISEPAGenerator sepagenerator = SEPAGeneratorFactory.get("LastSEPA",version);
+		    try
+		    {
+			    sepagenerator.generate(lastschriftRCUR,os,true);
+		    }
+	        catch (IOException e)
+	        {
+	          Logger.error("Generieren der SEPA-XML RCUR fehlgeschlagen!", e);
+	        }
+		    Logger.info("Genieren der SEPA-XML RCUR erfolgreich : " + param.sepafileRCUR);
+		    monitor.log("Genieren der SEPA-XML RCUR erfolgreich : " + param.sepafileRCUR);
+	    }	    
+	   
 
-    if (param.zusatzbetraege)
-    {
-      abbuchenZusatzbetraege(param, lastschrift, abrl, konto, monitor);
-    }
-    if (param.kursteilnehmer)
-    {
-      abbuchenKursteilnehmer(param, lastschrift);
-    }
+	    ArrayList<Zahler> z = lastschrift.getZahler();
+	    BigDecimal summemitgliedskonto = new BigDecimal("0");
+	    for (Zahler za : z)
+	    {
+	      Lastschrift ls = (Lastschrift) Einstellungen.getDBService()
+	          .createObject(Lastschrift.class, null);
+	      ls.setAbrechnungslauf(Integer.parseInt(abrl.getID()));
 
-    monitor.log(counter + " abgerechnete Fälle");
+	      assert (za instanceof JVereinZahler) : "Illegaler Zahlertyp in Sepa-Abrechnung detektiert.";
 
-    lastschrift.setMessageID(abrl.getID());
-    lastschrift.write(param.sepafileFRST, param.sepafileRCUR);
+	      JVereinZahler vza = (JVereinZahler) za;
 
-    ArrayList<Zahler> z = lastschrift.getZahler();
-    BigDecimal summemitgliedskonto = new BigDecimal("0");
-    for (Zahler za : z)
-    {
-      Lastschrift ls = (Lastschrift) Einstellungen.getDBService()
-          .createObject(Lastschrift.class, null);
-      ls.setAbrechnungslauf(Integer.parseInt(abrl.getID()));
+	      switch (vza.getPersonTyp())
+	      {
+	        case KURSTEILNEHMER:
+	          ls.setKursteilnehmer(Integer.parseInt(vza.getPersonId()));
+	          Kursteilnehmer k = (Kursteilnehmer) Einstellungen.getDBService()
+	              .createObject(Kursteilnehmer.class, vza.getPersonId());
+	          ls.setPersonenart(k.getPersonenart());
+	          ls.setAnrede(k.getAnrede());
+	          ls.setTitel(k.getTitel());
+	          ls.setName(k.getName());
+	          ls.setVorname(k.getVorname());
+	          ls.setStrasse(k.getStrasse());
+	          ls.setAdressierungszusatz(k.getAdressierungszusatz());
+	          ls.setPlz(k.getPlz());
+	          ls.setOrt(k.getOrt());
+	          ls.setStaat(k.getStaat());
+	          ls.setEmail(k.getEmail());
+	          break;
+	        case MITGLIED:
+	          ls.setMitglied(Integer.parseInt(vza.getPersonId()));
+	          Mitglied m = (Mitglied) Einstellungen.getDBService()
+	              .createObject(Mitglied.class, vza.getPersonId());
+	          if (m.getKtoiName() == null || m.getKtoiName().length() == 0)
+	          {
+	            ls.setPersonenart(m.getPersonenart());
+	            ls.setAnrede(m.getAnrede());
+	            ls.setTitel(m.getTitel());
+	            ls.setName(m.getName());
+	            ls.setVorname(m.getVorname());
+	            ls.setStrasse(m.getStrasse());
+	            ls.setAdressierungszusatz(m.getAdressierungszusatz());
+	            ls.setPlz(m.getPlz());
+	            ls.setOrt(m.getOrt());
+	            ls.setStaat(m.getStaat());
+	            ls.setEmail(m.getEmail());
+	            ls.setGeschlecht(m.getGeschlecht());
+	          }
+	          else
+	          {
+	            ls.setPersonenart(m.getKtoiPersonenart());
+	            ls.setAnrede(m.getKtoiAnrede());
+	            ls.setTitel(m.getKtoiTitel());
+	            ls.setName(m.getKtoiName());
+	            ls.setVorname(m.getKtoiVorname());
+	            ls.setStrasse(m.getKtoiStrasse());
+	            ls.setAdressierungszusatz(m.getKtoiAdressierungszusatz());
+	            ls.setPlz(m.getKtoiPlz());
+	            ls.setOrt(m.getKtoiOrt());
+	            ls.setStaat(m.getKtoiStaat());
+	            ls.setEmail(m.getKtoiEmail());
+	            ls.setGeschlecht(m.getKtoiGeschlecht());
+	          }
+	          break;
+	        default:
+	          assert false : "Personentyp ist nicht implementiert";
+	      }
+	      ls.setBetrag(za.getBetrag().doubleValue());
+	      summemitgliedskonto = summemitgliedskonto.add(za.getBetrag());
+	      ls.setBIC(za.getBic());
+	      ls.setIBAN(za.getIban());
+	      ls.setMandatDatum(za.getMandatdatum());
+	      ls.setMandatSequence(za.getMandatsequence().getTxt());
+	      ls.setMandatID(za.getMandatid());
+	      ls.setVerwendungszweck(za.getVerwendungszweck());
+	      ls.store();
+	    }
 
-      assert (za instanceof JVereinZahler) : "Illegaler Zahlertyp in Sepa-Abrechnung detektiert.";
+	    // Gegenbuchung für das Mitgliedskonto schreiben
+	    if (!summemitgliedskonto.equals(new BigDecimal("0")))
+	    {
+	      writeMitgliedskonto(null, new Date(), "Gegenbuchung",
+	          summemitgliedskonto.doubleValue() * -1, abrl, true, getKonto(), null);
+	    }
+	    if (param.abbuchungsausgabe == Abrechnungsausgabe.HIBISCUS)
+	    {
+	      buchenHibiscus(param, z);
+	    }
+	    monitor.setPercentComplete(100);
+	    if (param.sepaprint)
+	    {
+	      ausdruckenSEPA(lastschrift, param.pdffileFRST, param.pdffileRCUR);
+	    }
+	  }
 
-      JVereinZahler vza = (JVereinZahler) za;
+	  private void abrechnenMitglieder(AbrechnungSEPAParam param,
+	      JVereinBasislastschrift lastschrift, ProgressMonitor monitor,
+	      Abrechnungslauf abrl, Konto konto) throws Exception
+	  {
+	    if (param.abbuchungsmodus != Abrechnungsmodi.KEINBEITRAG)
+	    {
+	      // Alle Mitglieder lesen
+	      DBIterator<Mitglied> list = Einstellungen.getDBService()
+	          .createList(Mitglied.class);
+	      MitgliedUtils.setMitglied(list);
 
-      switch (vza.getPersonTyp())
-      {
-        case KURSTEILNEHMER:
-          ls.setKursteilnehmer(Integer.parseInt(vza.getPersonId()));
-          Kursteilnehmer k = (Kursteilnehmer) Einstellungen.getDBService()
-              .createObject(Kursteilnehmer.class, vza.getPersonId());
-          ls.setPersonenart(k.getPersonenart());
-          ls.setAnrede(k.getAnrede());
-          ls.setTitel(k.getTitel());
-          ls.setName(k.getName());
-          ls.setVorname(k.getVorname());
-          ls.setStrasse(k.getStrasse());
-          ls.setAdressierungszusatz(k.getAdressierungszusatz());
-          ls.setPlz(k.getPlz());
-          ls.setOrt(k.getOrt());
-          ls.setStaat(k.getStaat());
-          ls.setEmail(k.getEmail());
-          break;
-        case MITGLIED:
-          ls.setMitglied(Integer.parseInt(vza.getPersonId()));
-          Mitglied m = (Mitglied) Einstellungen.getDBService()
-              .createObject(Mitglied.class, vza.getPersonId());
-          if (m.getKtoiName() == null || m.getKtoiName().length() == 0)
-          {
-            ls.setPersonenart(m.getPersonenart());
-            ls.setAnrede(m.getAnrede());
-            ls.setTitel(m.getTitel());
-            ls.setName(m.getName());
-            ls.setVorname(m.getVorname());
-            ls.setStrasse(m.getStrasse());
-            ls.setAdressierungszusatz(m.getAdressierungszusatz());
-            ls.setPlz(m.getPlz());
-            ls.setOrt(m.getOrt());
-            ls.setStaat(m.getStaat());
-            ls.setEmail(m.getEmail());
-            ls.setGeschlecht(m.getGeschlecht());
-          }
-          else
-          {
-            ls.setPersonenart(m.getKtoiPersonenart());
-            ls.setAnrede(m.getKtoiAnrede());
-            ls.setTitel(m.getKtoiTitel());
-            ls.setName(m.getKtoiName());
-            ls.setVorname(m.getKtoiVorname());
-            ls.setStrasse(m.getKtoiStrasse());
-            ls.setAdressierungszusatz(m.getKtoiAdressierungszusatz());
-            ls.setPlz(m.getKtoiPlz());
-            ls.setOrt(m.getKtoiOrt());
-            ls.setStaat(m.getKtoiStaat());
-            ls.setEmail(m.getKtoiEmail());
-            ls.setGeschlecht(m.getKtoiGeschlecht());
-          }
-          break;
-        default:
-          assert false : "Personentyp ist nicht implementiert";
-      }
-      ls.setBetrag(za.getBetrag().doubleValue());
-      summemitgliedskonto = summemitgliedskonto.add(za.getBetrag());
-      ls.setBIC(za.getBic());
-      ls.setIBAN(za.getIban());
-      ls.setMandatDatum(za.getMandatdatum());
-      ls.setMandatSequence(za.getMandatsequence().getTxt());
-      ls.setMandatID(za.getMandatid());
-      ls.setVerwendungszweck(za.getVerwendungszweck());
-      ls.store();
-    }
+	      // Das Mitglied muss bereits eingetreten sein
+	      list.addFilter("(eintritt <= ? or eintritt is null) ", new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+	      // Das Mitglied darf noch nicht ausgetreten sein
+	      list.addFilter("(austritt is null or austritt > ?)", new Object[] { new java.sql.Date(param.stichtag.getTime()) });
+	      // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
+	      // berücksichtigt, die bis zu einem bestimmten Zeitpunkt ausgetreten sind.
+	      if (param.bisdatum != null)
+	      {
+	        list.addFilter("(austritt <= ?)", new Object[] { new java.sql.Date(param.bisdatum.getTime()) });
+	      }
+	      // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
+	      // berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
+	      if (param.vondatum != null)
+	      {
+	        list.addFilter("eingabedatum >= ?", new Object[] { new java.sql.Date(param.vondatum.getTime()) });
+	      }
+	      if (Einstellungen.getEinstellung()
+	          .getBeitragsmodel() == Beitragsmodel.MONATLICH12631)
+	      {
+	        if (param.abbuchungsmodus == Abrechnungsmodi.HAVIMO)
+	        {
+	          list.addFilter(
+	              "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
+	                  new Object[] { new Integer(Zahlungsrhythmus.HALBJAEHRLICH),
+	                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
+	                  new Integer(Zahlungsrhythmus.MONATLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.JAVIMO)
+	        {
+	          list.addFilter(
+	              "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
+	                  new Object[] { new Integer(Zahlungsrhythmus.JAEHRLICH),
+	                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
+	                  new Integer(Zahlungsrhythmus.MONATLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.VIMO)
+	        {
+	          list.addFilter("(zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
+	                  new Object[] { Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH),
+	                  Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.MO)
+	        {
+	          list.addFilter("zahlungsrhytmus = ?",
+	                  new Object[] { Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.VI)
+	        {
+	          list.addFilter("zahlungsrhytmus = ?", new Object[] {
+	              Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.HA)
+	        {
+	          list.addFilter("zahlungsrhytmus = ?",
+	              new Object[] { Integer.valueOf(Zahlungsrhythmus.HALBJAEHRLICH) });
+	        }
+	        if (param.abbuchungsmodus == Abrechnungsmodi.JA)
+	        {
+	          list.addFilter("zahlungsrhytmus = ?",
+	              new Object[] { Integer.valueOf(Zahlungsrhythmus.JAEHRLICH) });
+	        }
+	      }
 
-    // Gegenbuchung für das Mitgliedskonto schreiben
-    if (!summemitgliedskonto.equals(new BigDecimal("0")))
-    {
-      writeMitgliedskonto(null, new Date(), "Gegenbuchung",
-          summemitgliedskonto.doubleValue() * -1, abrl, true, getKonto(), null);
-    }
-    if (param.abbuchungsausgabe == Abrechnungsausgabe.HIBISCUS)
-    {
-      buchenHibiscus(param, z);
-    }
-    monitor.setPercentComplete(100);
-    if (param.sepaprint)
-    {
-      ausdruckenSEPA(lastschrift, param.pdffileFRST, param.pdffileRCUR);
-    }
-  }
+	      list.setOrder("ORDER BY name, vorname");
 
-  private void abrechnenMitglieder(AbrechnungSEPAParam param,
-      JVereinBasislastschrift lastschrift, ProgressMonitor monitor,
-      Abrechnungslauf abrl, Konto konto) throws Exception
-  {
-    if (param.abbuchungsmodus != Abrechnungsmodi.KEINBEITRAG)
-    {
-      // Alle Mitglieder lesen
-      DBIterator<Mitglied> list = Einstellungen.getDBService()
-          .createList(Mitglied.class);
-      MitgliedUtils.setMitglied(list);
+	      // Sätze im Resultset
+	      int count = 0;
+	      while (list.hasNext())
+	      {
+	        monitor.setStatus((int) ((double) count / (double) list.size() * 100d));
+	        Mitglied m = (Mitglied) list.next();
 
-      // Das Mitglied muss bereits eingetreten sein
-      list.addFilter("(eintritt <= ? or eintritt is null) ",
-          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
-      // Das Mitglied darf noch nicht ausgetreten sein
-      list.addFilter("(austritt is null or austritt > ?)",
-          new Object[] { new java.sql.Date(param.stichtag.getTime()) });
-      // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
-      // berücksichtigt, die bis zu einem bestimmten Zeitpunkt ausgetreten sind.
-      if (param.bisdatum != null)
-      {
-        list.addFilter("(austritt <= ?)",
-            new Object[] { new java.sql.Date(param.bisdatum.getTime()) });
-      }
-      // Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
-      // berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
-      if (param.vondatum != null)
-      {
-        list.addFilter("eingabedatum >= ?",
-            new Object[] { new java.sql.Date(param.vondatum.getTime()) });
-      }
-      if (Einstellungen.getEinstellung()
-          .getBeitragsmodel() == Beitragsmodel.MONATLICH12631)
-      {
-        if (param.abbuchungsmodus == Abrechnungsmodi.HAVIMO)
-        {
-          list.addFilter(
-              "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
-              new Object[] { new Integer(Zahlungsrhythmus.HALBJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.MONATLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.JAVIMO)
-        {
-          list.addFilter(
-              "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
-              new Object[] { new Integer(Zahlungsrhythmus.JAEHRLICH),
-                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.MONATLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.VIMO)
-        {
-          list.addFilter("(zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
-              new Object[] { Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH),
-                  Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.MO)
-        {
-          list.addFilter("zahlungsrhytmus = ?",
-              new Object[] { Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.VI)
-        {
-          list.addFilter("zahlungsrhytmus = ?", new Object[] {
-              Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.HA)
-        {
-          list.addFilter("zahlungsrhytmus = ?",
-              new Object[] { Integer.valueOf(Zahlungsrhythmus.HALBJAEHRLICH) });
-        }
-        if (param.abbuchungsmodus == Abrechnungsmodi.JA)
-        {
-          list.addFilter("zahlungsrhytmus = ?",
-              new Object[] { Integer.valueOf(Zahlungsrhythmus.JAEHRLICH) });
-        }
-      }
+	        JVereinZahler z = abrechnungMitgliederSub(param, lastschrift, monitor,
+	            abrl, konto, m, m.getBeitragsgruppe(), true);
 
-      list.setOrder("ORDER BY name, vorname");
+	        DBIterator<SekundaereBeitragsgruppe> sekundaer = Einstellungen
+	            .getDBService().createList(SekundaereBeitragsgruppe.class);
+	        sekundaer.addFilter("mitglied=?", m.getID());
+	        while (sekundaer.hasNext())
+	        {
+	          SekundaereBeitragsgruppe sb = (SekundaereBeitragsgruppe) sekundaer
+	              .next();
+	          JVereinZahler z2 = abrechnungMitgliederSub(param, lastschrift,
+	              monitor, abrl, konto, m, sb.getBeitragsgruppe(), false);
+	          if (z2 != null)
+	          {
+	            if (z != null)
+	            {
+	              z.add(z2);
+	            }
+	            else
+	            {
+	              z = z2;
+	            }
+	          }
+	        }
+	        if (z != null)
+	        {
+	        // 20220804: sbuer: Anpasung fur hbci4java
+	        // lastschrift.add(z);
+	        lastschrift_fillup(z);
+	        }
+	      }
+	    }
+	  }
 
-      // Sätze im Resultset
-      int count = 0;
-      while (list.hasNext())
-      {
-        monitor.setStatus((int) ((double) count / (double) list.size() * 100d));
-        Mitglied m = (Mitglied) list.next();
+	  private JVereinZahler abrechnungMitgliederSub(AbrechnungSEPAParam param,
+	      JVereinBasislastschrift lastschrift, ProgressMonitor monitor,
+	      Abrechnungslauf abrl, Konto konto, Mitglied m, Beitragsgruppe bg,
+	      boolean primaer) throws RemoteException, ApplicationException
+	  {
+	    Double betr = 0d;
+	    JVereinZahler zahler = null;
+	    if (Einstellungen.getEinstellung()
+	        .getBeitragsmodel() == Beitragsmodel.FLEXIBEL)
+	    {
+	      if (m.getZahlungstermin() != null
+	          && !m.getZahlungstermin().isAbzurechnen(param.abrechnungsmonat))
+	      {
+	        return zahler;
+	      }
+	    }
 
-        JVereinZahler z = abrechnungMitgliederSub(param, lastschrift, monitor,
-            abrl, konto, m, m.getBeitragsgruppe(), true);
+	    try
+	    {
+	      betr = BeitragsUtil.getBeitrag(
+	          Einstellungen.getEinstellung().getBeitragsmodel(),
+	          m.getZahlungstermin(), m.getZahlungsrhythmus().getKey(), bg,
+	          param.stichtag, m.getEintritt(), m.getAustritt());
+	    }
+	    catch (NullPointerException e)
+	    {
+	      throw new ApplicationException(
+	          "Zahlungsinformationen bei " + m.getName() + ", " + m.getVorname());
+	    }
+	    if (primaer)
+	    {
+	      if (Einstellungen.getEinstellung().getIndividuelleBeitraege()
+	          && m.getIndividuellerBeitrag() > 0)
+	      {
+	        betr = m.getIndividuellerBeitrag();
+	      }
+	    }
+	    if (betr == 0d)
+	    {
+	      return zahler;
+	    }
+	    if (!checkSEPA(m, monitor))
+	    {
+	      return zahler;
+	    }
+	    counter++;
 
-        DBIterator<SekundaereBeitragsgruppe> sekundaer = Einstellungen
-            .getDBService().createList(SekundaereBeitragsgruppe.class);
-        sekundaer.addFilter("mitglied=?", m.getID());
-        while (sekundaer.hasNext())
-        {
-          SekundaereBeitragsgruppe sb = (SekundaereBeitragsgruppe) sekundaer
-              .next();
-          JVereinZahler z2 = abrechnungMitgliederSub(param, lastschrift,
-              monitor, abrl, konto, m, sb.getBeitragsgruppe(), false);
-          if (z2 != null)
-          {
-            if (z != null)
-            {
-              z.add(z2);
-            }
-            else
-            {
-              z = z2;
-            }
-          }
-        }
-        if (z != null)
-        {
-          lastschrift.add(z);
-        }
-      }
-    }
-  }
+	    String vzweck = abrl.getZahlungsgrund();
+	    Map<String, Object> map = new MitgliedMap().getMap(m, null);
+	    try
+	    {
+	      vzweck = VelocityTool.eval(map, vzweck);
+	    }
+	    catch (IOException e)
+	    {
+	      Logger.error("Fehler bei der Aufbereitung der Variablen", e);
+	    }
 
-  private JVereinZahler abrechnungMitgliederSub(AbrechnungSEPAParam param,
-      JVereinBasislastschrift lastschrift, ProgressMonitor monitor,
-      Abrechnungslauf abrl, Konto konto, Mitglied m, Beitragsgruppe bg,
-      boolean primaer) throws RemoteException, ApplicationException
-  {
-    Double betr = 0d;
-    JVereinZahler zahler = null;
-    if (Einstellungen.getEinstellung()
-        .getBeitragsmodel() == Beitragsmodel.FLEXIBEL)
-    {
-      if (m.getZahlungstermin() != null
-          && !m.getZahlungstermin().isAbzurechnen(param.abrechnungsmonat))
-      {
-        return zahler;
-      }
-    }
+	    writeMitgliedskonto(m,
+	        m.getMandatSequence().getTxt().equals("FRST") ? param.faelligkeit1
+	            : param.faelligkeit2,
+	        primaer ? vzweck : bg.getBezeichnung(), betr, abrl,
+	        m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
+	        bg.getBuchungsart());
+	    if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
+	    {
+	      try
+	      {
+	        zahler = new JVereinZahler();
+	        zahler.setPersonId(m.getID());
+	        zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
+	        zahler.setBetrag(
+	            new BigDecimal(betr).setScale(2, BigDecimal.ROUND_HALF_UP));
+	        new BIC(m.getBic()); // Prüfung des BIC
+	        zahler.setBic(m.getBic());
+	        new IBAN(m.getIban()); // Prüfung der IBAN
+	        zahler.setIban(m.getIban());
+	        zahler.setMandatid(m.getMandatID());
+	        zahler.setMandatdatum(m.getMandatDatum());
+	        zahler.setMandatsequence(m.getMandatSequence());
+	        zahler.setFaelligkeit(param.faelligkeit1, param.faelligkeit2,
+	            m.getMandatSequence().getCode());
+	        if (primaer)
+	        {
+	          zahler.setVerwendungszweck(getVerwendungszweck2(m) + " " + vzweck);
+	        }
+	        else
+	        {
+	          zahler.setVerwendungszweck(bg.getBezeichnung());
+	        }
+	        if (m.getBeitragsgruppe()
+	            .getBeitragsArt() == ArtBeitragsart.FAMILIE_ZAHLER)
+	        {
+	          DBIterator<Mitglied> angeh = Einstellungen.getDBService()
+	              .createList(Mitglied.class);
+	          angeh.addFilter("zahlerid = ?", m.getID());
+	          String an = "";
+	          int i = 0;
+	          while (angeh.hasNext())
+	          {
+	            Mitglied a = (Mitglied) angeh.next();
+	            if (i > 0)
+	            {
+	              an += ", ";
+	            }
+	            i++;
+	            an += a.getVorname();
+	          }
+	          zahler.setVerwendungszweck(zahler.getVerwendungszweck() + " " + an);
+	        }
+	        zahler.setName(m.getKontoinhaber(1));
+	      }
+	      catch (Exception e)
+	      {
+	        throw new ApplicationException(
+	            Adressaufbereitung.getNameVorname(m) + ": " + e.getMessage());
+	      }
+	    }
+	    return zahler;
+	  }
 
-    try
-    {
-      betr = BeitragsUtil.getBeitrag(
-          Einstellungen.getEinstellung().getBeitragsmodel(),
-          m.getZahlungstermin(), m.getZahlungsrhythmus().getKey(), bg,
-          param.stichtag, m.getEintritt(), m.getAustritt());
-    }
-    catch (NullPointerException e)
-    {
-      throw new ApplicationException(
-          "Zahlungsinformationen bei " + m.getName() + ", " + m.getVorname());
-    }
-    if (primaer)
-    {
-      if (Einstellungen.getEinstellung().getIndividuelleBeitraege()
-          && m.getIndividuellerBeitrag() > 0)
-      {
-        betr = m.getIndividuellerBeitrag();
-      }
-    }
-    if (betr == 0d)
-    {
-      return zahler;
-    }
-    if (!checkSEPA(m, monitor))
-    {
-      return zahler;
-    }
-    counter++;
+	  private void abbuchenZusatzbetraege(AbrechnungSEPAParam param,
+	      JVereinBasislastschrift lastschrift, Abrechnungslauf abrl, Konto konto,
+	      ProgressMonitor monitor)
+	      throws NumberFormatException, IOException, ApplicationException
+	  {
+	    DBIterator<Zusatzbetrag> list = Einstellungen.getDBService()
+	        .createList(Zusatzbetrag.class);
+	    while (list.hasNext())
+	    {
+	      Zusatzbetrag z = (Zusatzbetrag) list.next();
+	      if (z.isAktiv(param.stichtag))
+	      {
+	        Mitglied m = z.getMitglied();
+	        if (m.isAngemeldet(param.stichtag)
+	            || Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
+	        {
+	          //
+	        }
+	        else
+	        {
+	          continue;
+	        }
+	        if (!checkSEPA(m, monitor))
+	        {
+	          continue;
+	        }
+	        counter++;
+	        String vzweck = z.getBuchungstext();
+	        Map<String, Object> map = new AllgemeineMap().getMap(null);
+	        map = new MitgliedMap().getMap(m, map);
+	        map = new AbrechnungsParameterMap().getMap(param, map);
+	        try
+	        {
+	          vzweck = VelocityTool.eval(map, vzweck);
+	        }
+	        catch (IOException e)
+	        {
+	          Logger.error("Fehler bei der Aufbereitung der Variablen", e);
+	        }
+	        if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
+	        {
+	          try
+	          {
+	            JVereinZahler zahler = new JVereinZahler();
+	            zahler.setPersonId(m.getID());
+	            zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
+	            zahler.setBetrag(new BigDecimal(z.getBetrag()).setScale(2,
+	                BigDecimal.ROUND_HALF_UP));
+	            new BIC(m.getBic());
+	            new IBAN(m.getIban());
+	            zahler.setBic(m.getBic());
+	            zahler.setIban(m.getIban());
+	            zahler.setMandatid(m.getMandatID());
+	            zahler.setMandatdatum(m.getMandatDatum());
+	            zahler.setMandatsequence(m.getMandatSequence());
+	            zahler.setFaelligkeit(param.faelligkeit1, param.faelligkeit2,
+	                m.getMandatSequence().getCode());
+	            zahler.setName(m.getKontoinhaber(1));
+	            zahler.setVerwendungszweck(vzweck);
+		        // 20220804: sbuer: Anpasung fur hbci4java
+		        // lastschrift.add(zahler);
+		        lastschrift_fillup(zahler);
+	          }
+	          catch (Exception e)
+	          {
+	            throw new ApplicationException(
+	                Adressaufbereitung.getNameVorname(m) + ": " + e.getMessage());
+	          }
+	        }
+	        if (z.getIntervall().intValue() != IntervallZusatzzahlung.KEIN
+	            && (z.getEndedatum() == null
+	                || z.getFaelligkeit().getTime() <= z.getEndedatum().getTime()))
+	        {
+	          z.setFaelligkeit(
+	              Datum.addInterval(z.getFaelligkeit(), z.getIntervall()));
+	        }
+	        try
+	        {
+	          if (abrl != null)
+	          {
+	            ZusatzbetragAbrechnungslauf za = (ZusatzbetragAbrechnungslauf) Einstellungen
+	                .getDBService()
+	                .createObject(ZusatzbetragAbrechnungslauf.class, null);
+	            za.setAbrechnungslauf(abrl);
+	            za.setZusatzbetrag(z);
+	            za.setLetzteAusfuehrung(z.getAusfuehrung());
+	            za.store();
+	            z.setAusfuehrung(Datum.getHeute());
+	            z.store();
+	          }
+	        }
+	        catch (ApplicationException e)
+	        {
+	          String debString = z.getStartdatum() + ", " + z.getEndedatum() + ", "
+	              + z.getIntervallText() + ", " + z.getBuchungstext() + ", "
+	              + z.getBetrag();
+	          Logger.error(Adressaufbereitung.getNameVorname(z.getMitglied()) + " "
+	              + debString, e);
+	          monitor.log(z.getMitglied().getName() + " " + debString + " " + e);
+	          throw e;
+	        }
+	        writeMitgliedskonto(m,
+	            m.getMandatSequence().getTxt().equals("FRST") ? param.faelligkeit1
+	                : param.faelligkeit2,
+	            vzweck, z.getBetrag(), abrl,
+	            m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
+	            z.getBuchungsart());
+	      }
+	    }
+	  }
 
-    String vzweck = abrl.getZahlungsgrund();
-    Map<String, Object> map = new MitgliedMap().getMap(m, null);
-    try
-    {
-      vzweck = VelocityTool.eval(map, vzweck);
-    }
-    catch (IOException e)
-    {
-      Logger.error("Fehler bei der Aufbereitung der Variablen", e);
-    }
+	  private void abbuchenKursteilnehmer(AbrechnungSEPAParam param,
+	      JVereinBasislastschrift lastschrift)
+	      throws ApplicationException, IOException
+	  {
+	    DBIterator<Kursteilnehmer> list = Einstellungen.getDBService()
+	        .createList(Kursteilnehmer.class);
+	    list.addFilter("abbudatum is null");
+	    while (list.hasNext())
+	    {
+	      counter++;
+	      Kursteilnehmer kt = (Kursteilnehmer) list.next();
+	      try
+	      {
+	        JVereinZahler zahler = new JVereinZahler();
+	        zahler.setPersonId(kt.getID());
+	        zahler.setPersonTyp(JVereinZahlerTyp.KURSTEILNEHMER);
+	        zahler.setBetrag(new BigDecimal(kt.getBetrag()).setScale(2,
+	            BigDecimal.ROUND_HALF_UP));
+	        new BIC(kt.getBic());
+	        new IBAN(kt.getIban());
+	        zahler.setBic(kt.getBic());
+	        zahler.setIban(kt.getIban());
+	        zahler.setMandatid(kt.getMandatID());
+	        zahler.setMandatdatum(kt.getMandatDatum());
+	        zahler.setMandatsequence(MandatSequence.FRST);
+	        zahler.setFaelligkeit(param.faelligkeit1);
+	        zahler.setName(kt.getName());
+	        zahler.setVerwendungszweck(kt.getVZweck1());
+	        // 20220804: sbuer: Anpasung fur hbci4java
+	        // lastschrift.add(zahler);
+	        lastschrift_fillup(zahler);
+	        kt.setAbbudatum();
+	        kt.store();
+	      }
+	      catch (Exception e)
+	      {
+	        throw new ApplicationException(kt.getName() + ": " + e.getMessage());
+	      }
+	    }
+	  }
 
-    writeMitgliedskonto(m,
-        m.getMandatSequence().getTxt().equals("FRST") ? param.faelligkeit1
-            : param.faelligkeit2,
-        primaer ? vzweck : bg.getBezeichnung(), betr, abrl,
-        m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
-        bg.getBuchungsart());
-    if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
-    {
-      try
-      {
-        zahler = new JVereinZahler();
-        zahler.setPersonId(m.getID());
-        zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
-        zahler.setBetrag(
-            new BigDecimal(betr).setScale(2, BigDecimal.ROUND_HALF_UP));
-        new BIC(m.getBic()); // Prüfung des BIC
-        zahler.setBic(m.getBic());
-        new IBAN(m.getIban()); // Prüfung der IBAN
-        zahler.setIban(m.getIban());
-        zahler.setMandatid(m.getMandatID());
-        zahler.setMandatdatum(m.getMandatDatum());
-        zahler.setMandatsequence(m.getMandatSequence());
-        zahler.setFaelligkeit(param.faelligkeit1, param.faelligkeit2,
-            m.getMandatSequence().getCode());
-        if (primaer)
-        {
-          zahler.setVerwendungszweck(getVerwendungszweck2(m) + " " + vzweck);
-        }
-        else
-        {
-          zahler.setVerwendungszweck(bg.getBezeichnung());
-        }
-        if (m.getBeitragsgruppe()
-            .getBeitragsArt() == ArtBeitragsart.FAMILIE_ZAHLER)
-        {
-          DBIterator<Mitglied> angeh = Einstellungen.getDBService()
-              .createList(Mitglied.class);
-          angeh.addFilter("zahlerid = ?", m.getID());
-          String an = "";
-          int i = 0;
-          while (angeh.hasNext())
-          {
-            Mitglied a = (Mitglied) angeh.next();
-            if (i > 0)
-            {
-              an += ", ";
-            }
-            i++;
-            an += a.getVorname();
-          }
-          zahler.setVerwendungszweck(zahler.getVerwendungszweck() + " " + an);
-        }
-        zahler.setName(m.getKontoinhaber(1));
-      }
-      catch (Exception e)
-      {
-        throw new ApplicationException(
-            Adressaufbereitung.getNameVorname(m) + ": " + e.getMessage());
-      }
-    }
-    return zahler;
-  }
+	  private void ausdruckenSEPA(final JVereinBasislastschrift lastschrift,
+	      final String pdfFRST, final String pdfRCUR)
+	      throws IOException, DocumentException, SEPAException
+	  {
+	    new Basislastschrift2Pdf(lastschrift.getLastschriftFRST(), pdfFRST);
+	    GUI.getDisplay().asyncExec(new Runnable()
+	    {
 
-  private void abbuchenZusatzbetraege(AbrechnungSEPAParam param,
-      JVereinBasislastschrift lastschrift, Abrechnungslauf abrl, Konto konto,
-      ProgressMonitor monitor)
-      throws NumberFormatException, IOException, ApplicationException
-  {
-    DBIterator<Zusatzbetrag> list = Einstellungen.getDBService()
-        .createList(Zusatzbetrag.class);
-    while (list.hasNext())
-    {
-      Zusatzbetrag z = (Zusatzbetrag) list.next();
-      if (z.isAktiv(param.stichtag))
-      {
-        Mitglied m = z.getMitglied();
-        if (m.isAngemeldet(param.stichtag)
-            || Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
-        {
-          //
-        }
-        else
-        {
-          continue;
-        }
-        if (!checkSEPA(m, monitor))
-        {
-          continue;
-        }
-        counter++;
-        String vzweck = z.getBuchungstext();
-        Map<String, Object> map = new AllgemeineMap().getMap(null);
-        map = new MitgliedMap().getMap(m, map);
-        map = new AbrechnungsParameterMap().getMap(param, map);
-        try
-        {
-          vzweck = VelocityTool.eval(map, vzweck);
-        }
-        catch (IOException e)
-        {
-          Logger.error("Fehler bei der Aufbereitung der Variablen", e);
-        }
-        if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
-        {
-          try
-          {
-            JVereinZahler zahler = new JVereinZahler();
-            zahler.setPersonId(m.getID());
-            zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
-            zahler.setBetrag(new BigDecimal(z.getBetrag()).setScale(2,
-                BigDecimal.ROUND_HALF_UP));
-            new BIC(m.getBic());
-            new IBAN(m.getIban());
-            zahler.setBic(m.getBic());
-            zahler.setIban(m.getIban());
-            zahler.setMandatid(m.getMandatID());
-            zahler.setMandatdatum(m.getMandatDatum());
-            zahler.setMandatsequence(m.getMandatSequence());
-            zahler.setFaelligkeit(param.faelligkeit1, param.faelligkeit2,
-                m.getMandatSequence().getCode());
-            zahler.setName(m.getKontoinhaber(1));
-            zahler.setVerwendungszweck(vzweck);
-            lastschrift.add(zahler);
-          }
-          catch (Exception e)
-          {
-            throw new ApplicationException(
-                Adressaufbereitung.getNameVorname(m) + ": " + e.getMessage());
-          }
-        }
-        if (z.getIntervall().intValue() != IntervallZusatzzahlung.KEIN
-            && (z.getEndedatum() == null
-                || z.getFaelligkeit().getTime() <= z.getEndedatum().getTime()))
-        {
-          z.setFaelligkeit(
-              Datum.addInterval(z.getFaelligkeit(), z.getIntervall()));
-        }
-        try
-        {
-          if (abrl != null)
-          {
-            ZusatzbetragAbrechnungslauf za = (ZusatzbetragAbrechnungslauf) Einstellungen
-                .getDBService()
-                .createObject(ZusatzbetragAbrechnungslauf.class, null);
-            za.setAbrechnungslauf(abrl);
-            za.setZusatzbetrag(z);
-            za.setLetzteAusfuehrung(z.getAusfuehrung());
-            za.store();
-            z.setAusfuehrung(Datum.getHeute());
-            z.store();
-          }
-        }
-        catch (ApplicationException e)
-        {
-          String debString = z.getStartdatum() + ", " + z.getEndedatum() + ", "
-              + z.getIntervallText() + ", " + z.getBuchungstext() + ", "
-              + z.getBetrag();
-          Logger.error(Adressaufbereitung.getNameVorname(z.getMitglied()) + " "
-              + debString, e);
-          monitor.log(z.getMitglied().getName() + " " + debString + " " + e);
-          throw e;
-        }
-        writeMitgliedskonto(m,
-            m.getMandatSequence().getTxt().equals("FRST") ? param.faelligkeit1
-                : param.faelligkeit2,
-            vzweck, z.getBetrag(), abrl,
-            m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
-            z.getBuchungsart());
-      }
-    }
-  }
+	      @Override
+	      public void run()
+	      {
+	        try
+	        {
+	          new Program().handleAction(new File(pdfFRST));
+	        }
+	        catch (ApplicationException ae)
+	        {
+	          Application.getMessagingFactory().sendMessage(new StatusBarMessage(
+	              ae.getLocalizedMessage(), StatusBarMessage.TYPE_ERROR));
+	        }
+	      }
+	    });
+	    new Basislastschrift2Pdf(lastschrift.getLastschriftRCUR(), pdfRCUR);
+	    GUI.getDisplay().asyncExec(new Runnable()
+	    {
 
-  private void abbuchenKursteilnehmer(AbrechnungSEPAParam param,
-      JVereinBasislastschrift lastschrift)
-      throws ApplicationException, IOException
-  {
-    DBIterator<Kursteilnehmer> list = Einstellungen.getDBService()
-        .createList(Kursteilnehmer.class);
-    list.addFilter("abbudatum is null");
-    while (list.hasNext())
-    {
-      counter++;
-      Kursteilnehmer kt = (Kursteilnehmer) list.next();
-      try
-      {
-        JVereinZahler zahler = new JVereinZahler();
-        zahler.setPersonId(kt.getID());
-        zahler.setPersonTyp(JVereinZahlerTyp.KURSTEILNEHMER);
-        zahler.setBetrag(new BigDecimal(kt.getBetrag()).setScale(2,
-            BigDecimal.ROUND_HALF_UP));
-        new BIC(kt.getBic());
-        new IBAN(kt.getIban());
-        zahler.setBic(kt.getBic());
-        zahler.setIban(kt.getIban());
-        zahler.setMandatid(kt.getMandatID());
-        zahler.setMandatdatum(kt.getMandatDatum());
-        zahler.setMandatsequence(MandatSequence.FRST);
-        zahler.setFaelligkeit(param.faelligkeit1);
-        zahler.setName(kt.getName());
-        zahler.setVerwendungszweck(kt.getVZweck1());
-        lastschrift.add(zahler);
-        kt.setAbbudatum();
-        kt.store();
-      }
-      catch (Exception e)
-      {
-        throw new ApplicationException(kt.getName() + ": " + e.getMessage());
-      }
-    }
-  }
+	      @Override
+	      public void run()
+	      {
+	        try
+	        {
+	          new Program().handleAction(new File(pdfRCUR));
+	        }
+	        catch (ApplicationException ae)
+	        {
+	          Application.getMessagingFactory().sendMessage(new StatusBarMessage(
+	              ae.getLocalizedMessage(), StatusBarMessage.TYPE_ERROR));
+	        }
+	      }
+	    });
+	  }
 
-  private void ausdruckenSEPA(final JVereinBasislastschrift lastschrift,
-      final String pdfFRST, final String pdfRCUR)
-      throws IOException, DocumentException, SEPAException
-  {
-    new Basislastschrift2Pdf(lastschrift.getLastschriftFRST(), pdfFRST);
-    GUI.getDisplay().asyncExec(new Runnable()
-    {
+	  private void buchenHibiscus(AbrechnungSEPAParam param, ArrayList<Zahler> z)
+	      throws ApplicationException
+	  {
+	    if (z.size() == 0)
+	    {
+	      // Wenn keine Buchungen vorhanden sind, wird nichts an Hibiscus übergeben.
+	      return;
+	    }
+	    try
+	    {
+	      SepaLastschrift[] lastschriften = new SepaLastschrift[z.size()];
+	      int sli = 0;
+	      Date d = new Date();
+	      for (Zahler za : z)
+	      {
+	        SepaLastschrift sl = (SepaLastschrift) param.service
+	            .createObject(SepaLastschrift.class, null);
+	        sl.setBetrag(za.getBetrag().doubleValue());
+	        sl.setCreditorId(Einstellungen.getEinstellung().getGlaeubigerID());
+	        sl.setGegenkontoName(za.getName());
+	        sl.setGegenkontoBLZ(za.getBic());
+	        sl.setGegenkontoNummer(za.getIban());
+	        sl.setKonto(param.konto);
+	        sl.setMandateId(za.getMandatid());
+	        sl.setSequenceType(
+	            SepaLastSequenceType.valueOf(za.getMandatsequence().getTxt()));
+	        sl.setSignatureDate(za.getMandatdatum());
+	        sl.setTargetDate(za.getFaelligkeit());
+	        sl.setTermin(d);
+	        sl.setType(SepaLastType.CORE);
+	        sl.setZweck(za.getVerwendungszweck());
+	        lastschriften[sli] = sl;
+	        sli++;
+	      }
+	      SepaLastschriftMerger merger = new SepaLastschriftMerger();
+	      List<SepaSammelLastschrift> sammler = merger
+	          .merge(Arrays.asList(lastschriften));
+	      for (SepaSammelLastschrift s : sammler)
+	      {
+	        // Hier noch die eigene Bezeichnung einfuegen
+	        String vzweck = getVerwendungszweck(param) + " "
+	            + s.getBezeichnung().substring(0, s.getBezeichnung().indexOf(" "))
+	            + " vom " + new JVDateFormatDATETIME().format(new Date());
+	        s.setBezeichnung(vzweck);
+	        s.store();
+	      }
+	    }
+	    catch (RemoteException e)
+	    {
+	      throw new ApplicationException(e);
+	    }
+	    catch (SEPAException e)
+	    {
+	      throw new ApplicationException(e);
+	    }
+	  }
 
-      @Override
-      public void run()
-      {
-        try
-        {
-          new Program().handleAction(new File(pdfFRST));
-        }
-        catch (ApplicationException ae)
-        {
-          Application.getMessagingFactory().sendMessage(new StatusBarMessage(
-              ae.getLocalizedMessage(), StatusBarMessage.TYPE_ERROR));
-        }
-      }
-    });
-    new Basislastschrift2Pdf(lastschrift.getLastschriftRCUR(), pdfRCUR);
-    GUI.getDisplay().asyncExec(new Runnable()
-    {
+	  private String getVerwendungszweck(AbrechnungSEPAParam param)
+	      throws RemoteException
+	  {
+	    Map<String, Object> map = new AllgemeineMap().getMap(null);
+	    map = new AbrechnungsParameterMap().getMap(param, map);
+	    try
+	    {
+	      return VelocityTool.eval(map, param.verwendungszweck);
+	    }
+	    catch (IOException e)
+	    {
+	      Logger.error("Fehler bei der Aufbereitung der Variablen", e);
+	      return param.verwendungszweck;
+	    }
+	  }
 
-      @Override
-      public void run()
-      {
-        try
-        {
-          new Program().handleAction(new File(pdfRCUR));
-        }
-        catch (ApplicationException ae)
-        {
-          Application.getMessagingFactory().sendMessage(new StatusBarMessage(
-              ae.getLocalizedMessage(), StatusBarMessage.TYPE_ERROR));
-        }
-      }
-    });
-  }
+	  private Abrechnungslauf getAbrechnungslauf(AbrechnungSEPAParam param)
+	      throws RemoteException, ApplicationException
+	  {
+	    Abrechnungslauf abrl = (Abrechnungslauf) Einstellungen.getDBService()
+	        .createObject(Abrechnungslauf.class, null);
+	    abrl.setDatum(new Date());
+	    abrl.setAbbuchungsausgabe(param.abbuchungsausgabe.getKey());
+	    abrl.setFaelligkeit(param.faelligkeit1);
+	    abrl.setFaelligkeit2(param.faelligkeit2);
+	    abrl.setDtausdruck(param.sepaprint);
+	    abrl.setEingabedatum(param.vondatum);
+	    abrl.setAustrittsdatum(param.bisdatum);
+	    abrl.setKursteilnehmer(param.kursteilnehmer);
+	    abrl.setModus(param.abbuchungsmodus);
+	    abrl.setStichtag(param.stichtag);
+	    abrl.setZahlungsgrund(getVerwendungszweck(param));
+	    abrl.setZusatzbetraege(param.zusatzbetraege);
+	    abrl.setAbgeschlossen(false);
+	    abrl.store();
+	    return abrl;
+	  }
 
-  private void buchenHibiscus(AbrechnungSEPAParam param, ArrayList<Zahler> z)
-      throws ApplicationException
-  {
-    if (z.size() == 0)
-    {
-      // Wenn keine Buchungen vorhanden sind, wird nichts an Hibiscus übergeben.
-      return;
-    }
-    try
-    {
-      SepaLastschrift[] lastschriften = new SepaLastschrift[z.size()];
-      int sli = 0;
-      Date d = new Date();
-      for (Zahler za : z)
-      {
-        SepaLastschrift sl = (SepaLastschrift) param.service
-            .createObject(SepaLastschrift.class, null);
-        sl.setBetrag(za.getBetrag().doubleValue());
-        sl.setCreditorId(Einstellungen.getEinstellung().getGlaeubigerID());
-        sl.setGegenkontoName(za.getName());
-        sl.setGegenkontoBLZ(za.getBic());
-        sl.setGegenkontoNummer(za.getIban());
-        sl.setKonto(param.konto);
-        sl.setMandateId(za.getMandatid());
-        sl.setSequenceType(
-            SepaLastSequenceType.valueOf(za.getMandatsequence().getTxt()));
-        sl.setSignatureDate(za.getMandatdatum());
-        sl.setTargetDate(za.getFaelligkeit());
-        sl.setTermin(d);
-        sl.setType(SepaLastType.CORE);
-        sl.setZweck(za.getVerwendungszweck());
-        lastschriften[sli] = sl;
-        sli++;
-      }
-      SepaLastschriftMerger merger = new SepaLastschriftMerger();
-      List<SepaSammelLastschrift> sammler = merger
-          .merge(Arrays.asList(lastschriften));
-      for (SepaSammelLastschrift s : sammler)
-      {
-        // Hier noch die eigene Bezeichnung einfuegen
-        String vzweck = getVerwendungszweck(param) + " "
-            + s.getBezeichnung().substring(0, s.getBezeichnung().indexOf(" "))
-            + " vom " + new JVDateFormatDATETIME().format(new Date());
-        s.setBezeichnung(vzweck);
-        s.store();
-      }
-    }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException(e);
-    }
-    catch (SEPAException e)
-    {
-      throw new ApplicationException(e);
-    }
-  }
+	  private void writeMitgliedskonto(Mitglied mitglied, Date datum, String zweck1,
+	      double betrag, Abrechnungslauf abrl, boolean haben, Konto konto,
+	      Buchungsart buchungsart) throws ApplicationException, RemoteException
+	  {
+	    Mitgliedskonto mk = null;
+	    if (mitglied != null) /*
+	                           * Mitglied darf dann null sein, wenn die Gegenbuchung
+	                           * geschrieben wird
+	                           */
+	    {
+	      mk = (Mitgliedskonto) Einstellungen.getDBService()
+	          .createObject(Mitgliedskonto.class, null);
+	      mk.setAbrechnungslauf(abrl);
+	      mk.setZahlungsweg(mitglied.getZahlungsweg());
+	      mk.setBetrag(betrag);
+	      mk.setDatum(datum);
+	      mk.setMitglied(mitglied);
+	      mk.setZweck1(zweck1);
+	      if (buchungsart != null)
+	      {
+	        mk.setBuchungsart(buchungsart);
+	      }
+	      mk.store();
+	    }
+	    if (haben)
+	    {
+	      Buchung buchung = (Buchung) Einstellungen.getDBService()
+	          .createObject(Buchung.class, null);
+	      buchung.setAbrechnungslauf(abrl);
+	      buchung.setBetrag(betrag);
+	      buchung.setDatum(datum);
+	      buchung.setKonto(konto);
+	      buchung.setName(
+	          mitglied != null ? Adressaufbereitung.getNameVorname(mitglied)
+	              : "JVerein");
+	      buchung.setZweck(zweck1);
+	      if (mk != null)
+	      {
+	        buchung.setMitgliedskonto(mk);
+	      }
+	      if (buchungsart != null)
+	      {
+	        buchung.setBuchungsart(new Long(buchungsart.getID()));
+	      }
+	      buchung.store();
+	    }
+	  }
 
-  private String getVerwendungszweck(AbrechnungSEPAParam param)
-      throws RemoteException
-  {
-    Map<String, Object> map = new AllgemeineMap().getMap(null);
-    map = new AbrechnungsParameterMap().getMap(param, map);
-    try
-    {
-      return VelocityTool.eval(map, param.verwendungszweck);
-    }
-    catch (IOException e)
-    {
-      Logger.error("Fehler bei der Aufbereitung der Variablen", e);
-      return param.verwendungszweck;
-    }
-  }
+	  /**
+	   * Ist das Abbuchungskonto in der Buchführung eingerichtet?
+	   * 
+	   * @throws SEPAException
+	   */
+	  private Konto getKonto()
+	      throws ApplicationException, RemoteException, SEPAException
+	  {
+	    // Variante 1: IBAN
+	    DBIterator<Konto> it = Einstellungen.getDBService().createList(Konto.class);
+	    it.addFilter("nummer = ?", Einstellungen.getEinstellung().getIban());
+	    if (it.size() == 1)
+	    {
+	      return (Konto) it.next();
+	    }
+	    // Variante 2: Kontonummer aus IBAN
+	    it = Einstellungen.getDBService().createList(Konto.class);
+	    IBAN iban = new IBAN(Einstellungen.getEinstellung().getIban());
+	    it.addFilter("nummer = ?", iban.getKonto());
+	    if (it.size() == 1)
+	    {
+	      return (Konto) it.next();
+	    }
+	    throw new ApplicationException(String.format(
+	        "Weder Konto %s noch Konto %s ist in der Buchführung eingerichtet. Menu: Buchführung | Konten",
+	        Einstellungen.getEinstellung().getIban(), iban.getKonto()));
+	  }
 
-  private Abrechnungslauf getAbrechnungslauf(AbrechnungSEPAParam param)
-      throws RemoteException, ApplicationException
-  {
-    Abrechnungslauf abrl = (Abrechnungslauf) Einstellungen.getDBService()
-        .createObject(Abrechnungslauf.class, null);
-    abrl.setDatum(new Date());
-    abrl.setAbbuchungsausgabe(param.abbuchungsausgabe.getKey());
-    abrl.setFaelligkeit(param.faelligkeit1);
-    abrl.setFaelligkeit2(param.faelligkeit2);
-    abrl.setDtausdruck(param.sepaprint);
-    abrl.setEingabedatum(param.vondatum);
-    abrl.setAustrittsdatum(param.bisdatum);
-    abrl.setKursteilnehmer(param.kursteilnehmer);
-    abrl.setModus(param.abbuchungsmodus);
-    abrl.setStichtag(param.stichtag);
-    abrl.setZahlungsgrund(getVerwendungszweck(param));
-    abrl.setZusatzbetraege(param.zusatzbetraege);
-    abrl.setAbgeschlossen(false);
-    abrl.store();
-    return abrl;
-  }
+	  private String getVerwendungszweck2(Mitglied m) throws RemoteException
+	  {
+	    String mitgliedname = (Einstellungen.getEinstellung()
+	        .getExterneMitgliedsnummer() ? m.getExterneMitgliedsnummer()
+	            : m.getID())
+	        + "/" + Adressaufbereitung.getNameVorname(m);
+	    return mitgliedname;
+	  }
 
-  private void writeMitgliedskonto(Mitglied mitglied, Date datum, String zweck1,
-      double betrag, Abrechnungslauf abrl, boolean haben, Konto konto,
-      Buchungsart buchungsart) throws ApplicationException, RemoteException
-  {
-    Mitgliedskonto mk = null;
-    if (mitglied != null) /*
-                           * Mitglied darf dann null sein, wenn die Gegenbuchung
-                           * geschrieben wird
-                           */
-    {
-      mk = (Mitgliedskonto) Einstellungen.getDBService()
-          .createObject(Mitgliedskonto.class, null);
-      mk.setAbrechnungslauf(abrl);
-      mk.setZahlungsweg(mitglied.getZahlungsweg());
-      mk.setBetrag(betrag);
-      mk.setDatum(datum);
-      mk.setMitglied(mitglied);
-      mk.setZweck1(zweck1);
-      if (buchungsart != null)
-      {
-        mk.setBuchungsart(buchungsart);
-      }
-      mk.store();
-    }
-    if (haben)
-    {
-      Buchung buchung = (Buchung) Einstellungen.getDBService()
-          .createObject(Buchung.class, null);
-      buchung.setAbrechnungslauf(abrl);
-      buchung.setBetrag(betrag);
-      buchung.setDatum(datum);
-      buchung.setKonto(konto);
-      buchung.setName(
-          mitglied != null ? Adressaufbereitung.getNameVorname(mitglied)
-              : "JVerein");
-      buchung.setZweck(zweck1);
-      if (mk != null)
-      {
-        buchung.setMitgliedskonto(mk);
-      }
-      if (buchungsart != null)
-      {
-        buchung.setBuchungsart(new Long(buchungsart.getID()));
-      }
-      buchung.store();
-    }
-  }
+	  private boolean checkSEPA(Mitglied m, ProgressMonitor monitor)
+	      throws RemoteException, ApplicationException
+	  {
+	    if (m.getZahlungsweg() == null
+	        || m.getZahlungsweg() != Zahlungsweg.BASISLASTSCHRIFT)
+	    {
+	      return true;
+	    }
+	    if (m.getLetzteLastschrift() != null
+	        && m.getLetzteLastschrift().before(sepagueltigkeit.getTime()))
+	    {
+	      monitor.log(Adressaufbereitung.getNameVorname(m)
+	          + ": Letzte Lastschrift ist älter als 36 Monate.");
+	      return false;
+	    }
+	    if (m.getMandatSequence().equals(MandatSequence.FRST)
+	        && m.getLetzteLastschrift() != null)
+	    {
+	      Mitglied m1 = (Mitglied) Einstellungen.getDBService()
+	          .createObject(Mitglied.class, m.getID());
+	      m1.setMandatSequence(MandatSequence.RCUR);
+	      m1.store();
+	      m.setMandatSequence(MandatSequence.RCUR);
+	    }
+	    if (m.getMandatDatum() == Einstellungen.NODATE)
+	    {
+	      monitor.log(Adressaufbereitung.getNameVorname(m)
+	          + ": Kein Mandat-Datum vorhanden.");
+	      return false;
+	    }
+	    return true;
+	  }
 
-  /**
-   * Ist das Abbuchungskonto in der Buchführung eingerichtet?
-   * 
-   * @throws SEPAException
-   */
-  private Konto getKonto()
-      throws ApplicationException, RemoteException, SEPAException
-  {
-    // Variante 1: IBAN
-    DBIterator<Konto> it = Einstellungen.getDBService().createList(Konto.class);
-    it.addFilter("nummer = ?", Einstellungen.getEinstellung().getIban());
-    if (it.size() == 1)
-    {
-      return (Konto) it.next();
-    }
-    // Variante 2: Kontonummer aus IBAN
-    it = Einstellungen.getDBService().createList(Konto.class);
-    IBAN iban = new IBAN(Einstellungen.getEinstellung().getIban());
-    it.addFilter("nummer = ?", iban.getKonto());
-    if (it.size() == 1)
-    {
-      return (Konto) it.next();
-    }
-    throw new ApplicationException(String.format(
-        "Weder Konto %s noch Konto %s ist in der Buchführung eingerichtet. Menu: Buchführung | Konten",
-        Einstellungen.getEinstellung().getIban(), iban.getKonto()));
-  }
+	}
 
-  private String getVerwendungszweck2(Mitglied m) throws RemoteException
-  {
-    String mitgliedname = (Einstellungen.getEinstellung()
-        .getExterneMitgliedsnummer() ? m.getExterneMitgliedsnummer()
-            : m.getID())
-        + "/" + Adressaufbereitung.getNameVorname(m);
-    return mitgliedname;
-  }
+	class JVereinBasislastschrift
+	{
+	  private Basislastschrift lastschriftFRST;
 
-  private boolean checkSEPA(Mitglied m, ProgressMonitor monitor)
-      throws RemoteException, ApplicationException
-  {
-    if (m.getZahlungsweg() == null
-        || m.getZahlungsweg() != Zahlungsweg.BASISLASTSCHRIFT)
-    {
-      return true;
-    }
-    if (m.getLetzteLastschrift() != null
-        && m.getLetzteLastschrift().before(sepagueltigkeit.getTime()))
-    {
-      monitor.log(Adressaufbereitung.getNameVorname(m)
-          + ": Letzte Lastschrift ist älter als 36 Monate.");
-      return false;
-    }
-    if (m.getMandatSequence().equals(MandatSequence.FRST)
-        && m.getLetzteLastschrift() != null)
-    {
-      Mitglied m1 = (Mitglied) Einstellungen.getDBService()
-          .createObject(Mitglied.class, m.getID());
-      m1.setMandatSequence(MandatSequence.RCUR);
-      m1.store();
-      m.setMandatSequence(MandatSequence.RCUR);
-    }
-    if (m.getMandatDatum() == Einstellungen.NODATE)
-    {
-      monitor.log(Adressaufbereitung.getNameVorname(m)
-          + ": Kein Mandat-Datum vorhanden.");
-      return false;
-    }
-    return true;
-  }
+	  private Basislastschrift lastschriftRCUR;
 
-}
+	  public JVereinBasislastschrift()
+	  {
+	    lastschriftFRST = new Basislastschrift();
+	    lastschriftRCUR = new Basislastschrift();
+	  }
 
-class JVereinBasislastschrift
-{
-  private Basislastschrift lastschriftFRST;
+	  public void setBIC(String bic) throws SEPAException
+	  {
+	    lastschriftFRST.setBIC(bic);
+	    lastschriftRCUR.setBIC(bic);
+	  }
 
-  private Basislastschrift lastschriftRCUR;
+	  public void setGlaeubigerID(String glaeubigerid)
+	      throws RemoteException, SEPAException
+	  {
+	    lastschriftFRST.setGlaeubigerID(glaeubigerid);
+	    lastschriftRCUR.setGlaeubigerID(glaeubigerid);
+	  }
 
-  public JVereinBasislastschrift()
-  {
-    lastschriftFRST = new Basislastschrift();
-    lastschriftRCUR = new Basislastschrift();
-  }
+	  public void setIBAN(String iban) throws SEPAException
+	  {
+	    lastschriftFRST.setIBAN(iban);
+	    lastschriftRCUR.setIBAN(iban);
+	  }
 
-  public void setBIC(String bic) throws SEPAException
-  {
-    lastschriftFRST.setBIC(bic);
-    lastschriftRCUR.setBIC(bic);
-  }
+	  public void setKomprimiert(boolean kompakt) throws SEPAException
+	  {
+	    lastschriftFRST.setKomprimiert(kompakt);
+	    lastschriftRCUR.setKomprimiert(kompakt);
+	  }
 
-  public void setGlaeubigerID(String glaeubigerid)
-      throws RemoteException, SEPAException
-  {
-    lastschriftFRST.setGlaeubigerID(glaeubigerid);
-    lastschriftRCUR.setGlaeubigerID(glaeubigerid);
-  }
+	  public void setName(String name) throws SEPAException
+	  {
+	    lastschriftFRST.setName(name);
+	    lastschriftRCUR.setName(name);
+	  }
 
-  public void setIBAN(String iban) throws SEPAException
-  {
-    lastschriftFRST.setIBAN(iban);
-    lastschriftRCUR.setIBAN(iban);
-  }
+	  public void setMessageID(String id) throws SEPAException
+	  {
+	    lastschriftFRST.setMessageID(id + "-FRST");
+	    lastschriftRCUR.setMessageID(id + "-RCUR");
+	  }
 
-  public void setKomprimiert(boolean kompakt) throws SEPAException
-  {
-    lastschriftFRST.setKomprimiert(kompakt);
-    lastschriftRCUR.setKomprimiert(kompakt);
-  }
+	  public void write(File frst, File rcur)
+	      throws DatatypeConfigurationException, SEPAException, JAXBException
+	  {
+	    lastschriftFRST.write(frst);
+	    lastschriftRCUR.write(rcur);
+	  }
 
-  public void setName(String name) throws SEPAException
-  {
-    lastschriftFRST.setName(name);
-    lastschriftRCUR.setName(name);
-  }
+	  public void add(Zahler zahler) throws SEPAException
+	  {
+	    if (zahler.getMandatsequence().equals(MandatSequence.FRST))
+	    {
+	      lastschriftFRST.add(zahler);
+	    }
+	    else if (zahler.getMandatsequence().equals(MandatSequence.RCUR))
+	    {
+	      lastschriftRCUR.add(zahler);
+	    }
+	    else
+	      throw new SEPAException("Ungültige Sequenz");
+	  }
 
-  public void setMessageID(String id) throws SEPAException
-  {
-    lastschriftFRST.setMessageID(id + "-FRST");
-    lastschriftRCUR.setMessageID(id + "-RCUR");
-  }
+	  public Basislastschrift getLastschriftFRST()
+	  {
+	    return lastschriftFRST;
+	  }
 
-  public void write(File frst, File rcur)
-      throws DatatypeConfigurationException, SEPAException, JAXBException
-  {
-    lastschriftFRST.write(frst);
-    lastschriftRCUR.write(rcur);
-  }
+	  public Basislastschrift getLastschriftRCUR()
+	  {
+	    return lastschriftRCUR;
+	  }
 
-  public void add(Zahler zahler) throws SEPAException
-  {
-    if (zahler.getMandatsequence().equals(MandatSequence.FRST))
-    {
-      lastschriftFRST.add(zahler);
-    }
-    else if (zahler.getMandatsequence().equals(MandatSequence.RCUR))
-    {
-      lastschriftRCUR.add(zahler);
-    }
-    else
-      throw new SEPAException("Ungültige Sequenz");
-  }
+	  public ArrayList<Zahler> getZahler()
+	  {
+	    ArrayList<Zahler> ret = new ArrayList<>();
+	    for (Zahler z : lastschriftFRST.getZahler())
+	    {
+	      ret.add(z);
+	    }
+	    for (Zahler z : lastschriftRCUR.getZahler())
+	    {
+	      ret.add(z);
+	    }
+	    return ret;
+	  }
 
-  public Basislastschrift getLastschriftFRST()
-  {
-    return lastschriftFRST;
-  }
-
-  public Basislastschrift getLastschriftRCUR()
-  {
-    return lastschriftRCUR;
-  }
-
-  public ArrayList<Zahler> getZahler()
-  {
-    ArrayList<Zahler> ret = new ArrayList<>();
-    for (Zahler z : lastschriftFRST.getZahler())
-    {
-      ret.add(z);
-    }
-    for (Zahler z : lastschriftRCUR.getZahler())
-    {
-      ret.add(z);
-    }
-    return ret;
-  }
-
-}
+	}

--- a/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
@@ -78,7 +78,7 @@ public class BuchungAuswertungPDF
       {
         if (einzel)
         {
-          query.setOrderDatumID();
+          query.getOrder("ORDER_DATUM_ID");
         }
         List<Buchung> liste = getBuchungenEinerBuchungsart(query.get(), bua);
         createTableContent(reporter, bua, liste, einzel);


### PR DESCRIPTION
Hibiscus ist für jverein erforderlich und liefert entsprechende Java-Klassen u.a. hbci4java.
Der Abrechnungslauf für die Dateiausgabe wurde umgestellt auf hbci4java.  Dadurch können nun aktuelle SEPA-XML Versionen direkt aus jVerein exportiert werden. Die obantoo Schnittstelle wurde durch die methode lastschrift genutzt - diese ist nun auskommentiert - aber noch weiterhin integriert.

Folgende Links aus dem jverein-forum dienen als Quellinformation:
https://jverein-forum.de/viewtopic.php?t=7154
https://jverein-forum.de/viewtopic.php?t=7139


Versehentlich ist die zweite Änderung auch hier reingewandert. Es gibt ingesamt 9 neue Sortierfilter für das Buchungsjournal zusätzlich zu den bisherigen 3.
Folgender Link aus dem jverein-forum dienst als Quellinformation:
https://jverein-forum.de/viewtopic.php?t=7085
