### PR TITLE
Fehler in Mitgliedskonto Auswahl Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -22,6 +22,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
@@ -58,6 +60,8 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
   private TablePart mitgliedlist = null;
 
   private Buchung buchung;
+  
+  private boolean abort = false;
 
   public MitgliedskontoAuswahlDialog(Buchung buchung)
   {
@@ -177,6 +181,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
         close();
       }
     }, null, false, "undo.png");
+    
     b.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIEDSKONTO_AUSWAHL, false, "question-circle.png");
 
@@ -186,9 +191,18 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
+        abort = true;
         close();
       }
     }, null, false, "stop-circle.png");
+    
+    getShell().addListener(SWT.Close,new Listener()
+    {
+      public void handleEvent(Event event)
+      {
+        abort = true;
+      }
+    });
     b.paint(parent);
   }
 
@@ -213,5 +227,10 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
   public void setText(String text)
   {
     this.text = text;
+  }
+  
+  public boolean getAbort()
+  {
+    return abort;
   }
 }


### PR DESCRIPTION

Der Request behebt einen Fehler und weiter Unstimmigkeiten
Fehler: 
- Ein Abbruch im MitgliedKontoAuswahl Dialog führt zum Löschen einer Zuordnung.

Unstimmigkeiten:
- Abbruch über Abbruch Button und Abbruch Icon rechts oben führt zur Meldung: "Mitgliedskonto zugeordnet". Das ist aber nicht der Fall, es wird nichts zugeordnet. Wegen des Bugs sogar gelöscht.
- Abbruch über ESC führt zur Meldung: "Fehler bei der Zuordnung des Mitgliedskontos". Es ist aber kein Fehler passiert.
Wie im letzten Request implementiert wurde behandle ich einen Abbruch explizit und gebe keine Meldungen mehr bei Abbruch via Button, ESC und Abbruch Icon aus.