### PR TITLE
Fehler SpendenbescheinigungAction #75

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoDetailAction.java
@@ -34,11 +34,6 @@ public class MitgliedskontoDetailAction implements Action
   {
     MitgliedskontoNode mkn = null;
     Mitgliedskonto mk = null;
-    
-    if (context == null || !(context instanceof MitgliedskontoNode))
-    {
-      throw new ApplicationException("Keine Sollbuchung ausgewählt");
-    }
 
     if (context != null && (context instanceof MitgliedskontoNode))
     {

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -42,12 +42,6 @@ public class SpendenbescheinigungAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !((context instanceof Spendenbescheinigung)
-        || (context instanceof Mitglied)
-        || (context instanceof MitgliedskontoNode)))
-    {
-      throw new ApplicationException("Kein Element ausgewählt");
-    }
     Spendenbescheinigung spb = null;
 
     try

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -42,9 +42,11 @@ public class SpendenbescheinigungAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context == null || !((context instanceof Spendenbescheinigung)
+        || (context instanceof Mitglied)
+        || (context instanceof MitgliedskontoNode)))
     {
-      throw new ApplicationException("Kein Mitgliedskonto ausgewählt");
+      throw new ApplicationException("Kein Element ausgewählt");
     }
     Spendenbescheinigung spb = null;
 


### PR DESCRIPTION
- Change context check in SpendenbescheinigungAction
- Remove context check in MitgliedskontoDetailAction

Doppelklick auf Spendenbescheinigung funktioniert wieder.
Rechtsklick > Sollbuchung im Mitglied > Mitgliedskonto funktioniert weiterhin:
<img width="1478" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/2bdce469-4aa2-4536-b457-f032dcd505fa">
