### PR TITLE
Text und Icon Korrektur für alle Menü Items

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufBuchungenMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufBuchungenMenu.java
@@ -37,6 +37,6 @@ public class AbrechnungslaufBuchungenMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Sollbuchung bearbeiten",
         new PreNotificationAction(), "file.png"));
     addItem(new CheckedContextMenuItem("Sollbuchung löschen",
-        new AbrechnungslaufDeleteAction(), "trash-alt.png"));
+        new AbrechnungslaufDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
@@ -45,14 +45,14 @@ public class AbrechnungslaufMenu extends ContextMenu
         "edit.png"));
     addItem(new AbgeschlossenDisabledItem("Pre-Notification",
         new PreNotificationAction(), "file.png"));
-    addItem(new AbgeschlossenDisabledItem("löschen...",
-        new AbrechnungslaufDeleteAction(), "trash-alt.png"));
+    addItem(new AbgeschlossenDisabledItem("Löschen...",
+        new AbrechnungslaufDeleteAction(), "user-trash-full.png"));
     try
     {
       if (Einstellungen.getEinstellung().getAbrlAbschliessen())
       {
         addItem(ContextMenuItem.SEPARATOR);
-        addItem(new AbgeschlossenDisabledItem("abschließen...",
+        addItem(new AbgeschlossenDisabledItem("Abschließen...",
             new AbrechnungslaufAbschliessenAction(), "lock.png"));
       }
     }

--- a/src/de/jost_net/JVerein/gui/menu/AdresstypMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/AdresstypMenu.java
@@ -31,7 +31,7 @@ public class AdresstypMenu extends ContextMenu
    */
   public AdresstypMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new AdresstypDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new AdresstypDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/AnfangsbestandMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/AnfangsbestandMenu.java
@@ -31,7 +31,7 @@ public class AnfangsbestandMenu extends ContextMenu
    */
   public AnfangsbestandMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new AnfangsbestandDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new AnfangsbestandDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/ArbeitseinsatzMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ArbeitseinsatzMenu.java
@@ -31,7 +31,7 @@ public class ArbeitseinsatzMenu extends ContextMenu
    */
   public ArbeitseinsatzMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new ArbeitseinsatzDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new ArbeitseinsatzDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/BeitragsgruppeMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BeitragsgruppeMenu.java
@@ -31,7 +31,7 @@ public class BeitragsgruppeMenu extends ContextMenu
    */
   public BeitragsgruppeMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new BeitragsgruppeDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new BeitragsgruppeDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -47,24 +47,24 @@ public class BuchungMenu extends ContextMenu
 
   public BuchungMenu(BuchungsControl control)
   {
-    addItem(new ContextMenuItem("neue Buchung", new BuchungNeuAction(),
+    addItem(new ContextMenuItem("Neue Buchung", new BuchungNeuAction(),
         "file.png"));
-    addItem(new CheckedSingleContextMenuItem("bearbeiten",
+    addItem(new CheckedSingleContextMenuItem("Bearbeiten",
         new BuchungAction(false), "edit.png"));
-    addItem(new SingleBuchungItem("duplizieren", new BuchungDuplizierenAction(),
+    addItem(new SingleBuchungItem("Duplizieren", new BuchungDuplizierenAction(),
         "copy.png"));
     addItem(new SingleBuchungItem("Splitbuchung", new SplitBuchungAction(),
         "edit.png"));
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
-        new BuchungBuchungsartZuordnungAction(control), "exchange-alt.png"));
+        new BuchungBuchungsartZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Mitgliedskonto zuordnen",
-        new BuchungMitgliedskontoZuordnungAction(control), "exchange-alt.png"));
+        new BuchungMitgliedskontoZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Projekt zuordnen",
-        new BuchungProjektZuordnungAction(control), "exchange-alt.png"));
+        new BuchungProjektZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Kontoauszug zuordnen",
-        new BuchungKontoauszugZuordnungAction(control), "exchange-alt.png"));
-    addItem(new BuchungItem("löschen...", new BuchungDeleteAction(false),
-        "trash-alt.png"));
+        new BuchungKontoauszugZuordnungAction(control), "view-refresh.png"));
+    addItem(new BuchungItem("Löschen...", new BuchungDeleteAction(false),
+        "user-trash-full.png"));
   }
 
   private static class SingleBuchungItem extends CheckedSingleContextMenuItem

