### PR TITLE
Button Korrektur für alle Dialoge

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungVorschauDialog.java
@@ -117,7 +117,7 @@ public class BuchungenMitgliedskontenZuordnungVorschauDialog extends AbstractDia
       {
         close();
       }
-    }, null, false, "window-close.png");
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
@@ -17,6 +17,7 @@
 
 package de.jost_net.JVerein.gui.dialogs;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
@@ -60,7 +61,7 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
     super(position);
 
     setTitle("Buchungsjournal-Sortierung");
-    setSize(300, 200);
+    setSize(300, 140);
   }
 
   @Override
@@ -69,22 +70,22 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
     LabelGroup options = new LabelGroup(parent, "Ihre Auswahl");
     options.addInput(this.getSortierung());
     ButtonArea b = new ButtonArea();
-    b.addButton("weiter", new Action()
+    b.addButton("Weiter", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         close();
       }
-    });
-    b.addButton("abbrechen", new Action()
+    }, null, false, "go-next.png");
+    b.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/DokumentDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DokumentDialog.java
@@ -53,7 +53,7 @@ public class DokumentDialog extends AbstractDialog<AbstractDokument>
   {
     getPart().paint(parent);
     ButtonArea b = new ButtonArea();
-    b.addButton("speichern", new Action()
+    b.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -70,15 +70,15 @@ public class DokumentDialog extends AbstractDialog<AbstractDokument>
         }
         close();
       }
-    });
-    b.addButton("abbrechen", new Action()
+    }, null, true, "ok.png");
+    b.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
@@ -120,7 +120,7 @@ public class EigenschaftenAuswahlDialog
         }
         close();
       }
-    });
+    }, null, true, "ok.png");
     buttons.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/ExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ExportDialog.java
@@ -135,7 +135,7 @@ public class ExportDialog extends AbstractDialog<Object>
       {
         close();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     group.addButtonArea(buttons);
 
     getShell()

--- a/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
@@ -82,7 +82,7 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
     lgBank.addLabelPair("BIC", control.getBic());
     // lgBank.addLabelPair("Kontoinhaber", control.getKontoinhaber());
     ButtonArea b = new ButtonArea();
-    b.addButton("weiter", new Action()
+    b.addButton("Weiter", new Action()
     {
 
       @Override
@@ -130,8 +130,8 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
           return;
         }
       }
-    });
-    b.addButton("abbrechen", new Action()
+    }, null, true, "go-next.png");
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -139,7 +139,7 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/ImportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ImportDialog.java
@@ -138,7 +138,7 @@ public class ImportDialog extends AbstractDialog<Object>
       {
         throw new OperationCanceledException();
       }
-    }, null, false, "stop-circle.png");
+    }, null, false, "process-stop.png");
     group.addButtonArea(buttons);
     getShell()
         .setMinimumSize(getShell().computeSize(WINDOW_WIDTH, SWT.DEFAULT));

--- a/src/de/jost_net/JVerein/gui/dialogs/KontoauszugZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/KontoauszugZuordnungDialog.java
@@ -113,7 +113,7 @@ public class KontoauszugZuordnungDialog extends AbstractDialog<Object>
         ueberschr = true;
         close();
       }
-    }, null, false, "undo.png");
+    }, null, false, "user-trash-full.png");
     buttons.addButton("Abbrechen", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -49,7 +49,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
     super(position);
     this.control = control;
     setTitle("Mail-Empfänger");
-    setSize(1000, 450);
+    setSize(650, 450);
   }
 
   @Override
@@ -92,8 +92,46 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         }
       }
     });
+    
+    b.addButton("Alle", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        try
+        {
+          for (Object o : control.getMitgliedMitMail().getItems(false))
+          {
+            control.getMitgliedMitMail().setChecked(o, true);
+          }
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+      }
+    });
 
