### PR TITLE
Filter Buchungsarten ohne Buchungen

### DIFF
--- a/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
@@ -85,6 +85,7 @@ public class BuchungAuswertungPDF
         createTableHeaderSumme(reporter);
       }
 
+      int anzahlBuchungsarten = 0;
       for (Buchungsart bua : buchungsarten)
       {
         if (einzel)
@@ -92,9 +93,13 @@ public class BuchungAuswertungPDF
         	query.getOrder("ORDER_DATUM_ID");
         }
         List<Buchung> liste = getBuchungenEinerBuchungsart(query.get(), bua);
-        createTableContent(reporter, bua, liste, einzel);
+        if (liste.size() >0)
+        {
+          createTableContent(reporter, bua, liste, einzel);
+          anzahlBuchungsarten++;
+        }
       }
-      if (buchungsarten.size() > 1)
+      if (anzahlBuchungsarten > 1)
       {
         if (einzel)
         {


### PR DESCRIPTION
Blendet Buchungsarten in den Reports Buchungsliste und Summenliste aus die keine Buchungen haben.

Falls das nicht allgemein gewünscht ist, könnte ich auch einen Schalter in den Einstellungen implementieren. Aber ich denke, das ist nicht nötig. Auch der View Buchungsklassen-Saldo zeigt keine Buchungsarten ohne Buchung an. 