### PR TITLE
 H2-Datenbank: readonly-User anlegen, optional mit AUTO_SERVER starten

### DIFF
--- a/src/de/jost_net/JVerein/server/DBSupportH2Impl.java
+++ b/src/de/jost_net/JVerein/server/DBSupportH2Impl.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.util.HashMap;
 
 import de.jost_net.JVerein.JVereinPlugin;
+import de.jost_net.JVerein.rmi.JVereinDBService;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -137,6 +138,9 @@ public class DBSupportH2Impl extends AbstractDBSupportImpl
     String url = "jdbc:h2:" + Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class).getResources().getWorkPath()
         + "/h2db/jverein";
+    if (JVereinDBService.SETTINGS.getBoolean("database.driver.h2.auto_server", false)) {
+      url += ";AUTO_SERVER=TRUE";
+    }
 
     // if (JVereinDBService.SETTINGS.getBoolean("database.driver.h2.encryption",
     // true))

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0418.java
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0418 extends AbstractDDLUpdate
+{
+  public Update0418(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    if (getDriver()==DRIVER.H2) {
+      execute("CREATE USER readonly PASSWORD 'jverein'; GRANT SELECT ON SCHEMA PUBLIC TO readonly", false);
+    }
+    setNewVersion(nr);
+  }
+}


### PR DESCRIPTION
Um auf die H2-Datenbank bei laufendem Programm zugreifen zu können, kann die Datenbank mit AUTO_SERVER gestartet werden (dafür in cfg die Datei de.jost_net.JVerein.rmi.JVereinDBService.properties erzeugen; Inhalt ist die Zeile database.driver.h2.auto_server=true). Um nicht ungewollt Änderungen in der Datenbank vorzunehmen, habe ich den User readonly mit Passwort jverein angelegt, der nur Leserechte hat.

Wir verwenden Python-Skripte für diverse Auswertungen, und es ist sehr lästig, jedesmal Jameica schließen zu müssen. Unter Linux hatte es noch funktioniert, die Datenbankdatei zu kopieren, aber unter Windows kann keine Kopie erzeugt werden, solange Jameica läuft.