-    b.addButton("aktive Mitglieder", new Action()
+    b.addButton("Keinen", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        try
+        {
+          for (Object o : control.getMitgliedMitMail().getItems(false))
+          {
+            control.getMitgliedMitMail().setChecked(o, false);
+          }
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+      }
+    });
+    
+    b.addButton("Aktive Mitglieder", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -118,7 +156,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       }
     });
 
-    b.addButton("inaktive Mitglieder", new Action()
+    b.addButton("Inaktive Mitglieder", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -143,7 +181,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       }
     });
 
-    b.addButton("alle Adressen", new Action()
+    b.addButton("Alle Adressen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -166,7 +204,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       }
     });
 
-    b.addButton("aktive Mitglieder und Adressen", new Action()
+    b.addButton("Aktive Mitglieder und Adressen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -195,44 +233,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
     b.paint(parent);
 
     ButtonArea c = new ButtonArea();
-    c.addButton("alle", new Action()
-    {
-      @Override
-      public void handleAction(Object context)
-      {
-        try
-        {
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            control.getMitgliedMitMail().setChecked(o, true);
-          }
-        }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
-      }
-    });
-
-    c.addButton("keinen", new Action()
-    {
-      @Override
-      public void handleAction(Object context)
-      {
-        try
-        {
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            control.getMitgliedMitMail().setChecked(o, false);
-          }
-        }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
-      }
-    });
-    c.addButton("übernehmen", new Action()
+    c.addButton("Übernehmen", new Action()
     {
 
       @Override
@@ -255,16 +256,16 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         }
         close();
       }
-    });
+    }, null, true, "ok.png");
 
-    c.addButton("abbrechen", new Action()
+    c.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
 
     c.paint(parent);
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -53,7 +53,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
     control.getMailVorlageTable().paint(parent);
 
     ButtonArea b = new ButtonArea();
-    b.addButton("verwenden", new Action()
+    b.addButton("Verwenden", new Action()
     {
 
       @Override
@@ -69,8 +69,8 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
         }
         close();
       }
-    });
-    b.addButton("ohne Mail-Vorlage", new Action()
+    }, null, true, "ok.png");
+    b.addButton("Ohne Mail-Vorlage", new Action()
     {
 
       @Override
@@ -78,7 +78,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
       {
         close();
       }
-    });
+    }, null, true, "go-next.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorschauDialog.java
@@ -157,7 +157,7 @@ public class MailVorschauDialog extends AbstractDialog<Object>
       {
         close();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedArbeitseinsatzZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedArbeitseinsatzZuordnungDialog.java
@@ -59,7 +59,7 @@ public class MitgliedArbeitseinsatzZuordnungDialog extends
     part.paint(parent);
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton("zuordnen", new Action()
+    buttons.addButton("Zuordnen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -78,15 +78,15 @@ public class MitgliedArbeitseinsatzZuordnungDialog extends
         }
         close();
       }
-    }, null, true);
-    buttons.addButton("abbrechen", new Action()
+    }, null, true, "ok.png");
+    buttons.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     buttons.paint(parent);
     getShell().setMinimumSize(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT));
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
@@ -67,7 +67,11 @@ public class MitgliedZusatzbetragZuordnungDialog extends AbstractDialog<String>
     part.paint(parent);
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton("zuordnen", new Action()
+    
+    buttons.addButton("Vorlagen", new ZusatzbetragVorlageAuswahlAction(part)
+        , null, false, "text-x-generic.png");
+    
+    buttons.addButton("Zuordnen", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -117,17 +121,16 @@ public class MitgliedZusatzbetragZuordnungDialog extends AbstractDialog<String>
 
         close();
       }
-    }, null, true);
-    buttons.addButton("Vorlagen", new ZusatzbetragVorlageAuswahlAction(part));
+    }, null, true, "ok.png");
 
-    buttons.addButton("abbrechen", new Action()
+    buttons.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     buttons.paint(parent);
     getShell().setMinimumSize(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT));
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -143,6 +143,9 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     mitgliedlist.paint(tabSollIst.getComposite());
 
     ButtonArea b = new ButtonArea();
