### PR TITLE
Maximale Länge des SMTP-Benutzernamens auf 140 erhöht

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -965,7 +965,7 @@ public class EinstellungControl extends AbstractControl
       return smtp_auth_user;
     }
     smtp_auth_user = new TextInput(Einstellungen.getEinstellung()
-        .getSmtpAuthUser(), 50);
+        .getSmtpAuthUser(), 140);
     return smtp_auth_user;
   }
 

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0423.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0423.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0423 extends AbstractDDLUpdate
+{
+  public Update0423(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(alterColumn("einstellung",
+        new Column("smtp_auth_user", COLTYPE.VARCHAR, 140, null, false, false)));
+  }
+}


### PR DESCRIPTION
Wie im [Forum](https://jverein-forum.de/viewtopic.php?p=19628#p19628) gewünscht