### PR TITLE
Automatische Generierung von Spendenbescheinigungen rückwirkend für 4 Jahre

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -72,7 +72,12 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     }
     Calendar cal = Calendar.getInstance();
     jahr = new SelectInput(
-        new Object[] { cal.get(Calendar.YEAR), cal.get(Calendar.YEAR) - 1 },
+            new Object[] {
+                    cal.get(Calendar.YEAR),
+                    cal.get(Calendar.YEAR) - 1,
+                    cal.get(Calendar.YEAR) - 2,
+                    cal.get(Calendar.YEAR) - 3
+                },
         cal.get(Calendar.YEAR));
     jahr.addListener(new Listener()
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -166,6 +166,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
             spbescheinigung.setZeile3(sp1.getMitglied().getStrasse());
             spbescheinigung.setZeile4(
                 sp1.getMitglied().getPlz() + " " + sp1.getMitglied().getOrt());
+            spbescheinigung.setZeile5(sp1.getMitglied().getStaat());
             spbescheinigung.setErsatzAufwendungen(false);
             spbescheinigung.setBescheinigungsdatum(new Date());
             spbescheinigung.setSpendedatum(new Date());


### PR DESCRIPTION
Dieser PR ist die Änderung für diese gewünschte Funktion:
https://github.com/jverein/jverein/pull/64

Erlaube das erstellen von Spendenbescheinigungen für die letzten 4 Jahre.
Mit diesem PR lässt sich über die Funktion jverein > Spendenbescheinigung > neu (automatisch) im Dropdown Feld Jahr, die letzten 4 Jahre auswählen.

Ich denke mal, daß dies im Interesse der User ist, daß diese Funktion endlich enthalten ist.