### PR TITLE
Fix: Nullpointer Exception bei Aufruf der Buchungsklassen

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -85,7 +85,10 @@ public class BuchungsklasseSaldoView extends AbstractView
         });
 
     Calendar calendar = new GregorianCalendar();
-    calendar.setTime(earliest);
+    if (earliest != null)
+    {
+      calendar.setTime(earliest);
+    }
     return calendar.get(Calendar.YEAR);
   }
 


### PR DESCRIPTION
Im https://github.com/jverein/jverein/issues/55 wurde der Fehler, welcher nur auftaucht wenn es noch keine Buchungen gibt, beschrieben. Im https://github.com/jverein/jverein/pull/65 gibt es bereits einen PR für das alte jverein.
Hier ist nun der PR für openjverein.