### PR TITLE
Feature/GitHub workflow release

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -5,12 +5,12 @@ name: openjverein nightly release
 
 on:
   push:
-    branches: 
+    branches:
       - master
-    tags-ignore: 
+    tags-ignore:
       - '**'
   pull_request:
-    types: 
+    types:
       - closed
 
 jobs:
@@ -32,17 +32,17 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
-        
+
     - name: Build jameica nightly
       working-directory: ./
       run: ant -noinput -buildfile jameica/build/build.xml nightly
-    
+
     - name: Check out hibiscus
       uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
         path: hibiscus
-        
+
     - name: Build hibiscus nightly
       working-directory: ./
       run: ant -noinput -buildfile hibiscus/build/build.xml nightly
@@ -52,7 +52,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: jverein
-    
+
     - name: Build openjverein plugin
       id: openjverein
       working-directory: ./
@@ -84,11 +84,11 @@ jobs:
         builddatetime=$(date +'%Y-%m-%d %H:%M')
         echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
 
-    - name: Create release and publish
-      uses: "marvinpinto/action-automatic-releases@latest"
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        repo_token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
-        automatic_release_tag: ${{ steps.openjverein.outputs.selected_version }}
+        tag_name: ${{ steps.openjverein.outputs.selected_version }}
         prerelease: true
-        title: Release ${{ steps.openjverein.outputs.selected_version }}
+        name: Release ${{ steps.openjverein.outputs.selected_version }}
         files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
