### PR TITLE
Zeichenkodierungsfehler neues Konto erstellen

### DIFF
--- a/src/de/jost_net/JVerein/gui/input/KontoInput.java
+++ b/src/de/jost_net/JVerein/gui/input/KontoInput.java
@@ -54,7 +54,7 @@ public class KontoInput extends SelectInput
   {
     super(init(), konto);
     setName(i18n.tr("Konto"));
-    setPleaseChoose(i18n.tr("Bitte w√§hlen..."));
+    setPleaseChoose(i18n.tr("Bitte w‰hlen..."));
   }
 
   /**


### PR DESCRIPTION
Zeichenkodierungsfehler im Menüpunkt Buchführung-->Konten-->Neu-->Hibiscus-Konto korrigiert.