### PR TITLE
Zweiter Aufruf des KontoAuswahlDialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -294,7 +294,7 @@ public class BuchungsControl extends AbstractControl
     }
     String kontoid = getVorauswahlKontoId();
     konto = new KontoauswahlInput(getBuchung().getKonto())
-        .getKontoAuswahl(false, kontoid, false, false);
+        .getKontoAuswahl(false, kontoid, false, true);
     if (withFocus)
     {
       konto.focus();


### PR DESCRIPTION
Der KontoAuswahlDialog wird im Buchung bearbeiten Dialog mit einer anderen Methode aufgerufen. Bei diesem Aufruf soll auch der Default für nurAktuelleKonten auf true stehen.