### PR TITLE
Fix für NullPointerException in MitgliederStammdaten

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailAction.java
@@ -34,6 +34,11 @@ public class MitgliedskontoDetailAction implements Action
   {
     MitgliedskontoNode mkn = null;
     Mitgliedskonto mk = null;
+    
+    if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Keine Sollbuchung ausgewählt");
+    }
 
     if (context != null && (context instanceof MitgliedskontoNode))
     {

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollLoeschenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollLoeschenAction.java
@@ -36,6 +36,11 @@ public class MitgliedskontoDetailSollLoeschenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
+  	if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Keine Sollbuchung ausgewählt");
+    }
+  	
     YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
     d.setTitle("Sollbuchung löschen");
     d.setText("Wollen Sie die Sollbuchung wirklich löschen?");

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollLoeschenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollLoeschenAction.java
@@ -36,7 +36,7 @@ public class MitgliedskontoDetailSollLoeschenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-  	if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context == null || !(context instanceof MitgliedskontoNode))
     {
       throw new ApplicationException("Keine Sollbuchung ausgewählt");
     }

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailSollNeuAction.java
@@ -35,6 +35,11 @@ public class MitgliedskontoDetailSollNeuAction implements Action
   {
     MitgliedskontoNode mkn = null;
     Mitgliedskonto mk = null;
+    
+    if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Kein Mitgliedskonto ausgewählt");
+    }
 
     if (context != null && (context instanceof MitgliedskontoNode))
     {

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstLoesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstLoesenAction.java
@@ -35,6 +35,11 @@ public class MitgliedskontoIstLoesenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
+  	if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Keine Istbuchung ausgewählt");
+    }
+  	
     YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
     d.setTitle("Istbuchung vom Mitgliedskonto lösen");
     d.setText("Wollen Sie die Istbuchung wirklich vom Mitgliedskonto lösen?");

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstLoesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstLoesenAction.java
@@ -35,7 +35,7 @@ public class MitgliedskontoIstLoesenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-  	if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context == null || !(context instanceof MitgliedskontoNode))
     {
       throw new ApplicationException("Keine Istbuchung ausgewählt");
     }

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -42,7 +42,7 @@ public class SpendenbescheinigungAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-  	if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context == null || !(context instanceof MitgliedskontoNode))
     {
       throw new ApplicationException("Kein Mitgliedskonto ausgewählt");
     }

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -42,6 +42,10 @@ public class SpendenbescheinigungAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
+  	if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Kein Mitgliedskonto ausgewählt");
+    }
     Spendenbescheinigung spb = null;
 
     try


### PR DESCRIPTION
Dieser Pull Request behebt die Nullpointerexception in den Stammdaten -> Mitgliedskonto, wenn das Mitgliedskonto nicht ausgewählt wurde. Es erscheinen nun passende Fehlermeldungen.

https://github.com/openjverein/jverein/issues/20