### PR TITLE
Einstellungen für IBAN, BIC und Gläubiger-ID

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -456,7 +456,6 @@ public class EinstellungControl extends AbstractControl
       return bic;
     }
     bic = new BICInput(Einstellungen.getEinstellung().getBic());
-    bic.setMandatory(true);
     return bic;
   }
 
@@ -467,7 +466,6 @@ public class EinstellungControl extends AbstractControl
       return iban;
     }
     iban = new IBANInput(Einstellungen.getEinstellung().getIban(), bic);
-    iban.setMandatory(true);
     return iban;
   }
 
@@ -479,7 +477,6 @@ public class EinstellungControl extends AbstractControl
     }
     glaeubigerid = new TextInput(Einstellungen.getEinstellung()
         .getGlaeubigerID(), 35);
-    glaeubigerid.setMandatory(true);
     return glaeubigerid;
   }
 

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -114,31 +114,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
       {
         throw new ApplicationException("Bitte Namen eingeben");
       }
-      if (getIban() == null || getIban().length() == 0)
-      {
-        throw new ApplicationException("Bitte IBAN eingeben");
-      }
-      if (getBic() == null || getBic().length() == 0)
-      {
-        throw new ApplicationException("Bitte BIC eingeben");
-      }
-
-      try
-      {
-        new IBAN(getIban());
-      }
-      catch (SEPAException e1)
-      {
-        throw new ApplicationException(e1.getMessage());
-      }
-      try
-      {
-        new BIC(getBic());
-      }
-      catch (SEPAException e1)
-      {
-        throw new ApplicationException(e1.getMessage());
-      }
+      
       try
       {
         new AltersgruppenParser(getAltersgruppen());


### PR DESCRIPTION
Bisher waren IBAN und BIC Pflichtfelder. Wenn allerdings ein Verein nur die Mitgliederverwaltung von OpenJVerein verwenden möchte, so gibt es wenig Sinn eine IBAN und BIC hinterlegen zu müssen.

Die Gläubiger-ID war in der Benutzeroberfläche als Pflichtfeld gekennzeichnet. Eine Überprüfung fand aber im Hintergrund nicht wirklich statt. Das Feld Gläubiger-ID wird als normales Eingabefeld gekennzeichnet.

Wenn man sich in den Einstellungen in einem anderen Menüpunkt als Allgemein befand, bspw. unter Anzeige, so wurde bei einem klick auf Speichern immer überprüft ob die Felder IBAN und BIC auch ausgefüllt sind. Durch das entfernen der Überprüfung treten die irreführenden Meldungen nicht mehr auf.