### PR TITLE
Bugfix: Automatisches Generieren von Spendenbescheinigungen (Staat in Zeile5)

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -161,6 +161,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
             spbescheinigung.setZeile3(sp1.getMitglied().getStrasse());
             spbescheinigung.setZeile4(
                 sp1.getMitglied().getPlz() + " " + sp1.getMitglied().getOrt());
+            spbescheinigung.setZeile5(sp1.getMitglied().getStaat());
             spbescheinigung.setErsatzAufwendungen(false);
             spbescheinigung.setBescheinigungsdatum(new Date());
             spbescheinigung.setSpendedatum(new Date());


### PR DESCRIPTION
Wenn man Spendenbescheinigungen automatisch generiert, so wird bei Auslandsadressen das Attribut Staat nicht in die Zeile5 übernommen. Dieser Fehler wurde mit dem zusätzlichen Eintrag behoben.

Quellinformation zum Forum:
https://jverein-forum.de/viewtopic.php?t=7045