### PR TITLE
Do not run nightly build on closed pull requests

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -9,9 +9,6 @@ on:
       - master
     tags-ignore:
       - '**'
-  pull_request:
-    types:
-      - closed
 
 jobs:
   build:


### PR DESCRIPTION
Nightly build will run if pull requests are merged to master branch.

Es bleibt alles beim Alten, nur die fehlgeschlagenen Actions bleiben aus:
![image](https://github.com/openjverein/jverein/assets/63780296/79dc9fa1-a47c-4eb7-b12a-02839f6dbe26)

![image](https://github.com/openjverein/jverein/assets/63780296/184412e1-7494-4725-9451-865874ac5660)