--- a/src/de/jost_net/JVerein/gui/menu/BuchungsartMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungsartMenu.java
@@ -31,7 +31,7 @@ public class BuchungsartMenu extends ContextMenu
    */
   public BuchungsartMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new BuchungsartDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new BuchungsartDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/BuchungsklasseMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungsklasseMenu.java
@@ -31,7 +31,7 @@ public class BuchungsklasseMenu extends ContextMenu
    */
   public BuchungsklasseMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new BuchungsklasseDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new BuchungsklasseDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/DokumentMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/DokumentMenu.java
@@ -32,15 +32,15 @@ public class DokumentMenu extends ContextMenu
   public DokumentMenu(boolean enabled)
   {
     new ContextMenuItem();
-    addItem(new CheckedContextMenuItem("anzeigen", new DokumentShowAction(),
+    addItem(new CheckedContextMenuItem("Anzeigen", new DokumentShowAction(),
         "eye.png"));
     addItem(new CheckedContextMenuItem("Infos bearbeiten",
         new DokumentInfoBearbeitenAction(), "edit.png"));
     if (enabled)
     {
       addItem(ContextMenuItem.SEPARATOR);
-      addItem(new CheckedContextMenuItem("löschen...",
-          new DokumentDeleteAction(), "trash-alt.png"));
+      addItem(new CheckedContextMenuItem("Löschen...",
+          new DokumentDeleteAction(), "user-trash-full.png"));
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/EigenschaftGruppeMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/EigenschaftGruppeMenu.java
@@ -33,9 +33,9 @@ public class EigenschaftGruppeMenu extends ContextMenu
    */
   public EigenschaftGruppeMenu()
   {
-    addItem(new ContextMenuItem("neu", new EigenschaftGruppeDetailAction(true),
+    addItem(new ContextMenuItem("Neu", new EigenschaftGruppeDetailAction(true),
         "file.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new EigenschaftGruppeDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new EigenschaftGruppeDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/EigenschaftMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/EigenschaftMenu.java
@@ -33,9 +33,9 @@ public class EigenschaftMenu extends ContextMenu
    */
   public EigenschaftMenu()
   {
-    addItem(new ContextMenuItem("neu", new EigenschaftDetailAction(true),
+    addItem(new ContextMenuItem("Neu", new EigenschaftDetailAction(true),
         "file.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new EigenschaftDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new EigenschaftDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/FamilienbeitragMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FamilienbeitragMenu.java
@@ -31,7 +31,7 @@ public class FamilienbeitragMenu extends ContextMenu
   public FamilienbeitragMenu()
   {
     addItem(new AngehoerigerItem("Aus Familienverband entfernen",
-        new FamilienmitgliedEntfernenAction(), "trash-alt.png"));
+        new FamilienmitgliedEntfernenAction(), "user-trash-full.png"));
   }
 
   private static class AngehoerigerItem extends CheckedContextMenuItem

--- a/src/de/jost_net/JVerein/gui/menu/FelddefinitionMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FelddefinitionMenu.java
@@ -31,7 +31,7 @@ public class FelddefinitionMenu extends ContextMenu
    */
   public FelddefinitionMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new FelddefinitionDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new FelddefinitionDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/FormularMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FormularMenu.java
@@ -39,12 +39,12 @@ public class FormularMenu extends ContextMenu
   {
     addItem(new CheckedContextMenuItem("Formularfelder",
         new FormularfelderListeAction(), "file-invoice.png"));
-    addItem(new CheckedContextMenuItem("anzeigen", new FormularAnzeigeAction(),
+    addItem(new CheckedContextMenuItem("Anzeigen", new FormularAnzeigeAction(),
         "edit.png"));
-    addItem(new CheckedSingleContextMenuItem("duplizieren",
+    addItem(new CheckedSingleContextMenuItem("Duplizieren",
         new FormularDuplizierenAction(control), "copy.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem("löschen...", new FormularDeleteAction(),
-        "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...", new FormularDeleteAction(),
+        "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/FormularfeldMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FormularfeldMenu.java
@@ -31,7 +31,7 @@ public class FormularfeldMenu extends ContextMenu
    */
   public FormularfeldMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new FormularfeldDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new FormularfeldDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/InventarLagerortMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/InventarLagerortMenu.java
@@ -31,7 +31,7 @@ public class InventarLagerortMenu extends ContextMenu
    */
   public InventarLagerortMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new InventarLagerortDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new InventarLagerortDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/JahresabschlussMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/JahresabschlussMenu.java
@@ -31,7 +31,7 @@ public class JahresabschlussMenu extends ContextMenu
    */
   public JahresabschlussMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new JahresabschlussDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new JahresabschlussDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/KontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/KontoMenu.java
@@ -34,7 +34,7 @@ public class KontoMenu extends ContextMenu
   {
     addItem(new CheckedContextMenuItem("Anfangsbestand",
         new AnfangsbestandNeuAction(), "file.png"));
-    addItem(new CheckedContextMenuItem("löschen...", new KontoDeleteAction(),
-        "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...", new KontoDeleteAction(),
+        "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/KursteilnehmerMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/KursteilnehmerMenu.java
@@ -35,10 +35,10 @@ public class KursteilnehmerMenu extends ContextMenu
   public KursteilnehmerMenu(TablePart table)
   {
     addItem(new CheckedContextMenuItem("Abbuchungsdatum löschen...",
-        new KursteilnehmerAbuResetAction(table), "trash-alt.png"));
+        new KursteilnehmerAbuResetAction(table), "user-trash-full.png"));
     addItem(new CheckedContextMenuItem("Zum Mitglied machen",
-        new KursteilnehmerWirdMitgliedAction(), "exchange-alt.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new KursteilnehmerDeleteAction(), "trash-alt.png"));
+        new KursteilnehmerWirdMitgliedAction(), "view-refresh.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new KursteilnehmerDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/LehrgangMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LehrgangMenu.java
@@ -31,7 +31,7 @@ public class LehrgangMenu extends ContextMenu
    */
   public LehrgangMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...", new LehrgangDeleteAction(),
-        "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...", new LehrgangDeleteAction(),
+        "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/LehrgangsartMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LehrgangsartMenu.java
@@ -31,7 +31,7 @@ public class LehrgangsartMenu extends ContextMenu
    */
   public LehrgangsartMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new LehrgangsartDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new LehrgangsartDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MailAnhangMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MailAnhangMenu.java
@@ -30,9 +30,9 @@ public class MailAnhangMenu extends ContextMenu
 
   public MailAnhangMenu(MailControl control)
   {
-    addItem(new CheckedContextMenuItem("anzeigen",
+    addItem(new CheckedContextMenuItem("Anzeigen",
         new MailAnhangAnzeigeAction(), "eye.png"));
-    addItem(new CheckedContextMenuItem("entfernen",
-        new MailAnhangDeleteAction(control), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Entfernen",
+        new MailAnhangDeleteAction(control), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MailAuswahlMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MailAuswahlMenu.java
@@ -92,7 +92,7 @@ public class MailAuswahlMenu extends ContextMenu
       }
 
     }, "edit.png" /* "mail-message-new.png" */));
-    addItem(new CheckedContextMenuItem("entfernen",
-        new MailAuswahlDeleteAction(control), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Entfernen",
+        new MailAuswahlDeleteAction(control), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MailMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MailMenu.java
@@ -28,7 +28,7 @@ public class MailMenu extends ContextMenu
 
   public MailMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...", new MailDeleteAction(),
-        "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...", new MailDeleteAction(),
+        "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MailVorlageMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MailVorlageMenu.java
@@ -28,7 +28,7 @@ public class MailVorlageMenu extends ContextMenu
 
   public MailVorlageMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new MailVorlageDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new MailVorlageDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMailMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMailMenu.java
@@ -32,7 +32,7 @@ public class MitgliedMailMenu extends ContextMenu
    */
   public MitgliedMailMenu(MitgliedControl mc)
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new MailemfaengerDeleteAction(mc), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new MailemfaengerDeleteAction(mc), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -63,15 +63,15 @@ public class MitgliedMenu extends ContextMenu
    */
   public MitgliedMenu(Action detailaction) throws RemoteException
   {
-    addItem(new CheckedSingleContextMenuItem("bearbeiten", detailaction,
+    addItem(new CheckedSingleContextMenuItem("Bearbeiten", detailaction,
         "edit.png"));
-    addItem(new CheckedSingleContextMenuItem("duplizieren",
+    addItem(new CheckedSingleContextMenuItem("Duplizieren",
         new MitgliedDuplizierenAction(), "copy.png"));
-    addItem(new CheckedContextMenuItem("in Zwischenablage kopieren",
+    addItem(new CheckedContextMenuItem("In Zwischenablage kopieren",
         new MitgliedInZwischenablageKopierenAction(), "copy.png"));
     if (detailaction instanceof AdresseDetailAction)
     {
-      addItem(new CheckedContextMenuItem("zu Mitglied umwandeln", new Action()
+      addItem(new CheckedContextMenuItem("Zu Mitglied umwandeln", new Action()
       {
 
         @Override
@@ -105,8 +105,8 @@ public class MitgliedMenu extends ContextMenu
         }
       }, "arrows-alt-h.png"));
     }
-    addItem(new CheckedSingleContextMenuItem("löschen...",
-        new MitgliedDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedSingleContextMenuItem("Löschen...",
+        new MitgliedDeleteAction(), "user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedContextMenuItem("Mail senden ...",
         new MitgliedMailSendenAction(), "envelope-open.png"));
@@ -124,7 +124,7 @@ public class MitgliedMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Zusatzbeträge zuweisen",
         new MitgliedZusatzbetraegeZuordnungAction(), "coins.png"));
     addItem(new CheckedContextMenuItem("Kontoauszug", new KontoauszugAction(),
-        "rechnung.png"));
+        "receipt.png"));
     addItem(new CheckedSingleContextMenuItem("Spendenbescheinigung",
         new SpendenbescheinigungAction(), "file-invoice.png"));
     addItem(new CheckedContextMenuItem("Personalbogen",

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedNextBGruppeMenue.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedNextBGruppeMenue.java
@@ -33,6 +33,6 @@ public class MitgliedNextBGruppeMenue extends ContextMenu
     addItem(new ContextMenuItem("Beitragsgruppe hinzufügen",
         new MitgliedNextBGruppeNeuAction(control), "file.png"));
     addItem(new CheckedContextMenuItem("Beitragsgruppe löschen",
-        new MitgliedNextBGruppeLoeschenAction(), "trash-alt.png"));
+        new MitgliedNextBGruppeLoeschenAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -44,7 +44,7 @@ public class MitgliedskontoMenu extends ContextMenu
    */
   public MitgliedskontoMenu()
   {
-    addItem(new MitgliedItem("neue Sollbuchung",
+    addItem(new MitgliedItem("Neue Sollbuchung",
         new MitgliedskontoDetailSollNeuAction(), "calculator.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SollItem("Sollbuchung bearbeiten",

--- a/src/de/jost_net/JVerein/gui/menu/ProjektMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ProjektMenu.java
@@ -31,7 +31,7 @@ public class ProjektMenu extends ContextMenu
    */
   public ProjektMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...", new ProjektDeleteAction(),
-        "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...", new ProjektDeleteAction(),
+        "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/ShowVariablesMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ShowVariablesMenu.java
@@ -104,6 +104,6 @@ public class ShowVariablesMenu extends ContextMenu
         }
       }
     };
-    addItem(new CheckedContextMenuItem("kopieren", copy, "copy.png"));
+    addItem(new CheckedContextMenuItem("Kopieren", copy, "copy.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -41,11 +41,11 @@ public class SpendenbescheinigungMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Drucken (individuell)",
         new SpendenbescheinigungPrintAction(false), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new DuplicateMenuItem("als Vorlage für neue Spende",
+    addItem(new DuplicateMenuItem("Als Vorlage für neue Spende",
         new SpendenbescheinigungDuplizierenAction(), "copy.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem("löschen...",
-        new SpendenbescheinigungDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new SpendenbescheinigungDeleteAction(), "user-trash-full.png"));
   }
 
   private static class DuplicateMenuItem extends CheckedContextMenuItem

--- a/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
@@ -46,16 +46,16 @@ public class SplitBuchungMenu extends ContextMenu
 
   public SplitBuchungMenu(BuchungsControl control)
   {
-    addItem(new CheckedSplitBuchungItem("bearbeiten", new BuchungAction(true),
+    addItem(new CheckedSplitBuchungItem("Bearbeiten", new BuchungAction(true),
         "edit.png"));
     addItem(new CheckedSplitBuchungItem("Buchungsart zuordnen",
-        new BuchungBuchungsartZuordnungAction(control), "zuordnung.png"));
+        new BuchungBuchungsartZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Mitgliedskonto zuordnen",
-        new BuchungMitgliedskontoZuordnungAction(control), "exchange-alt.png"));
+        new BuchungMitgliedskontoZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Projekt zuordnen",
-        new BuchungProjektZuordnungAction(control), "exchange-alt.png"));
+        new BuchungProjektZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Kontoauszug zuordnen",
-        new BuchungKontoauszugZuordnungAction(control), "zuordnung.png"));
+        new BuchungKontoauszugZuordnungAction(control), "view-refresh.png"));
     addItem(new DeleteSplitBuchungItem());
     addItem(new RestoreSplitBuchungItem());
   }
@@ -90,7 +90,7 @@ public class SplitBuchungMenu extends ContextMenu
   {
     private DeleteSplitBuchungItem()
     {
-      super("löschen...", new BuchungDeleteAction(true), "trash-alt.png");
+      super("Löschen...", new BuchungDeleteAction(true), "user-trash-full.png");
     }
 
     @Override
@@ -116,7 +116,7 @@ public class SplitBuchungMenu extends ContextMenu
   {
     private RestoreSplitBuchungItem()
     {
-      super("wiederherstellen", new Action()
+      super("Wiederherstellen", new Action()
       {
         @Override
         public void handleAction(Object context) throws ApplicationException
@@ -154,7 +154,7 @@ public class SplitBuchungMenu extends ContextMenu
             Logger.error(fehler, e);
           }
         }
-      }, "undo.png");
+      }, "edit-undo.png");
     }
 
     @Override

--- a/src/de/jost_net/JVerein/gui/menu/SuchprofilMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SuchprofilMenu.java
@@ -29,9 +29,9 @@ public class SuchprofilMenu extends ContextMenu
 {
   public SuchprofilMenu(MitgliedSuchProfilControl control)
   {
-    addItem(new CheckedContextMenuItem("laden", new SuchprofilLadenAction(),
+    addItem(new CheckedContextMenuItem("Laden", new SuchprofilLadenAction(),
         "document-open.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new SuchprofilDeleteAction(control), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new SuchprofilDeleteAction(control), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/WiedervorlageMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/WiedervorlageMenu.java
@@ -33,9 +33,9 @@ public class WiedervorlageMenu extends ContextMenu
    */
   public WiedervorlageMenu(TablePart table)
   {
-    addItem(new CheckedContextMenuItem("erledigt",
+    addItem(new CheckedContextMenuItem("Erledigt",
         new WiedervorlageErledigungAction(table), "check.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new WiedervorlageDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new WiedervorlageDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
@@ -44,9 +44,9 @@ public class ZusatzbetraegeMenu extends ContextMenu
         new ZusatzbetraegeNaechsteFaelligkeitAction(table),
         "calendar-alt.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedSingleContextMenuItem("erneut ausführen",
+    addItem(new CheckedSingleContextMenuItem("Erneut ausführen",
         new ZusatzbetraegeResetAction(table), "sync.png"));
-    addItem(new CheckedContextMenuItem("löschen...",
-        new ZusatzbetraegeDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new ZusatzbetraegeDeleteAction(), "user-trash-full.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/ZusatzbetragVorlageMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ZusatzbetragVorlageMenu.java
@@ -31,7 +31,7 @@ public class ZusatzbetragVorlageMenu extends ContextMenu
    */
   public ZusatzbetragVorlageMenu()
   {
-    addItem(new CheckedContextMenuItem("löschen...",
-        new ZusatzbetragVorlageDeleteAction(), "trash-alt.png"));
+    addItem(new CheckedContextMenuItem("Löschen...",
+        new ZusatzbetragVorlageDeleteAction(), "user-trash-full.png"));
   }
 }


### PR DESCRIPTION
Menü Items unter de.jost_net.JVerein.gui.menu angepasst:
- Großschrift
- Entfernen/Löschen Icon durch user-trash-full.png ersetzt wie in Hibiscus.
- Zuordnen Icon (zuordnung.png) hat nicht existiert. Ersetzt durch view-refresh.png genauso wie exchange-alt.png damit ersetzt