### PR TITLE
Verbesserung ProjektAuswahlDialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungProjektZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungProjektZuordnungAction.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.rmi.Projekt;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -71,25 +72,31 @@ public class BuchungProjektZuordnungAction implements Action
             AbstractDialog.POSITION_CENTER, b);
         Projekt open = pad.open();
 
-        if (open == null)
+        if (!pad.getAbort())
         {
-          GUI.getStatusBar().setErrorText("Kein Projekt ausgewählt");
-          return;
+          if (open == null)
+          {
+            GUI.getStatusBar().setErrorText("Kein Projekt ausgewählt");
+            return;
+          }
+  
+          for (Buchung buchung : b)
+          {
+            buchung.setProjekt(open);
+            buchung.store();
+          }
+          control.getBuchungsList();
+          GUI.getStatusBar().setSuccessText("Projekt zugeordnet");
         }
-
-        for (Buchung buchung : b)
-        {
-          buchung.setProjekt(open);
-          buchung.store();
-        }
-        control.getBuchungsList();
-        GUI.getStatusBar().setSuccessText("Projekt zugeordnet");
       }
       catch (Exception e)
       {
-        Logger.error("Fehler", e);
-        GUI.getStatusBar().setErrorText(
-            "Fehler bei der Zuordnung des Projektes");
+        if (!(e instanceof OperationCanceledException))
+        {
+          Logger.error("Fehler", e);
+          GUI.getStatusBar().setErrorText(
+              "Fehler bei der Zuordnung des Projektes");
+        }
         return;
       }
     }

--- a/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.dialogs;
 
 import java.rmi.RemoteException;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
@@ -32,7 +33,6 @@ import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
-import de.willuhn.jameica.system.OperationCanceledException;
 
 /**
  * Ein Dialog, ueber den man ein Projekt auswählen kann.
@@ -43,6 +43,8 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
   private Projekt selected = null;
 
   private SelectInput projekte = null;
+  
+  private Boolean abort = false;
 
   Buchung[] buchungen = null;
 
@@ -51,7 +53,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
     super(position);
     this.buchungen = buchungen;
 
-    setTitle("Projekt auswâ€hlen");
+    setTitle("Projekt auswählen");
     setSize(450, 150);
   }
 
@@ -61,7 +63,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
     LabelGroup options = new LabelGroup(parent, "Projekte");
     options.addInput(this.getProjekte());
     ButtonArea b = new ButtonArea();
-    b.addButton("weiter", new Action()
+    b.addButton("übernehmen", new Action()
     {
 
       @Override
@@ -70,14 +72,22 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
         selected = (Projekt) projekte.getValue();
         close();
       }
-    });
+    }, null, false, "check.png");
     b.addButton("abbrechen", new Action()
     {
 
       @Override
       public void handleAction(Object context)
       {
-        throw new OperationCanceledException();
+        abort = true;
+        close();
+      }
+    }, null, false, "stop-circle.png");
+    getShell().addListener(SWT.Close,new Listener()
+    {
+      public void handleEvent(Event event)
+      {
+        abort = true;
       }
     });
     b.paint(parent);
@@ -87,6 +97,11 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
   protected Projekt getData() throws Exception
   {
     return this.selected;
+  }
+  
+  public boolean getAbort()
+  {
+    return abort;
   }
 
   private SelectInput getProjekte() throws RemoteException


### PR DESCRIPTION
Ändere Button Text "weiter" zu "übernehmen". Weiter suggeriert das noch was folgt. Übernehmen ist wie bei anderen Dialogen.
Korrektur des falschen ä in "auswählen"
Icons für die Buttons hinzugefügt, analog zu den anderen Dialogen.
Korrektes Handling von Abbruch über Button, Icon und ESC ohne Ausgabe einer Meldung.
ESC und Abbruch Button meldeten "Fehler bei der Zuordnung des Projektes".
Abbruch Icon rechts oben meldete "Kein Projekt ausgewählt".