### PR TITLE
Schöne Icons für KontoAuswahlDialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
@@ -148,7 +148,7 @@ public class BuchungenMitgliedskontenZuordnungDialog extends AbstractDialog<Obje
       {
         throw new OperationCanceledException();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     group.addButtonArea(buttons);
     getShell()
         .setMinimumSize(getShell().computeSize(WINDOW_WIDTH, SWT.DEFAULT));

--- a/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
@@ -121,7 +121,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
     konten.paint(parent);
 
     ButtonArea b = new ButtonArea();
-    b.addButton(i18n.tr("übernehmen"), new Action()
+    b.addButton(i18n.tr("Übernehmen"), new Action()
     {
 
       @Override
@@ -134,10 +134,10 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
         choosen = (Konto) o;
         close();
       }
-    }, null, false, "check.png");
+    }, null, false, "ok.png");
     if (keinkonto)
     {
-      b.addButton("alle Konten", new Action()
+      b.addButton("Alle Konten", new Action()
       {
 
         @Override
@@ -148,7 +148,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
         }
       }, null, false, "list.png");
     }
-    b.addButton("abbrechen", new Action()
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -156,7 +156,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
       {
         throw new OperationCanceledException();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
@@ -134,10 +134,10 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
         choosen = (Konto) o;
         close();
       }
-    });
+    }, null, false, "check.png");
     if (keinkonto)
     {
-      b.addButton("kein Konto", new Action()
+      b.addButton("alle Konten", new Action()
       {
 
         @Override
@@ -146,7 +146,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
           choosen = null;
           close();
         }
-      });
+      }, null, false, "list.png");
     }
     b.addButton("abbrechen", new Action()
     {
@@ -156,7 +156,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "stop-circle.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/KontoauszugZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/KontoauszugZuordnungDialog.java
@@ -76,7 +76,7 @@ public class KontoauszugZuordnungDialog extends AbstractDialog<Object>
     group.addLabelPair("", getStatus());
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton("übernehmen", new Action()
+    buttons.addButton("Übernehmen", new Action()
     {
 
       @Override
@@ -101,8 +101,8 @@ public class KontoauszugZuordnungDialog extends AbstractDialog<Object>
         ueberschr = (Boolean) getUeberschreiben().getValue();
         close();
       }
-    }, null, true, "check.png");
-    buttons.addButton("entfernen", new Action()
+    }, null, true, "ok.png");
+    buttons.addButton("Entfernen", new Action()
     {
 
       @Override
@@ -114,7 +114,7 @@ public class KontoauszugZuordnungDialog extends AbstractDialog<Object>
         close();
       }
     }, null, false, "undo.png");
-    buttons.addButton("abbrechen", new Action()
+    buttons.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -123,7 +123,7 @@ public class KontoauszugZuordnungDialog extends AbstractDialog<Object>
         abort = true;
         close();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     getShell().addListener(SWT.Close,new Listener()
     {
       public void handleEvent(Event event)

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -144,7 +144,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
 
     ButtonArea b = new ButtonArea();
 
-    b.addButton("übernehmen", new Action()
+    b.addButton("Übernehmen", new Action()
     {
 
       @Override
@@ -169,9 +169,9 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
         }
         return;
       }
-    }, null, false, "check.png");
+    }, null, false, "ok.png");
 
-    b.addButton("entfernen", new Action()
+    b.addButton("Entfernen", new Action()
     {
 
       @Override
@@ -185,7 +185,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     b.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIEDSKONTO_AUSWAHL, false, "question-circle.png");
 
-    b.addButton("abbrechen", new Action()
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -194,7 +194,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
         abort = true;
         close();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     
     getShell().addListener(SWT.Close,new Listener()
     {

--- a/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
@@ -75,7 +75,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
     group.addLabelPair("", getStatus());
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton("übernehmen", new Action()
+    buttons.addButton("Übernehmen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -90,8 +90,8 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
         ueberschr = (boolean) getUeberschreiben().getValue();
         close();
       }
-    }, null, false, "check.png");
-    buttons.addButton("entfernen", new Action()
+    }, null, false, "ok.png");
+    buttons.addButton("Entfernen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -100,7 +100,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
         close();
       }
     }, null, false, "undo.png");
-    buttons.addButton("abbrechen", new Action()
+    buttons.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -109,7 +109,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
         abort = true;
         close();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     getShell().addListener(SWT.Close,new Listener()
     {
       public void handleEvent(Event event)


### PR DESCRIPTION
Habe auch "keine Konten" in "alle Konten" umbenannt. Man wählt ja mit dem Button die Anzeige der Buchungen aller Konten aus.
![Screenshot_20240121_170017](https://github.com/openjverein/jverein/assets/126261667/562cdaf5-5f89-49b5-9e41-50ed6b18f539)