+    
+    b.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.MITGLIEDSKONTO_AUSWAHL, false, "question-circle.png");
 
     b.addButton("Übernehmen", new Action()
     {
@@ -180,10 +183,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
         choosen = null;
         close();
       }
-    }, null, false, "undo.png");
-    
-    b.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.MITGLIEDSKONTO_AUSWAHL, false, "question-circle.png");
+    }, null, false, "user-trash-full.png");
 
     b.addButton("Abbrechen", new Action()
     {

--- a/src/de/jost_net/JVerein/gui/dialogs/PersonenartDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/PersonenartDialog.java
@@ -51,7 +51,7 @@ public class PersonenartDialog extends AbstractDialog<String>
     LabelGroup options = new LabelGroup(parent, "Personenart");
     options.addInput(this.getPersonenartInput());
     ButtonArea b = new ButtonArea();
-    b.addButton("weiter", new Action()
+    b.addButton("Weiter", new Action()
     {
 
       @Override
@@ -61,8 +61,8 @@ public class PersonenartDialog extends AbstractDialog<String>
         selected = s.substring(0, 1);
         close();
       }
-    });
-    b.addButton("abbrechen", new Action()
+    }, null, false, "go-next.png");
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -70,7 +70,7 @@ public class PersonenartDialog extends AbstractDialog<String>
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ProjektAuswahlDialog.java
@@ -99,7 +99,7 @@ public class ProjektAuswahlDialog extends AbstractDialog<Projekt>
         selected = null;
         close();
       }
-    }, null, false, "undo.png");
+    }, null, false, "user-trash-full.png");
     buttons.addButton("Abbrechen", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/dialogs/QRCodeImageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/QRCodeImageDialog.java
@@ -47,14 +47,14 @@ public class QRCodeImageDialog extends AbstractDialog<Object>
   {
     image.paint(parent);
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton("schlieﬂen", new Action()
+    buttons.addButton("Schlieﬂen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         close();
       }
-    });
+    }, null, true, "process-stop.png");
     buttons.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
@@ -63,7 +63,7 @@ public class SammelueberweisungAuswahlDialog
   {
     this.getSammelueberweisungen().paint(parent);
     ButtonArea b = new ButtonArea();
-    b.addButton("abbrechen", new Action()
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -71,7 +71,7 @@ public class SammelueberweisungAuswahlDialog
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/ShowVariablesDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ShowVariablesDialog.java
@@ -98,7 +98,7 @@ public class ShowVariablesDialog extends AbstractDialog<Object>
       {
         close();
       }
-    });
+    }, null, true, "ok.png");
     buttons.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
@@ -58,14 +58,14 @@ public class ZusatzbetragVorlageDialog
   {
     this.getZusatzbetragVorlagen().paint(parent);
     ButtonArea b = new ButtonArea();
-    b.addButton("abbrechen", new Action()
+    b.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         throw new OperationCanceledException();
       }
-    });
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 


### PR DESCRIPTION
Buttons für alle Dialoge unter de.jost_net.JVerein.gui.dialogs angepasst:
- Großschrift
- Icons für Ok, Abbrechen etc. eingefügt
- Entfernen/Löschen Icon durch user-trash-full.png ersetzt. Dieses wird auch in Hibiscus dafür verwendet.
Allerdings finde ich dieses Icon zu hübsch. Löschen ist eine gefährliche Aktion. Da sollte das Icon eine Warnfarbe wie z.B. rot haben. Eclipse benutzt ein rotes X. Aber neben dem Abbrechen Button schaut es dann sehr ähnlich zu diesem Icon aus. Evtl. sollte man den Müll im Trash rot einfärben.

Der BuchungsartZuordnungDialog ist nicht dabei weil er in dem Pull Request #104 entsprechend angepasst wurde.