+        generate_release_notes: false

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,96 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+
+name: openjverein nightly release
+
+on:
+  push:
+    branches: 
+      - master
+    tags-ignore: 
+      - '**'
+  pull_request:
+    types: 
+      - closed
+
+jobs:
+  build:
+    name: Building release and upload to branch
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@main
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+
+    - name: Check out jameica
+      uses: actions/checkout@main
+      with:
+        repository: willuhn/jameica
+        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        path: jameica
+        
+    - name: Build jameica nightly
+      working-directory: ./
+      run: ant -noinput -buildfile jameica/build/build.xml nightly
+    
+    - name: Check out hibiscus
+      uses: actions/checkout@main
+      with:
+        repository: willuhn/hibiscus
+        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        path: hibiscus
+        
+    - name: Build hibiscus nightly
+      working-directory: ./
+      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
+
+    - name: Checkout openjverein
+      id: openjverein_checkout
+      uses: actions/checkout@main
+      with:
+        path: jverein
+    
+    - name: Build openjverein plugin
+      id: openjverein
+      working-directory: ./
+      run: |
+        ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml nightly)
+        echo $ant_output
+
+        ssa="SELECTED_VERSION="
+        ssb=".zip"
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+        tmp_version=$tmp_version
+
+        ssa="SELECTED_FILENAME="
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+
+        ssa="SELECTED_PATH="
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+
+        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+        echo "selected_filename=$tmp_filename" >> $GITHUB_OUTPUT
+        echo "selected_path=$tmp_path" >> $GITHUB_OUTPUT
+
+        builddatetime=$(date +'%Y-%m-%d %H:%M')
+        echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
+
+    - name: Create release and publish
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        automatic_release_tag: ${{ steps.openjverein.outputs.selected_version }}
+        prerelease: true
+        title: Release ${{ steps.openjverein.outputs.selected_version }}
+        files: ./jverein/${{ steps.openjverein.outputs.selected_path }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -21,17 +21,16 @@ jobs:
 
     steps:
     - name: Set up JDK 11 for x64
-      uses: actions/setup-java@main
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
     - name: Check out jameica
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: willuhn/jameica
-        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         path: jameica
         
     - name: Build jameica nightly
@@ -39,10 +38,9 @@ jobs:
       run: ant -noinput -buildfile jameica/build/build.xml nightly
     
     - name: Check out hibiscus
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
-        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         path: hibiscus
         
     - name: Build hibiscus nightly
@@ -51,7 +49,7 @@ jobs:
 
     - name: Checkout openjverein
       id: openjverein_checkout
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         path: jverein
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,16 @@ jobs:
 
     steps:
     - name: Set up JDK 11 for x64
-      uses: actions/setup-java@main
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
     - name: Check out jameica
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: willuhn/jameica
-        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         path: jameica
         
     - name: Build jameica nightly
@@ -31,10 +30,9 @@ jobs:
       run: ant -noinput -buildfile jameica/build/build.xml nightly
     
     - name: Check out hibiscus
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
-        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         path: hibiscus
         
     - name: Build hibiscus nightly
@@ -43,7 +41,7 @@ jobs:
 
     - name: Checkout openjverein
       id: openjverein_checkout
-      uses: actions/checkout@main
+      uses: actions/checkout@v4
       with:
         path: jverein
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+
+name: openjverein official release
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: Building release and upload to branch
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@main
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+
+    - name: Check out jameica
+      uses: actions/checkout@main
+      with:
+        repository: willuhn/jameica
+        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        path: jameica
+        
+    - name: Build jameica nightly
+      working-directory: ./
+      run: ant -noinput -buildfile jameica/build/build.xml nightly
+    
+    - name: Check out hibiscus
+      uses: actions/checkout@main
+      with:
+        repository: willuhn/hibiscus
+        token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        path: hibiscus
+        
+    - name: Build hibiscus nightly
+      working-directory: ./
+      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
+
+    - name: Checkout openjverein
+      id: openjverein_checkout
+      uses: actions/checkout@main
+      with:
+        path: jverein
+    
+    - name: Build openjverein plugin
+      id: openjverein
+      working-directory: ./
+      run: |
+        ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml)
+        echo $ant_output
+
+        ssa="SELECTED_VERSION="
+        ssb=".zip"
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+        tmp_version=$tmp_version
+
+        ssa="SELECTED_FILENAME="
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+
+        ssa="SELECTED_PATH="
+        text="${ant_output#*${ssa}}"
+        text="${text%${ssb}*}.zip"
+        tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+
+        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+        echo "selected_filename=$tmp_filename" >> $GITHUB_OUTPUT
+        echo "selected_path=$tmp_path" >> $GITHUB_OUTPUT
+
+        builddatetime=$(date +'%Y-%m-%d %H:%M')
+        echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
+
+    - name: Create release and publish
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+        automatic_release_tag: ${{ steps.openjverein.outputs.selected_version }}
+        prerelease: false
+        title: Release ${{ steps.openjverein.outputs.selected_version }}
+        files: ./jverein/${{ steps.openjverein.outputs.selected_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,17 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
-        
+
     - name: Build jameica nightly
       working-directory: ./
       run: ant -noinput -buildfile jameica/build/build.xml nightly
-    
+
     - name: Check out hibiscus
       uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
         path: hibiscus
-        
+
     - name: Build hibiscus nightly
       working-directory: ./
       run: ant -noinput -buildfile hibiscus/build/build.xml nightly
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: jverein
-    
+
     - name: Build openjverein plugin
       id: openjverein
       working-directory: ./
@@ -76,11 +76,11 @@ jobs:
         builddatetime=$(date +'%Y-%m-%d %H:%M')
         echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
 
-    - name: Create release and publish
-      uses: "marvinpinto/action-automatic-releases@latest"
+    - name: Release
+      uses: softprops/action-gh-release@v1
       with:
-        repo_token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
-        automatic_release_tag: ${{ steps.openjverein.outputs.selected_version }}
+        tag_name: ${{ steps.openjverein.outputs.selected_version }}
         prerelease: false
-        title: Release ${{ steps.openjverein.outputs.selected_version }}
+        name: Release ${{ steps.openjverein.outputs.selected_version }}
         files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
+        generate_release_notes: true

--- a/build/build.properties
+++ b/build/build.properties
@@ -7,13 +7,14 @@ release.dir                     = releases
 define.encoding                 = ISO-8859-1
 define.jarfilename              = ${plugin.name}.jar
 define.srcfilename              = ${plugin.name}.src.zip
+define.srcfilename.nightly      = ${plugin.name}.src-nightly.zip
 define.package                  = de.jost_net.JVerein
-define.java.version             = 1.7
+define.java.version             = 11
 
-project.releaseCurrent          = ${release.dir}/current
 project.release                 = ${release.dir}/${plugin_version}-${build.number}
+project.release.nightly         = ${release.dir}/nightly
 project.tmp                     = ${project.release}/tmp
 project.javadoc                 = ${project.release}/javadoc
 project.zipdir                  = ${project.release}/${plugin.name}
 project.zipfilename             = ${plugin.name}.${plugin_version}.zip
-project.zipfilenameCurrent      = ${plugin.name}.zip
+project.zipfilename.nightly     = ${plugin.name}.${plugin_version}-nightly.zip

--- a/build/build.xml
+++ b/build/build.xml
@@ -2,149 +2,181 @@
 
 <project basedir=".." default="all" name="All">
 
-	<target name="init" description="inits the build">
-		<xmlproperty file="plugin.xml" collapseattributes="true" />
-		<property environment="env" />
-		<property name="build.dir" value="build" />
+  <target name="init" description="inits the build">
 
-		<tstamp>
-			<format property="build.timestamp" pattern="yyyyMMdd" />
-		</tstamp>
-		<loadfile property="plugin_version" srcFile="${build.dir}/RELEASE">
-			<filterchain>
-				<striplinebreaks/>
-			</filterchain>
-		</loadfile>
-		<buildnumber file="${build.dir}/BUILD" />
+    <property environment="env" />
+    <property name="build.dir" value="build" />
+    <buildnumber file="${build.dir}/BUILD" />
+    <xmlproperty file="plugin.xml" collapseattributes="true" />
 
-		<loadproperties srcfile="${build.dir}/build.properties" />
+    <tstamp>
+      <format property="build.timestamp" pattern="yyyyMMdd" />
+    </tstamp>
+    <loadfile property="plugin_version" srcFile="${build.dir}/RELEASE">
+      <filterchain>
+        <striplinebreaks/>
+      </filterchain>
+    </loadfile>
 
-		<path id="compilepath">
-			<fileset dir="lib">
-				<include name="**/*.jar" />
-			</fileset>
-			<fileset dir="../hibiscus/lib">
-				<include name="**/*.jar" />
-			</fileset>
-			<pathelement path="../hibiscus/bin" />
-			<pathelement path="../jameica/bin" />
-			<fileset dir="../jameica/lib">
-				<include name="**/*.jar" />
-				<exclude name="apache_xmlrpc/**" />
-				<exclude name="bouncycastle/**" />
-				<exclude name="mckoi/**" />
-				<exclude name="h2/**" />
-				<exclude name="mysql/**" />
-				<exclude name="paperclips/**" />
-				<exclude name="swt/linux/**" />
+    <loadproperties srcfile="${build.dir}/build.properties" />
+
+  	<echo message="VERSION: ${plugin_version}" level="info"/>
+    <echo message="BUILD  : ${build.number}" level="info"/>
+    <echo message="JAVA   : ${java.version}" level="info"/>
+
+    <path id="compilepath">
+      <fileset dir="${lib.dir}">
+        <include name="**/*.jar" />
+      </fileset>
+      <fileset dir="../hibiscus/lib">
+        <include name="**/*.jar" />
+      </fileset>
+      <fileset dir="../jameica/lib">
+        <include name="**/*.jar" />
+        <exclude name="apache_xmlrpc/**" />
+        <exclude name="bouncycastle/**" />
+        <exclude name="mckoi/**" />
+        <exclude name="h2/**" />
+        <exclude name="mysql/**" />
+        <exclude name="paperclips/**" />
+        <exclude name="swt/linux/**" />
         <exclude name="swt/linux-arm64/**" />
-				<exclude name="swt/macos*/**" />
-				<exclude name="swt/win32/**" />
-				<exclude name="swt/win64/**" />
-			</fileset>
-		</path>
+        <exclude name="swt/macos*/**" />
+        <exclude name="swt/win32/**" />
+        <exclude name="swt/win64/**" />
+      </fileset>
+      <pathelement path="../hibiscus/bin" />
+      <pathelement path="../jameica/bin" />
+      <pathelement path="../jameica/releases/jameica-lib.jar" />
+      <pathelement path="../hibiscus/releases/hibiscus-lib.jar" />
+    </path>
 
-		<path id="classpath">
-			<path refid="compilepath" />
-			<pathelement location="bin" />
-		</path>
+    <path id="classpath">
+      <path refid="compilepath" />
+      <pathelement location="${class.dir}" />
+    </path>
+  </target>
 
-	</target>
-
-	<target name="compile" depends="init, clean">
-		<mkdir dir="${class.dir}" />
-		<javac debug="true" includeantruntime="false" debuglevel="lines,vars,source" source="${define.java.version}" target="${define.java.version}" encoding="${define.encoding}" deprecation="true" destdir="${class.dir}" srcdir="${src.dir}">
+  <target name="compile" depends="init, clean">
+    <mkdir dir="${class.dir}" />
+    <javac debug="true" includeantruntime="false" debuglevel="lines,vars,source" source="${define.java.version}" target="${define.java.version}" encoding="${define.encoding}" deprecation="true" destdir="${class.dir}" srcdir="${src.dir}">
 			<classpath refid="compilepath" />
 		</javac>
-	</target>
+  </target>
 
-	<target name="jar" depends="init,compile" description="generates the jar file">
-		<mkdir dir="${project.release}" />
-		<mkdir dir="${project.zipdir}" />
-		<tstamp />
-		<jar destfile="${project.zipdir}/${define.jarfilename}">
-			<manifest>
-				<attribute name="Built-By" value="${user.name}" />
-				<attribute name="Built-Date" value="${DSTAMP}" />
-				<attribute name="Implementation-Title" value="${plugin.name}" />
-				<attribute name="Implementation-Version" value="${plugin_version}" />
-				<attribute name="Implementation-Buildnumber" value="${build.number}" />
-				<attribute name="Class-Path" value="lang help lib" />
-			</manifest>
-			<fileset dir="${class.dir}" />
-			<fileset dir="${src.dir}">
-				<exclude name="*.java" />
-			</fileset>
-		</jar>
-		<mkdir dir="${project.zipdir}/lib" />
-		<copy todir="${project.zipdir}/lib">
-			<fileset dir="${lib.dir}" />
-		</copy>
-		<copy todir="${project.zipdir}" file="plugin.xml" />
-		<replace file="${project.zipdir}/plugin.xml">
-			<replacefilter token="[VERSION]" value="${plugin_version}"/>
-			<replacefilter token="[PLUGIN_ZIP]" value="${project.zipfilename}"/>
-		</replace>
-		<!-- Jetzt muessen wir noch das ZIP-File erzeugen -->
-		<zip destfile="${project.release}/${project.zipfilename}">
-			<fileset dir="${project.release}">
-				<include name="${plugin.name}" />
-				<include name="${plugin.name}/**" />
-			</fileset>
-		</zip>
-	</target>
+  <target name="jar" depends="init,compile" description="generates the jar file">
+    <mkdir dir="${project.zipdir}" />
+    <tstamp />
+    <jar destfile="${project.zipdir}/${define.jarfilename}">
+      <manifest>
+        <attribute name="Built-By" value="${user.name}" />
+        <attribute name="Built-Date" value="${DSTAMP}" />
+        <attribute name="Implementation-Title" value="${plugin.name}" />
+        <attribute name="Implementation-Version" value="${plugin_version}" />
+        <attribute name="Implementation-Buildnumber" value="${build.number}" />
+        <attribute name="Class-Path" value="lang help lib" />
+      </manifest>
+      <fileset dir="${class.dir}" />
+      <fileset dir="${src.dir}">
+        <exclude name="*.java" />
+      </fileset>
+    </jar>
 
-	<target name="javadoc" depends="init" description="creates the api doc">
-		<mkdir dir="${project.javadoc}" />
-		<javadoc destdir="${project.javadoc}" packagenames="${define.package}.*" encoding="${define.encoding}">
-			<classpath refid="compilepath" />
-			<sourcepath>
-				<pathelement location="${src.dir}" />
-			</sourcepath>
-		</javadoc>
-	</target>
+    <mkdir dir="${project.zipdir}/lib" />
+    <copy todir="${project.zipdir}/lib">
+      <fileset dir="${lib.dir}" />
+    </copy>
 
-<!--	
-	<target name="junit" depends="init" description="JUnit-Tests">
-		<junit printsummary="yes" haltonfailure="yes">
-			<classpath refid="classpath" />
+    <copy todir="${project.zipdir}" file="plugin.xml" />
+    <replace file="${project.zipdir}/plugin.xml">
+      <replacefilter token="[VERSION]" value="${plugin_version}"/>
+      <replacefilter token="[PLUGIN_ZIP]" value="${project.zipfilename}"/>
+    </replace>
 
-			<formatter type="plain" usefile="false"/>
+    <!-- Jetzt muessen wir noch das ZIP-File erzeugen -->
+    <zip destfile="${project.release}/${project.zipfilename}">
+      <fileset dir="${project.release}">
+        <include name="${plugin.name}" />
+        <include name="${plugin.name}/**" />
+      </fileset>
+    </zip>
+  </target>
 
-			<test name="test.de.jost_net.JVerein.TestSuite" haltonfailure="yes">
-				<formatter type="xml" usefile="false" />
-			</test>
-		</junit>
-	</target>
+  <target name="javadoc" depends="init" description="creates the api doc">
+    <mkdir dir="${project.javadoc}" />
+    <javadoc destdir="${project.javadoc}" packagenames="${define.package}.*" encoding="${define.encoding}">
+      <classpath refid="compilepath" />
+      <sourcepath>
+        <pathelement location="${src.dir}" />
+      </sourcepath>
+    </javadoc>
+  </target>
+
+  <!--  
+  <target name="junit" depends="init" description="JUnit-Tests">
+    <junit printsummary="yes" haltonfailure="yes">
+      <classpath refid="classpath" />
+
+      <formatter type="plain" usefile="false"/>
+
+      <test name="test.de.jost_net.JVerein.TestSuite" haltonfailure="yes">
+        <formatter type="xml" usefile="false" />
+      </test>
+    </junit>
+  </target>
 -->
-	<target name="src" description="build source package, depends compile target to make sure, the code has no errors">
-		<mkdir dir="${project.release}" />
-		<mkdir dir="${project.tmp}/${plugin.name}" />
-		<copy todir="${project.tmp}/${plugin.name}">
-			<fileset dir=".">
-				<include name=".project" />
-				<include name=".classpath" />
-				<include name="${src.dir}/**" />
-				<include name="${build.dir}/**" />
-				<exclude name="${build.dir}/BUILD" />
-			</fileset>
-		</copy>
-		<zip casesensitive="true" zipfile="${project.release}/${define.srcfilename}">
-			<fileset dir="${project.tmp}">
-				<include name="${plugin.name}/**" />
-			</fileset>
-		</zip>
-	</target>
+  <target name="src" description="build source package, depends compile target to make sure, the code has no errors">
+    <mkdir dir="${project.release}" />
+    <mkdir dir="${project.tmp}/${plugin.name}" />
+    <copy todir="${project.tmp}/${plugin.name}">
+      <fileset dir="${basedir}">
+        <include name=".project" />
+        <include name=".classpath" />
+        <include name="${src.dir}/**" />
+        <include name="${build.dir}/**" />
+        <exclude name="${build.dir}/BUILD" />
+      </fileset>
+    </copy>
+    <zip casesensitive="true" zipfile="${project.release}/${define.srcfilename}">
+      <fileset dir="${project.tmp}">
+        <include name="${plugin.name}/**" />
+      </fileset>
+    </zip>
+  </target>
 
-	<target name="clean" description="cleanup">
-		<delete dir="${project.tmp}" />
-		<delete dir="${class.dir}" />
-	</target>
+  <target name="clean" description="cleanup">
+    <delete dir="${project.tmp}" />
+    <delete dir="${class.dir}" />
+  </target>
+  
+  <target name="lib">
+    <!-- Die Datei brauchen die anderen Plugins zum Kompilieren //-->
+    <copy file="${project.zipdir}/${define.jarfilename}" tofile="releases/jverein-lib.jar" />
+  </target>
 
-	<target name="all" depends="init,jar,javadoc,src,clean" description="build an official release" />
+  <target name="all" depends="init,jar,javadoc,src,clean" description="build an official release">
+  	<echo message="SELECTED_VERSION=${plugin_version}" />
+  	<echo message="SELECTED_PATH=${project.release}/${project.zipfilename}" />
+  	<echo message="SELECTED_FILENAME=${project.zipfilename}" />
+  </target>
 
-	<target name="fast" depends="init,jar,src" description="Entwicklerversion bauen">
-		<move file="${project.release}/${project.zipfilename}" tofile="${project.release}/${project.zipfilename}" />
-	</target>
+  <target name="fast" depends="init,jar,src" description="Entwicklerversion bauen">
+    <move file="${project.release}/${project.zipfilename}" tofile="${project.release}/${project.zipfilename}" />
+  </target>
+
+  <target name="nightly" depends="init,compile,jar,javadoc,src" description="build nightly release">
+    <mkdir dir="${project.release.nightly}" />
+
+    <copy file="${project.release}/${project.zipfilename}" tofile="${project.release.nightly}/${project.zipfilename.nightly}" />
+    <copy file="${project.release}/${define.srcfilename}" tofile="${project.release.nightly}/${define.srcfilename.nightly}" />
+
+    <antcall target="lib"/>
+
+    <delete dir="${project.release}" />
+
+  	<echo message="SELECTED_VERSION=${plugin_version}-nightly" />
+  	<echo message="SELECTED_PATH=${project.release.nightly}/${project.zipfilename.nightly}" />
+  	<echo message="SELECTED_FILENAME=${project.zipfilename.nightly}" />
+  </target>
 
 </project>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,12 +1,12 @@
-<plugin xmlns="http://www.willuhn.de/schema/jameica-plugin"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.willuhn.de/schema/jameica-plugin http://www.willuhn.de/schema/jameica-plugin-1.2.xsd"
+<plugin xmlns="https://www.willuhn.de/schema/jameica-plugin"
+        xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.willuhn.de/schema/jameica-plugin https://www.willuhn.de/schema/jameica-plugin-1.5.xsd"
         name="jverein" version="[VERSION]" class="de.jost_net.JVerein.JVereinPlugin">
 
   <description>OpenSource-Vereinsverwaltung</description>
   <url>https://openjverein.github.io/jameica-repository/[PLUGIN_ZIP]</url>
   <homepage>https://openjverein.github.io/</homepage>
-  <license>GPL - http://www.gnu.org/copyleft/gpl.html</license>
+  <license>GPL - https://www.gnu.org/copyleft/gpl.html</license>
   <icon>jverein-icon-64x64.png</icon>
   <menu>
     <item name="JVerein" >


### PR DESCRIPTION
Aufgrund des issues https://github.com/openjverein/jverein/issues/39 habe zwei github workflows gebaut.

Mit dem ersten workflow wird ein offizielles Release erstellt. Dies geschieht manuell über Actions > "openjverein official release" > "Run workflow".
<img width="1553" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/c1163bb6-bc42-4edb-83c6-22bf8dcd959c">

Es wird ein tag und ein release erstellt. Der Name des tags ist die Versionsnummer. Die Nummer wird aus dem Quellcode ermittelt. Der Name des Release ist "Release [Versionsnummer]". Es wird das kompilierte Plugin als Zip angehängt. Der Beschreibungstext wird automatisch anhand der commits zwischen diesem und dem letzten release erstellt.
<img width="1178" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/f74e1c6d-3070-4e57-80a8-fcb95534be0d">

Der zweite workflow  "openjverein nightly release" erstellt ein nightly release. Es wird automatisch ausgeführt sobald 1. ein PR in den master überführt wird, oder 2. wenn ein push in den master erfolgt (commit push). Das nightly wird als pre-release gekennzeichnet. Tag und release werden immer überschrieben, solange sich die Versionsnummer von jverein nicht ändert.
<img width="319" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/953c6e76-ef4a-4e65-9d2b-7c9bea91f727">
<img width="1069" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/94737cc9-f23a-46c1-a7cb-116c0661a24a">
<img width="878" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/cb8b98ac-15de-433e-851d-8114dd2f9138">

**Installation**
Nach merge des PR wird die nightly action sofort ausgeführt. Es sind keine weiteren Anpassungen am Repository nötig.

**Sonstiges**
Die build.xml hat nun eine "nightly" und "lib" Methode. 
Die Methode nightly erstellt im Ordner ./releases/nightly die folgenden Dateien:
- "jverein.[Version]-nightly.zip" 
- "Source code (zip)"
- "Source code (tar.gz)
Beim Ausführen des "official release" werden analog zur nightly die gleichen Anhänge, wie in der Auflistung, erstellt.

Die Methode lib erstellt die Datei "jverein-lib.jar" im Ordner ./releases.

Da Java 1.7 sehr veraltet ist, habe ich die Java Version in den build.properties auf 11 gesetzt.

Ich weiß es kann einiges am Code optimiert/verändert werden, aber es sollte soweit funktionieren. 