### PR TITLE
Bezeichnung Buchungsklasse 50 > 100 Zeichen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
@@ -84,7 +84,7 @@ public class BuchungsklasseControl extends AbstractControl
     {
       return bezeichnung;
     }
-    bezeichnung = new TextInput(getBuchungsklasse().getBezeichnung(), 50);
+    bezeichnung = new TextInput(getBuchungsklasse().getBezeichnung(), 100);
     return bezeichnung;
   }
 

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0419.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0419.java
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0419 extends AbstractDDLUpdate
+{
+  public Update0419(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(alterColumn("buchungsklasse",
+        new Column("bezeichnung", COLTYPE.VARCHAR, 100, null, false, false)));
+
+    setNewVersion(nr);
+  }
+}


### PR DESCRIPTION
Die Bezeichnung der Buchungsklassen sind auf 50 Zeichen beschränkt. Das ist für die aktuellen Begriffe vom [DATEV SKR 49](https://www.datev.de/dnlexom/v2/content/files/st2111319691_de.pdf) (z.B. "Erfolgskonten für ertragsteuerpflichtige Geschäftsbetriebe Sport" mit 64 Zeichen) zu wenig. Die Beschränkung soll hiermit auf 100 Zeichen erhöht werden.