### PR TITLE
Neue Sortiermöglichkeiten von 3 auf 12 erweitert.

### DIFF
--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.Queries;
 import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.List;
+import java.util.HashMap;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.Suchbetrag;
@@ -50,20 +51,26 @@ public class BuchungQuery
   private List<Buchung> ergebnis;
 
   private Boolean hasMitglied;
+  
+  private HashMap<String, String> sortValues = new HashMap<String, String>();
 
-  private static final int ORDER_UMSATZID = 0;
-
-  private static final int ORDER_DATUM = 1;
-
-  private static final int ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER = 2;
-
-  private static final int ORDER_DATUM_NAME = 3;
-
-  private static final int ORDER_ID = 4;
-
-  private static final int ORDER_DATUM_ID = 5;
-
-  private int order = ORDER_UMSATZID;
+  private void SortHashMap() {
+	  sortValues.put("ORDER_ID","order by id");
+	  sortValues.put("ORDER_DATUM","order by datum");
+	  sortValues.put("ORDER_DATUM_NAME","order by datum, name");
+	  sortValues.put("ORDER_DATUM_ID","order by datum, id");
+	  sortValues.put("ORDER_DATUM_ID_NAME","order by datum, id, name");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER","order by datum, auszugsnummer");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_NAME","order by datum, auszugsnummer, name");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER","order by datum, blattnummer");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER_NAME","order by datum, blattnummer, name");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_ID","order by datum, auszugsnummer, id");
+	  sortValues.put("ORDER_DATUM_BLATTNUMMER_ID","order by datum, blattnummer, id");
+	  sortValues.put("ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER_ID","order by datum, auszugsnummer, blattnummer, id");
+	  sortValues.put("DEFAULT","order by datum");
+  }
+  
+  public String ordername = null;
 
   public BuchungQuery(Date datumvon, Date datumbis, Konto konto,
       Buchungsart buchungsart, Projekt projekt, String text, String betrag,
@@ -78,12 +85,27 @@ public class BuchungQuery
     this.betrag = betrag;
     this.hasMitglied = hasMitglied;
   }
-
-  public void setOrderID()
-  {
-    order = ORDER_ID;
+  
+  public String getOrder(String value) {
+	  SortHashMap();
+	  String newvalue = null;
+	  if ( value == null ) {
+		  return sortValues.get("DEFAULT");
+	  } else {
+		  newvalue = value.replaceAll(", ", "_");
+		  newvalue = newvalue.toUpperCase();
+		  newvalue = "ORDER_" + newvalue;
+          return sortValues.get(newvalue);
+	  }
   }
-
+  
+  public void setOrdername(String value)
+  {
+    if ( value != null ) {
+    	ordername = value;
+    }
+  }
+  
   public Boolean getHasMitglied()
   {
     return hasMitglied;
@@ -92,26 +114,6 @@ public class BuchungQuery
   public void setHasMitglied(Boolean hasMitglied)
   {
     this.hasMitglied = hasMitglied;
-  }
-
-  public void setOrderDatum()
-  {
-    order = ORDER_DATUM;
-  }
-
-  public void setOrderDatumID()
-  {
-    order = ORDER_DATUM_ID;
-  }
-
-  public void setOrderDatumAuszugsnummerBlattnummer()
-  {
-    order = ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER;
-  }
-
-  public void setOrderDatumName()
-  {
-    order = ORDER_DATUM_NAME;
   }
 
   public Date getDatumvon()
@@ -245,41 +247,13 @@ public class BuchungQuery
           "(upper(name) like ? or upper(zweck) like ? or upper(kommentar) like ?) ",
           ttext, ttext, ttext);
     }
-    switch (order)
-    {
-      case ORDER_UMSATZID:
-      {
-        it.setOrder("ORDER BY umsatzid DESC");
-        break;
-      }
-      case ORDER_DATUM:
-      {
-        it.setOrder("ORDER BY datum");
-        break;
-      }
-      case ORDER_DATUM_AUSZUGSNUMMER_BLATTNUMMER:
-      {
-        it.setOrder("ORDER BY datum, auszugsnummer, blattnummer, id");
-        break;
-      }
-      case ORDER_DATUM_NAME:
-      {
-        it.setOrder("ORDER BY datum, name, id");
-        break;
-      }
-      case ORDER_ID:
-      {
-        it.setOrder("ORDER BY id");
-        break;
-      }
-      case ORDER_DATUM_ID:
-      {
-        it.setOrder("ORDER BY datum, id");
-        break;
-      }
- 
-    }
 
+    // 20220823: sbuer: Neue Sortierfelder
+    SortHashMap();
+    String orderString = getOrder(ordername);
+    // System.out.println("ordervalue : " + ordername + " ,orderString : " + orderString);
+    it.setOrder(orderString);
+    
     this.ergebnis = PseudoIterator.asList(it);
     return ergebnis;
   }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1312,19 +1312,11 @@ public class BuchungsControl extends AbstractControl
 
       BuchungsjournalSortDialog djs = new BuchungsjournalSortDialog(
           BuchungsjournalSortDialog.POSITION_CENTER);
+      
+      // 20220823: sbuer: Statische Variablen fuer neue Sortiermöglichkeiten
       String sort = djs.open();
