### PR TITLE
Fix: Use lowercase file extensions and check

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/FreiesFormularAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FreiesFormularAction.java
@@ -97,17 +97,17 @@ public class FreiesFormularAction implements Action
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("freiesformular", "", Einstellungen
-        .getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        .getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     settings.setAttribute("lastdir", file.getParent());

--- a/src/de/jost_net/JVerein/gui/action/MitgliedVCardDateiAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedVCardDateiAction.java
@@ -75,17 +75,17 @@ public class MitgliedVCardDateiAction implements Action
           fd.setFilterPath(path);
         }
         fd.setFileName(new Dateiname("vCards", "",
-            Einstellungen.getEinstellung().getDateinamenmuster(), "VCF").get());
-        fd.setFilterExtensions(new String[] { "*.VCF" });
+            Einstellungen.getEinstellung().getDateinamenmuster(), "vcf").get());
+        fd.setFilterExtensions(new String[] { "*.vcf" });
 
         String s = fd.open();
         if (s == null || s.length() == 0)
         {
           return;
         }
-        if (!s.endsWith(".VCF"))
+        if (!s.toLowerCase().endsWith(".vcf"))
         {
-          s = s + ".VCF";
+          s = s + ".vcf";
         }
         final File file = new File(s);
         final BufferedWriter w = new BufferedWriter(

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -117,17 +117,17 @@ public class PersonalbogenAction implements Action
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("personalbogen", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     settings.setAttribute("lastdir", file.getParent());

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -249,17 +249,17 @@ public class ArbeitseinsatzControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("arbeitseinsaetze", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     final GenericIterator<ArbeitseinsatzZeile> it = getIterator();
@@ -342,17 +342,17 @@ public class ArbeitseinsatzControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("arbeitseinsaetze", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "CSV").get());
-    fd.setFilterExtensions(new String[] { "*.CSV" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "csv").get());
+    fd.setFilterExtensions(new String[] { "*.csv" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".CSV"))
+    if (!s.toLowerCase().endsWith(".csv"))
     {
-      s = s + ".CSV";
+      s = s + ".csv";
     }
     final File file = new File(s);
     final GenericIterator<ArbeitseinsatzZeile> it = getIterator();

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -343,17 +343,17 @@ public class BuchungsartControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("buchungsarten", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     final DBIterator<Buchungsart> it = Einstellungen.getDBService()

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -3571,7 +3571,7 @@ public class MitgliedControl extends AbstractControl
   {
     FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
     fd.setText("Ausgabedatei wählen.");
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+    fd.setFilterExtensions(new String[] { "*.pdf" });
     String path = settings.getString("lastdir",
         System.getProperty("user.home"));
     if (path != null && path.length() > 0)
@@ -3579,7 +3579,7 @@ public class MitgliedControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("statistik", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
 
     String s = fd.open();
 
@@ -3587,9 +3587,9 @@ public class MitgliedControl extends AbstractControl
     {
       return;
     }
-    if (!s.toUpperCase().endsWith("PDF"))
+    if (!s.toLowerCase().endsWith("pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
 
     final File file = new File(s);

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -327,17 +327,17 @@ public class PreNotificationControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("prenotification", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     settings.setAttribute("lastdir", file.getParent());
@@ -363,7 +363,7 @@ public class PreNotificationControl extends AbstractControl
     it.setOrder("order by name, vorname");
 
     int dateinummer = 0;
-    String postfix = ".PDF";
+    String postfix = ".pdf";
     String prefix = s.substring(0, s.length() - postfix.length());
 
     while (it.hasNext())
@@ -421,8 +421,8 @@ public class PreNotificationControl extends AbstractControl
         fd.setFilterPath(path);
       }
       fd.setFileName(new Dateiname("1ctueberweisung", "",
-          Einstellungen.getEinstellung().getDateinamenmuster(), "XML").get());
-      fd.setFilterExtensions(new String[] { "*.XML" });
+          Einstellungen.getEinstellung().getDateinamenmuster(), "xml").get());
+      fd.setFilterExtensions(new String[] { "*.xml" });
 
       String s = fd.open();
       if (s == null || s.length() == 0)
@@ -430,9 +430,9 @@ public class PreNotificationControl extends AbstractControl
         return;
       }
       settings.setAttribute("ausgabedateiname", s);
-      if (!s.endsWith(".XML"))
+      if (!s.toLowerCase().endsWith(".xml"))
       {
-        s = s + ".XML";
+        s = s + ".xml";
       }
       file = new File(s);
       settings.setAttribute("lastdir", file.getParent());

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -516,7 +516,7 @@ public class SpendenbescheinigungControl extends AbstractControl
           {
             return;
           }
-          if (!s.endsWith(".pdf"))
+          if (!s.toLowerCase().endsWith(".pdf"))
           {
             s = s + ".pdf";
           }
@@ -606,7 +606,7 @@ public class SpendenbescheinigungControl extends AbstractControl
     {
       return;
     }
-    if (!s.endsWith(".pdf"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
       s = s + ".pdf";
     }

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -384,17 +384,17 @@ public class ZusatzbetragControl extends AbstractControl
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("zusatzbetraege", "",
-        Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        Einstellungen.getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     final File file = new File(s);
     final DBIterator<Zusatzbetrag> it = getIterator();

--- a/src/de/jost_net/JVerein/io/AbstractMitgliedskontoDokument.java
+++ b/src/de/jost_net/JVerein/io/AbstractMitgliedskontoDokument.java
@@ -69,11 +69,11 @@ public abstract class AbstractMitgliedskontoDokument
     switch ((Ausgabeart) control.getAusgabeart().getValue())
     {
       case DRUCK:
-        file = getDateiAuswahl("PDF");
+        file = getDateiAuswahl("pdf");
         formularaufbereitung = new FormularAufbereitung(file);
         break;
       case EMAIL:
-        file = getDateiAuswahl("ZIP");
+        file = getDateiAuswahl("zip");
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
     }
@@ -93,7 +93,7 @@ public abstract class AbstractMitgliedskontoDokument
           formularaufbereitung = new FormularAufbereitung(f);
           aufbereitenFormular(mk, formularaufbereitung, formular);
           formularaufbereitung.closeFormular();
-          zos.putNextEntry(new ZipEntry(getDateiname(mk) + ".PDF"));
+          zos.putNextEntry(new ZipEntry(getDateiname(mk) + ".pdf"));
           FileInputStream in = new FileInputStream(f);
           // buffer size
           byte[] b = new byte[1024];
@@ -139,7 +139,7 @@ public abstract class AbstractMitgliedskontoDokument
     {
       return null;
     }
-    if (!s.endsWith("." + extension))
+    if (!s.toLowerCase().endsWith("." + extension))
     {
       s = s + "." + extension;
     }

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -86,17 +86,17 @@ public class Kontoauszug
       fd.setFilterPath(path);
     }
     fd.setFileName(new Dateiname("kontoauszug", "", Einstellungen
-        .getEinstellung().getDateinamenmuster(), "PDF").get());
-    fd.setFilterExtensions(new String[] { "*.PDF" });
+        .getEinstellung().getDateinamenmuster(), "pdf").get());
+    fd.setFilterExtensions(new String[] { "*.pdf" });
 
     String s = fd.open();
     if (s == null || s.length() == 0)
     {
       return;
     }
-    if (!s.endsWith(".PDF"))
+    if (!s.toLowerCase().endsWith(".pdf"))
     {
-      s = s + ".PDF";
+      s = s + ".pdf";
     }
     file = new File(s);
     settings.setAttribute("lastdir", file.getParent());


### PR DESCRIPTION
Die Prüfung auf Dateiendungen hat nicht immer funktioniert. Mit dieser Anpassung ist die Groß- und Kleinschreibung der Dateiendungen egal. Weiterhin werden die Ausgabe-Dateiendungen nun kleingeschrieben.