### PR TITLE
Fix: database column length at lastschrift table

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0422.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0422.java
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0422 extends AbstractDDLUpdate
+{
+  public Update0422(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(alterColumn("lastschrift",
+        new Column("email", COLTYPE.VARCHAR, 255, null, false, false)));
+    execute(alterColumn("lastschrift",
+        new Column("iban", COLTYPE.VARCHAR, 34, null, true, false)));
+
+  }
+}


### PR DESCRIPTION
https://github.com/openjverein/jverein/issues/86

Anpassung der DB Spalten "email" und "iban" in der Tabelle "lastschrift" an die selbe Länge wie in den Tabellen "mitglied" und "kursteilnehmer".