-      if (sort.equals(BuchungsjournalSortDialog.DATUM))
-      {
-        query.setOrderDatumAuszugsnummerBlattnummer();
-      }
-      else if (sort.equals(BuchungsjournalSortDialog.DATUM_NAME))
-      {
-        query.setOrderDatumName();
-      }
-      else
-      {
-        query.setOrderID();
-      }
+      query.setOrdername(sort);
+
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
       fd.setText("Ausgabedatei wählen.");
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
@@ -35,11 +35,21 @@ import de.willuhn.jameica.system.OperationCanceledException;
 public class BuchungsjournalSortDialog extends AbstractDialog<String>
 {
 
+  // 20220823: sbuer: Statische Variablen fuer neue Sortiermöglichkeiten
+  //                  Der Key dient als eindeutiger Bezeichner fuer das Dialogfeld und die Hashmap
+  //                  Der Value dient als Anzeigename im Dialogfeld
+  public final static String ID = "Id";
   public final static String DATUM = "Datum";
-
-  public final static String DATUM_NAME = "Datum, Name, Buchungsnummer";
-
-  public final static String BUCHUNGSNUMMER = "Buchungsnummer";
+  public final static String DATUM_NAME = "Datum, Name";
+  public final static String DATUM_ID = "Datum, Id";
+  public final static String DATUM_ID_NAME = "Datum, Id, Name";
+  public final static String DATUM_AUSZUGSNUMMER = "Datum, Auszugsnummer";
+  public final static String DATUM_AUSZUGSNUMMER_NAME = "Datum, Auszugsnummer, Name";
+  public final static String DATUM_BLATTNUMMER = "Datum, Blattnummer";
+  public final static String DATUM_BLATTNUMMER_NAME = "Datum, Blattnummer, Name";
+  public final static String DATUM_AUSGZUGSNUMMER_ID = "Datum, Auszugsnummer, Id";
+  public final static String DATUM_BLATTNUMMER_ID = "Datum, Blattnummer, Id";
+  public final static String DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID = "Datum, Auszugsnummer, Blattnummer, Id";
 
   private String selected = DATUM;
 
@@ -56,7 +66,7 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
   @Override
   protected void paint(Composite parent) throws Exception
   {
-    LabelGroup options = new LabelGroup(parent, "Buchungsjournal-Sortierung");
+    LabelGroup options = new LabelGroup(parent, "Ihre Auswahl");
     options.addInput(this.getSortierung());
     ButtonArea b = new ButtonArea();
     b.addButton("weiter", new Action()
@@ -90,8 +100,14 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
     {
       return this.sortierung;
     }
-    this.sortierung = new SelectInput(new Object[] { DATUM, DATUM_NAME,
-        BUCHUNGSNUMMER }, DATUM);
+    // 20220823: sbuer: Statische Variablen fuer neue Sortiermöglichkeiten
+    this.sortierung = new SelectInput(new Object[] 
+    		{ ID,DATUM,
+    		  DATUM_NAME,DATUM_ID,DATUM_ID_NAME,
+    		  DATUM_AUSZUGSNUMMER,DATUM_AUSZUGSNUMMER_NAME,
+    		  DATUM_BLATTNUMMER,DATUM_BLATTNUMMER_NAME,
+    		  DATUM_AUSGZUGSNUMMER_ID,DATUM_BLATTNUMMER_ID,
+    		  DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID }, DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID);
     this.sortierung.setName("Sortierung");
     this.sortierung.addListener(new Listener()
     {

--- a/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
@@ -78,7 +78,7 @@ public class BuchungAuswertungPDF
       {
         if (einzel)
         {
-          query.setOrderDatumID();
+        	query.getOrder("ORDER_DATUM_ID");
         }
         List<Buchung> liste = getBuchungenEinerBuchungsart(query.get(), bua);
         createTableContent(reporter, bua, liste, einzel);


### PR DESCRIPTION
Neue Sortiermöglichkeiten von 3 auf 12 erweitert (siehe PDF-Buchungsjournal Funktion über Buchungsliste)

Hierzu wurde auch die Art und Weise wie die Sortierung bisher eingebaut war verbessert.

Im BuchungsjournalSortDialog wird ein Statischer Wert dem Dropdown-Feld zugewiesen. Der statische Wert enthält eine Übersetzung (Pretty-Name) für die Dialog-Auswahl.
Im BuchungQuery gibt es eine HashMap. Der Key ist der Statische Wert aus dem Dropdown-Dialog, welcher als Value eine Where-Clausel für die SQL-Query bereithält. 
Wenn der Nutzer den jeweiligen Suchdialog ausgewählt hat, so ist der Standard das der Pretty-Name ausgelesen wird. Durch die getOrder Methode (siehe BuchungQuery) wird nun der Pretty-Name in den Key-Wert zurückgerechnet und mittels get Property Methode gegen die Hashmap ausgelesen. Dadurch erhält man die SQL Where Clausel und kann diese der Query übergeben.

Betroffen von der Änderung war auch die PDF-Einzelbuchungen (BuchungAuswertungPDF.java). Die dort enthältene query benötigte ebenfalls eine Standard Where Clausel. Dafür wurde die Methode getOrder definiert, die wiederum geziehlt einen default Key der Hashmap ausliest. (Es ist die gleiche SQL Where Clausel wie vorher - nur halt angepasst an das neue Verfahren.

Man spart sich somit etliche Methoden, die als Brücke bisher einen IntegerWert genutzt haben. (diese habe ich daher entfernt). Ich fand das alte Verfahren zu komplex und unnötig und habe es somit verbessert, damit sich einfacher neue Sortiermöglichkeiten hinzufügen lassen.

Quellinformationen zum Forum:
https://jverein-forum.de/viewtopic.php?t=7085


