### PR TITLE
Buttons und Labels in Views Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -271,7 +271,7 @@ public class AbrechnungSEPAControl extends AbstractControl
 
   public Button getStartButton()
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
       @Override
       public void handleAction(Object context)

--- a/src/de/jost_net/JVerein/gui/control/BuchungsuebernahmeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsuebernahmeControl.java
@@ -52,7 +52,7 @@ public class BuchungsuebernahmeControl extends AbstractControl
 
   public Button getStartButton()
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
       @Override
       public void handleAction(Object context)

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -543,7 +543,7 @@ public class KursteilnehmerControl extends AbstractControl
 
   public Button getStartAuswertungButton()
   {
-    Button b = new Button("starten", new Action()
+    Button b = new Button("Starten", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
@@ -97,7 +97,7 @@ public class LehrgangsartControl extends AbstractControl
       d = null;
     }
     this.von = new DateInput(d, new JVDateFormatTTMMJJJJ());
-    this.von.setTitle("von/am");
+    this.von.setTitle("Von/am");
     this.von.setText("Bitte Beginn oder Tag der Veranstaltung wählen");
     return von;
   }
@@ -114,7 +114,7 @@ public class LehrgangsartControl extends AbstractControl
       d = null;
     }
     this.bis = new DateInput(d, new JVDateFormatTTMMJJJJ());
-    this.bis.setTitle("bis");
+    this.bis.setTitle("Bis");
     this.bis.setText("Bitte Ende der Veranstaltung wählen");
     return bis;
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2559,7 +2559,7 @@ public class MitgliedControl extends AbstractControl
 
   public Button getStartAuswertungButton()
   {
-    Button b = new Button("starten", new Action()
+    Button b = new Button("Starten", new Action()
     {
 
       @Override
@@ -2640,7 +2640,7 @@ public class MitgliedControl extends AbstractControl
 
   public Button getStartAdressAuswertungButton()
   {
-    Button b = new Button("starten", new Action()
+    Button b = new Button("Starten", new Action()
     {
 
       @Override
@@ -2664,7 +2664,7 @@ public class MitgliedControl extends AbstractControl
 
   public Button getStartStatistikButton()
   {
-    Button b = new Button("starten", new Action()
+    Button b = new Button("Starten", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -906,7 +906,7 @@ public class MitgliedskontoControl extends AbstractControl
 
   public Button getStartRechnungButton(final Object currentObject)
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
 
       @Override
@@ -934,7 +934,7 @@ public class MitgliedskontoControl extends AbstractControl
   public Button getStartKontoauszugButton(final Object currentObject,
       final DateInput von, final DateInput bis)
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
 
       @Override
@@ -970,7 +970,7 @@ public class MitgliedskontoControl extends AbstractControl
 
   public Button getStartMahnungButton(final Object currentObject)
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -230,7 +230,7 @@ public class PreNotificationControl extends AbstractControl
 
   public Button getStartButton(final Object currentObject)
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
 
       @Override
@@ -273,7 +273,7 @@ public class PreNotificationControl extends AbstractControl
 
   public Button getStart1ctUeberweisungButton(final Object currentObject)
   {
-    Button button = new Button("starten", new Action()
+    Button button = new Button("Starten", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -124,7 +124,7 @@ public class MitgliedMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Zusatzbeträge zuweisen",
         new MitgliedZusatzbetraegeZuordnungAction(), "coins.png"));
     addItem(new CheckedContextMenuItem("Kontoauszug", new KontoauszugAction(),
-        "receipt.png"));
+        "file-invoice.png"));
     addItem(new CheckedSingleContextMenuItem("Spendenbescheinigung",
         new SpendenbescheinigungAction(), "file-invoice.png"));
     addItem(new CheckedContextMenuItem("Personalbogen",

--- a/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
@@ -66,7 +66,7 @@ public class ZusatzbetragPart implements Part
   {
     LabelGroup group = new LabelGroup(parent, "Zusatzbetrag");
     group.addLabelPair("Startdatum", getStartdatum(true));
-    group.addLabelPair("nächste Fälligkeit", getFaelligkeit());
+    group.addLabelPair("Nächste Fälligkeit", getFaelligkeit());
     group.addLabelPair("Intervall", getIntervall());
     group.addLabelPair("Endedatum", getEndedatum());
     group.addLabelPair("Buchungstext", getBuchungstext());

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufView.java
@@ -76,7 +76,7 @@ public class AbrechnungslaufView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/AbstractAdresseDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractAdresseDetailView.java
@@ -204,21 +204,21 @@ public abstract class AbstractAdresseDetailView extends AbstractView
       // R.M. 27.01.2013 Mitglieder sollten aus dem Dialog raus kopiert werden
       // können
       buttons
-          .addButton(new Button("duplizieren", new MitgliedDuplizierenAction(),
+          .addButton(new Button("Duplizieren", new MitgliedDuplizierenAction(),
               control.getCurrentObject(), false, "copy.png"));
     }
     buttons.addButton("Mail", new MitgliedMailSendenAction(),
         getCurrentObject(), false, "envelope-open.png");
     // buttons.addButton("neue Mail", new MailDetailAction(),
     // control.getCurrentObject(), false, "document-new.png");
-    buttons.addButton("neu", (isMitgliedDetail() ? new MitgliedDetailAction()
+    buttons.addButton("Neu", (isMitgliedDetail() ? new MitgliedDetailAction()
         : new AdresseDetailAction()), null, false, "file.png");
 
-    buttons.addButton("löschen",
+    buttons.addButton("Löschen",
         (isMitgliedDetail() ? new MitgliedDeleteAction()
             : new AdresseDeleteAction()),
-        control.getCurrentObject(), false, "trash-alt.png");
-    buttons.addButton("speichern", new Action()
+        control.getCurrentObject(), false, "user-trash-full.png");
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -234,7 +234,7 @@ public abstract class AbstractAdresseDetailView extends AbstractView
           Logger.error("Fehler", e);
         }
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/view/AbstractAdresseSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractAdresseSucheView.java
@@ -104,7 +104,7 @@ public abstract class AbstractAdresseSucheView extends AbstractView
     buttons.addButton(getHilfeButton());
     if (anzahlbeitragsgruppe > 0)
     {
-      buttons.addButton("neu", getDetailAction(), null, false, "file.png");
+      buttons.addButton("Neu", getDetailAction(), null, false, "file.png");
     }
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/AdresstypListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AdresstypListView.java
@@ -42,7 +42,7 @@ public class AdresstypListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ADRESSTYPEN, false, "question-circle.png");
-    buttons.addButton("neu", new AdresstypAction(), null, false, "file.png");
+    buttons.addButton("Neu", new AdresstypAction(), null, false, "file.png");
 
     DBIterator<Adresstyp> it = Einstellungen.getDBService()
         .createList(Adresstyp.class);

--- a/src/de/jost_net/JVerein/gui/view/AdresstypView.java
+++ b/src/de/jost_net/JVerein/gui/view/AdresstypView.java
@@ -41,14 +41,14 @@ public class AdresstypView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ADRESSTYPEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
@@ -38,7 +38,7 @@ public class AnfangsbestandListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ANFANGSBESTAENDE, false, "question-circle.png");
-    buttons.addButton("neu", new AnfangsbestandNeuAction(), null, true,
+    buttons.addButton("Neu", new AnfangsbestandNeuAction(), null, true,
         "file.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandView.java
@@ -46,14 +46,14 @@ public class AnfangsbestandView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ANFANGSBESTAENDE, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzDetailView.java
@@ -40,14 +40,14 @@ public class ArbeitseinsatzDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ARBEITSEINSATZ, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
@@ -60,7 +60,7 @@ public class ArbeitseinsatzUeberpruefungView extends AbstractView
     group.addLabelPair("Auswertung", aui);
 
     ButtonArea buttons = new ButtonArea();
-    Button button = new Button("suchen", new Action()
+    Button button = new Button("Suchen", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/view/AuswertungKursteilnehmerView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungKursteilnehmerView.java
@@ -34,8 +34,8 @@ public class AuswertungKursteilnehmerView extends AbstractView
     final KursteilnehmerControl control = new KursteilnehmerControl(this);
 
     LabelGroup grAbu = new LabelGroup(getParent(), "Abbuchungsdatum");
-    grAbu.addLabelPair("von", control.getAbbuchungsdatumvon());
-    grAbu.addLabelPair("bis", control.getAbbuchungsdatumbis());
+    grAbu.addLabelPair("Von", control.getAbbuchungsdatumvon());
+    grAbu.addLabelPair("Bis", control.getAbbuchungsdatumbis());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
@@ -83,16 +83,16 @@ public class BeitragsgruppeDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BEITRAGSGRUPPEN, false, "question-circle.png");
-    buttons.addButton("suche", new BeitragsgruppeSucheAction(), null, false,
+    buttons.addButton("Suche", new BeitragsgruppeSucheAction(), null, false,
         "search.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeSucheView.java
@@ -39,9 +39,9 @@ public class BeitragsgruppeSucheView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BEITRAGSGRUPPEN, false, "question-circle.png");
-    buttons.addButton("löschen", new BeitragsgruppeDeleteAction(),
-        control.getBeitragsgruppeTable(), false, "trash-alt.png");
-    buttons.addButton("neu", new BeitragsgruppeDetailAction(), null, false,
+    buttons.addButton("Löschen", new BeitragsgruppeDeleteAction(),
+        control.getBeitragsgruppeTable(), false, "user-trash-full.png");
+    buttons.addButton("Neu", new BeitragsgruppeDetailAction(), null, false,
         "file.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/BuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungView.java
@@ -44,10 +44,10 @@ public class BuchungView extends AbstractView
         DokumentationUtil.BUCHUNGEN, false, "question-circle.png");
     if (control.getBuchung().getSpeicherung())
     {
-      buttons.addButton("neu", new BuchungNeuAction(), null, false, "file.png");
+      buttons.addButton("Neu", new BuchungNeuAction(), null, false, "file.png");
     }
-    Button savButton = new Button("speichern",
-        control.getBuchungSpeichernAction(), null, true, "save.png");
+    Button savButton = new Button("Speichern",
+        control.getBuchungSpeichernAction(), null, true, "document-save.png");
     savButton.setEnabled(!buchungabgeschlossen);
     buttons.addButton(savButton);
     buttons.paint(getParent());

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartListView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartListView.java
@@ -43,7 +43,7 @@ public class BuchungsartListView extends AbstractView
     group.addLabelPair("Suche", control.getSuchtext());
 
     ButtonArea buttons1 = new ButtonArea();
-    Button button = new Button("suchen", new Action()
+    Button button = new Button("Suchen", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -69,7 +69,7 @@ public class BuchungsartListView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGSART, false, "question-circle.png");
     buttons.addButton(control.getPDFAusgabeButton());
-    buttons.addButton("neu", new BuchungsartAction(), null, false, "file.png");
+    buttons.addButton("Neu", new BuchungsartAction(), null, false, "file.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartView.java
@@ -47,14 +47,14 @@ public class BuchungsartView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGSART, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseListView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseListView.java
@@ -38,7 +38,7 @@ public class BuchungsklasseListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGSKLASSEN, false, "question-circle.png");
-    buttons.addButton("neu", new BuchungsklasseAction(), null, false,
+    buttons.addButton("Neu", new BuchungsklasseAction(), null, false,
         "file.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -132,8 +132,8 @@ public class BuchungsklasseSaldoView extends AbstractView
         this);
 
     LabelGroup group = new LabelGroup(getParent(), "Zeitraum");
-    group.addLabelPair("von", control.getDatumvon());
-    group.addLabelPair("bis", control.getDatumbis());
+    group.addLabelPair("Von", control.getDatumvon());
+    group.addLabelPair("Bis", control.getDatumbis());
 
     DBIterator<Buchung> list = Einstellungen.getDBService().createList(Buchung.class);
     if (list == null || !list.hasNext())
@@ -156,7 +156,7 @@ public class BuchungsklasseSaldoView extends AbstractView
     quickGroup.addPart(quickBtns);
 
     ButtonArea buttons = new ButtonArea();
-    Button button = new Button("suchen", new Action()
+    Button button = new Button("Suchen", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseView.java
@@ -42,14 +42,14 @@ public class BuchungsklasseView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGSKLASSEN, false, "question-circle.png");
 
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -57,9 +57,9 @@ public class BuchungslisteView extends AbstractView
       left.addLabelPair("Projekt", control.getSuchProjekt());
       left.addLabelPair("Betrag", control.getSuchBetrag());
       left.addLabelPair("Mitglied zugeordnet?", control.getSuchMitgliedZugeordnet());
-      right.addLabelPair("von Datum", control.getVondatum());
-      right.addLabelPair("bis Datum", control.getBisdatum());
-      right.addLabelPair("enthaltener Text", control.getSuchtext());
+      right.addLabelPair("Von Datum", control.getVondatum());
+      right.addLabelPair("Bis Datum", control.getBisdatum());
+      right.addLabelPair("Enthaltener Text", control.getSuchtext());
     }
     {
       final BuchungsHeaderControl headerControl = new BuchungsHeaderControl(
@@ -99,7 +99,7 @@ public class BuchungslisteView extends AbstractView
     buttons.addButton(control.getStartAuswertungEinzelbuchungenButton());
     buttons.addButton(control.getStartAuswertungSummenButton());
     buttons.addButton(control.getStarteBuchungMitgliedskontoZuordnungAutomatischButton());
-    buttons.addButton("neu", new BuchungNeuAction(), control, false,
+    buttons.addButton("Neu", new BuchungNeuAction(), control, false,
         "file.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
@@ -47,7 +47,7 @@ public class BuchungsuebernahmeView extends AbstractView
       {
         new Buchungsuebernahme();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftDetailView.java
@@ -41,7 +41,7 @@ public class EigenschaftDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EIGENSCHAFT, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -49,7 +49,7 @@ public class EigenschaftDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeDetailView.java
@@ -43,9 +43,9 @@ public class EigenschaftGruppeDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EIGENSCHAFTGRUPPE, false, "question-circle.png");
-    buttons.addButton("suche", new EigenschaftGruppeListeAction(), null, false,
+    buttons.addButton("Suche", new EigenschaftGruppeListeAction(), null, false,
         "search.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class EigenschaftGruppeDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
@@ -39,9 +39,9 @@ public class EigenschaftGruppeListeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EIGENSCHAFTGRUPPE, false, "question-circle.png");
-    buttons.addButton("löschen", new EigenschaftGruppeDeleteAction(),
-        control.getEigenschaftGruppeList(), false, "trash-alt.png");
-    buttons.addButton("neu", new EigenschaftGruppeDetailAction(true), null,
+    buttons.addButton("Löschen", new EigenschaftGruppeDeleteAction(),
+        control.getEigenschaftGruppeList(), false, "user-trash-full.png");
+    buttons.addButton("Neu", new EigenschaftGruppeDetailAction(true), null,
         false, "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
@@ -39,9 +39,9 @@ public class EigenschaftListeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EIGENSCHAFT, false, "question-circle.png");
-    buttons.addButton("löschen", new EigenschaftDeleteAction(),
-        control.getEigenschaftList(), false, "trash-alt.png");
-    buttons.addButton("neu", new EigenschaftDetailAction(true), null, false,
+    buttons.addButton("Löschen", new EigenschaftDeleteAction(),
+        control.getEigenschaftList(), false, "user-trash-full.png");
+    buttons.addButton("Neu", new EigenschaftDetailAction(true), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
@@ -54,7 +54,7 @@ public class EinstellungenAbrechnungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -62,7 +62,7 @@ public class EinstellungenAbrechnungView extends AbstractView
       {
         control.handleStoreAbrechnung();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAllgemeinView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAllgemeinView.java
@@ -51,7 +51,7 @@ public class EinstellungenAllgemeinView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -59,7 +59,7 @@ public class EinstellungenAllgemeinView extends AbstractView
       {
         control.handleStoreAllgemein();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -92,7 +92,7 @@ public class EinstellungenAnzeigeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -100,7 +100,7 @@ public class EinstellungenAnzeigeView extends AbstractView
       {
         control.handleStoreAnzeige();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -45,7 +45,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
       {
         control.handleStoreBuchfuehrung();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenDateinamenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenDateinamenView.java
@@ -45,7 +45,7 @@ public class EinstellungenDateinamenView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class EinstellungenDateinamenView extends AbstractView
       {
         control.handleStoreDateinamen();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMailView.java
@@ -67,7 +67,7 @@ public class EinstellungenMailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -75,7 +75,7 @@ public class EinstellungenMailView extends AbstractView
       {
         control.handleStoreMail();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
@@ -115,7 +115,7 @@ public class EinstellungenMitgliedAnsichtView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -123,7 +123,7 @@ public class EinstellungenMitgliedAnsichtView extends AbstractView
       {
         control.handleStoreMitgliedAnsicht();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
@@ -39,7 +39,7 @@ public class EinstellungenMitgliederSpaltenView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -47,7 +47,7 @@ public class EinstellungenMitgliederSpaltenView extends AbstractView
       {
         control.handleStoreMitgliederSpalten();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -45,7 +45,7 @@ public class EinstellungenRechnungenView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class EinstellungenRechnungenView extends AbstractView
       {
         control.handleStoreRechnungen();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -56,7 +56,7 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -64,7 +64,7 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
       {
         control.handleStoreSpendenbescheinigungen();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenStatistikView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenStatistikView.java
@@ -45,7 +45,7 @@ public class EinstellungenStatistikView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class EinstellungenStatistikView extends AbstractView
       {
         control.handleStoreStatistik();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/FelddefinitionDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FelddefinitionDetailView.java
@@ -45,7 +45,7 @@ public class FelddefinitionDetailView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FELDDEFINITIONEN, false, "question-circle.png");
     buttons.addButton("Übersicht", new FelddefinitionenAction());
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -53,7 +53,7 @@ public class FelddefinitionDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/FelddefinitionenUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/FelddefinitionenUebersichtView.java
@@ -38,7 +38,7 @@ public class FelddefinitionenUebersichtView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FELDDEFINITIONEN, false, "question-circle.png");
-    buttons.addButton("neu", new FelddefinitionDetailAction(), null, false,
+    buttons.addButton("Neu", new FelddefinitionDetailAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
@@ -44,7 +44,7 @@ public class FormularDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -52,7 +52,7 @@ public class FormularDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/FormularListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularListeView.java
@@ -38,7 +38,7 @@ public class FormularListeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
-    buttons.addButton("neu", new FormularAction(), null, false,
+    buttons.addButton("Neu", new FormularAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/FormularfeldView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularfeldView.java
@@ -40,15 +40,15 @@ public class FormularfeldView extends AbstractView
     LabelGroup group = new LabelGroup(getParent(), "Formularfeld");
     group.addLabelPair("Name", control.getName());
     group.addLabelPair("Seite", control.getSeite());
-    group.addLabelPair("von links", control.getX());
-    group.addLabelPair("von unten", control.getY());
+    group.addLabelPair("Von links", control.getX());
+    group.addLabelPair("Von unten", control.getY());
     group.addLabelPair("Font", control.getFont());
     group.addLabelPair("Font-Höhe", control.getFontsize());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -56,7 +56,7 @@ public class FormularfeldView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/FormularfelderListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularfelderListeView.java
@@ -48,12 +48,12 @@ public class FormularfelderListeView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
     buttons.addButton("Export", new FormularfelderExportAction(),
-        getCurrentObject(), false, "save.png");
+        getCurrentObject(), false, "document-save.png");
     buttons.addButton("Import", new FormularfelderImportAction(control),
         getCurrentObject(), false, "file-import.png");
-    buttons.addButton("anzeigen", new FormularAnzeigeAction(),
+    buttons.addButton("Anzeigen", new FormularAnzeigeAction(),
         getCurrentObject(), false, "edit.png");
-    buttons.addButton("neu", new FormularfeldAction(), getCurrentObject(),
+    buttons.addButton("Neu", new FormularfeldAction(), getCurrentObject(),
         false, "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussListView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussListView.java
@@ -38,7 +38,7 @@ public class JahresabschlussListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.JAHRESABSCHLUSS, false, "question-circle.png");
-    buttons.addButton("neu", new JahresabschlussDetailAction(), null, false,
+    buttons.addButton("Neu", new JahresabschlussDetailAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussView.java
@@ -35,8 +35,8 @@ public class JahresabschlussView extends AbstractView
     final JahresabschlussControl control = new JahresabschlussControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Jahresabschluss");
-    group.addLabelPair("von", control.getVon());
-    group.addLabelPair("bis", control.getBis());
+    group.addLabelPair("Von", control.getVon());
+    group.addLabelPair("Bis", control.getBis());
     group.addLabelPair("Datum", control.getDatum());
     group.addLabelPair("Name", control.getName());
     group.addLabelPair("Anfangsbestände Folgejahr",
@@ -46,7 +46,7 @@ public class JahresabschlussView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.JAHRESABSCHLUSS, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -54,7 +54,7 @@ public class JahresabschlussView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/JahressaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahressaldoView.java
@@ -40,7 +40,7 @@ public class JahressaldoView extends AbstractView
     group.addLabelPair("Jahr", control.getSuchJahr());
 
     ButtonArea buttons = new ButtonArea();
-    Button button = new Button("suchen", new Action()
+    Button button = new Button("Suchen", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/view/KontoListView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoListView.java
@@ -41,7 +41,7 @@ public class KontoListView extends AbstractView
         DokumentationUtil.KONTEN, false, "question-circle.png");
     buttons.addButton("Hibiscus-Konten-Import",
         new HibiscusKontenImportAction(control), null, false, "walking.png");
-    buttons.addButton("neu", new KontoAction(), null, false,
+    buttons.addButton("Neu", new KontoAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/KontoView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoView.java
@@ -44,7 +44,7 @@ public class KontoView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KONTEN, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -52,7 +52,7 @@ public class KontoView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
@@ -36,8 +36,8 @@ public class KontoauszugView extends AbstractView
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Zeitraum");
-    group.addLabelPair("von", control.getVondatum("kontoauszug"));
-    group.addLabelPair("bis", control.getBisdatum("kontoauszug"));
+    group.addLabelPair("Von", control.getVondatum("kontoauszug"));
+    group.addLabelPair("Bis", control.getBisdatum("kontoauszug"));
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
@@ -72,11 +72,11 @@ public class KursteilnehmerDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KURSTEILNEHMER, false, "question-circle.png");
-    buttons.addButton("neu", new KursteilnehmerDetailAction(), null, false,
+    buttons.addButton("Neu", new KursteilnehmerDetailAction(), null, false,
         "document-new.png");
-    buttons.addButton("löschen", new KursteilnehmerDeleteAction(),
-        control.getCurrentObject(), false, "trash-alt.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Löschen", new KursteilnehmerDeleteAction(),
+        control.getCurrentObject(), false, "user-trash-full.png");
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -84,7 +84,7 @@ public class KursteilnehmerDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
@@ -66,7 +66,7 @@ public class KursteilnehmerSucheView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KURSTEILNEHMER, false, "question-circle.png");
-    buttons.addButton("neu", new KursteilnehmerDetailAction(), null, false,
+    buttons.addButton("Neu", new KursteilnehmerDetailAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangView.java
@@ -35,15 +35,15 @@ public class LehrgangView extends AbstractView
 
     LabelGroup group = new LabelGroup(getParent(), "Lehrgang");
     group.addLabelPair("Lehrgangsart", control.getLehrgangsart());
-    group.addLabelPair("am/von", control.getVon());
-    group.addLabelPair("bis", control.getBis());
+    group.addLabelPair("Am/von", control.getVon());
+    group.addLabelPair("Bis", control.getBis());
     group.addLabelPair("Veranstalter", control.getVeranstalter());
     group.addLabelPair("Ergebnis", control.getErgebnis());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LEHRGANG, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -51,7 +51,7 @@ public class LehrgangView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangsartDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangsartDetailView.java
@@ -36,14 +36,14 @@ public class LehrgangsartDetailView extends AbstractView
 
     LabelGroup group = new LabelGroup(getParent(), "Lehrgangsart");
     group.addLabelPair("Bezeichnung", control.getBezeichnung(true));
-    group.addLabelPair("von/am", control.getVon());
-    group.addLabelPair("bis", control.getBis());
+    group.addLabelPair("Von/am", control.getVon());
+    group.addLabelPair("Bis", control.getBis());
     group.addLabelPair("Veranstalter", control.getVeranstalter());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LEHRGANG, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -51,7 +51,7 @@ public class LehrgangsartDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
@@ -38,7 +38,7 @@ public class LehrgangsartListeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LEHRGANG, false, "question-circle.png");
-    buttons.addButton("neu", new LehrgangsartAction(), null, false,
+    buttons.addButton("Neu", new LehrgangsartAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
@@ -93,7 +93,7 @@ public class LesefeldDetailView extends AbstractView implements Listener
         new OpenInsertVariableDialogAction(), null, false, "zuordnung.png");
     buttonArea.addButton(button);
     button = new Button("Speichern und zurück", new SaveLesefeldAction(), null,
-        false, "save.png");
+        false, "document-save.png");
     buttonArea.addButton(button);
     button = new Button("Abbrechen und zurück", new AbortEditLesefeldAction(),
         null, false, "stop-circle.png");

--- a/src/de/jost_net/JVerein/gui/view/MailUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailUebersichtView.java
@@ -38,7 +38,7 @@ public class MailUebersichtView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MAIL, false, "question-circle.png");
-    buttons.addButton("neu", new MailDetailAction(), null, false,
+    buttons.addButton("Neu", new MailDetailAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
@@ -43,7 +43,7 @@ public class MailVorlageDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MAIL, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -51,7 +51,7 @@ public class MailVorlageDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MailVorlagenUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlagenUebersichtView.java
@@ -38,7 +38,7 @@ public class MailVorlagenUebersichtView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MAIL, false, "question-circle.png");
-    buttons.addButton("neu", new MailVorlageDetailAction(), null, false,
+    buttons.addButton("Neu", new MailVorlageDetailAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedNextBGruppeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedNextBGruppeView.java
@@ -34,12 +34,12 @@ public class MitgliedNextBGruppeView extends AbstractView
     MitgliedNextBGruppeControl control = new MitgliedNextBGruppeControl(this);
 
     LabelGroup lblGroup = new LabelGroup(getParent(),
-        "neue Beitragsgruppe für Zukunft");
-    lblGroup.addLabelPair("für Mitglied", control.getMitgliedsnameInput());
-    lblGroup.addLabelPair("aktuelle Beitragsgruppe",
+        "Neue Beitragsgruppe für Zukunft");
+    lblGroup.addLabelPair("Für Mitglied", control.getMitgliedsnameInput());
+    lblGroup.addLabelPair("Aktuelle Beitragsgruppe",
         control.getBeitragsgruppeAktuellInput());
     lblGroup.addLabelPair("Ab Datum", control.getAbDatumInput());
-    lblGroup.addLabelPair("neue Beitragsgruppe",
+    lblGroup.addLabelPair("Neue Beitragsgruppe",
         control.getBeitragsgruppeInput());
     lblGroup.addLabelPair("Bemerkung", control.getBemerkungsInput());
 
@@ -47,7 +47,7 @@ public class MitgliedNextBGruppeView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIED, false, "question-circle.png");
     buttons.addButton("Speichern", control.getSpeichernAction(), null, false,
-        "save.png");
+        "document-save.png");
     buttons.paint(getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MitgliederSuchProfilView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliederSuchProfilView.java
@@ -41,7 +41,7 @@ public class MitgliederSuchProfilView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SUCHPROFIL, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -49,7 +49,7 @@ public class MitgliederSuchProfilView extends AbstractView
       {
         control.handleStore(false);
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.addButton("speichern unter", new Action()
     {
 
@@ -58,7 +58,7 @@ public class MitgliederSuchProfilView extends AbstractView
       {
         control.handleStore(true);
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
     control.getSuchprofilList().paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoDetailView.java
@@ -54,7 +54,7 @@ public class MitgliedskontoDetailView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIEDSKONTO_UEBERSICHT, false,
         "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -62,7 +62,7 @@ public class MitgliedskontoDetailView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoListeView.java
@@ -39,9 +39,9 @@ public class MitgliedskontoListeView extends AbstractView
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
     LabelGroup group = new LabelGroup(getParent(), "Filter");
     group.addInput(control.getSuchName());
-    group.addLabelPair("von",
+    group.addLabelPair("Von",
         control.getVondatum(MitgliedskontoControl.DATUM_MITGLIEDSKONTO));
-    group.addLabelPair("bis",
+    group.addLabelPair("Bis",
         control.getBisdatum(MitgliedskontoControl.DATUM_MITGLIEDSKONTO));
     group.addLabelPair("Differenz", control.getDifferenz());
 
@@ -54,7 +54,7 @@ public class MitgliedskontoListeView extends AbstractView
         "question-circle.png");
     buttons.addButton(new Button("Export",
         new MitgliedskontoExportAction(EXPORT_TYP.MITGLIEDSKONTO, null),
-        control, false, "save.png"));
+        control, false, "document-save.png"));
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
@@ -42,9 +42,9 @@ public class MitgliedskontoMahnungView extends AbstractView
     cont.addHeadline("Parameter");
     if (this.getCurrentObject() == null)
     {
-      cont.addLabelPair("von Datum",
+      cont.addLabelPair("Von Datum",
           control.getVondatum(MitgliedskontoControl.TYP.MAHNUNG.name()));
-      cont.addLabelPair("bis Datum",
+      cont.addLabelPair("Bis Datum",
           control.getBisdatum(MitgliedskontoControl.TYP.MAHNUNG.name()));
     }
     cont.addLabelPair("Formular", control.getFormular(FormularArt.MAHNUNG));
@@ -61,7 +61,7 @@ public class MitgliedskontoMahnungView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MAHNUNG, false, "question-circle.png");
     buttons.addButton(new Button("Export", new MitgliedskontoExportAction(
-        EXPORT_TYP.MAHNUNGEN, getCurrentObject()), control, false, "save.png"));
+        EXPORT_TYP.MAHNUNGEN, getCurrentObject()), control, false, "document-save.png"));
     buttons.addButton(control.getStartMahnungButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
@@ -41,11 +41,11 @@ public class MitgliedskontoRechnungView extends AbstractView
     cont.addHeadline("Parameter");
     if (this.getCurrentObject() == null)
     {
-      cont.addLabelPair("von Datum",
+      cont.addLabelPair("Von Datum",
           control.getVondatum(MitgliedskontoControl.TYP.RECHNUNG.name()));
-      cont.addLabelPair("bis Datum",
+      cont.addLabelPair("Bis Datum",
           control.getBisdatum(MitgliedskontoControl.TYP.RECHNUNG.name()));
-      cont.addLabelPair("ohne Abbucher", control.getOhneAbbucher());
+      cont.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
     }
     cont.addLabelPair("Formular", control.getFormular(FormularArt.RECHNUNG));
     cont.addInput(control.getAusgabeart());
@@ -63,7 +63,7 @@ public class MitgliedskontoRechnungView extends AbstractView
     buttons.addButton(new Button("Export",
         new MitgliedskontoExportAction(EXPORT_TYP.RECHNUNGEN,
             getCurrentObject()),
-        control, false, "save.png"));
+        control, false, "document-save.png"));
     buttons.addButton(control.getStartRechnungButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/ProjektListView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektListView.java
@@ -38,7 +38,7 @@ public class ProjektListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.PROJEKTE, false, "question-circle.png");
-    buttons.addButton("neu", new ProjektAction(), null, false,
+    buttons.addButton("Neu", new ProjektAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -37,11 +37,11 @@ public class ProjektSaldoView extends AbstractView
     final ProjektSaldoControl control = new ProjektSaldoControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Zeitraum");
-    group.addLabelPair("von", control.getDatumvon());
-    group.addLabelPair("bis", control.getDatumbis());
+    group.addLabelPair("Von", control.getDatumvon());
+    group.addLabelPair("Bis", control.getDatumbis());
 
     ButtonArea buttons = new ButtonArea();
-    Button button = new Button("suchen", new Action()
+    Button button = new Button("Suchen", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/view/ProjektView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektView.java
@@ -42,7 +42,7 @@ public class ProjektView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.PROJEKTE, false, "question-circle.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -50,7 +50,7 @@ public class ProjektView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/QIFBuchungsImportView.java
+++ b/src/de/jost_net/JVerein/gui/view/QIFBuchungsImportView.java
@@ -81,7 +81,7 @@ public class QIFBuchungsImportView extends AbstractView
         false, "file-import.png");
     buttons.addButton("Import löschen",
         control.getAktuellenImportLoeschenAction(), null, false,
-        "trash-alt.png");
+        "user-trash-full.png");
     buttons.addButton("Imports löschen", control.getAlleImportsLoeschenAction(),
         null, false, "list-remove.png");
     buttons.addButton("Buchungsarten zuordnen", new QIFBuchungsartAction(),

--- a/src/de/jost_net/JVerein/gui/view/QIFBuchungsartZuordnenView.java
+++ b/src/de/jost_net/JVerein/gui/view/QIFBuchungsartZuordnenView.java
@@ -62,7 +62,7 @@ public class QIFBuchungsartZuordnenView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.QIFIMPORT, false, "question-circle.png");
     buttons.addButton("Speichern", detailControl.getSpeichernAction(), null,
-        false, "save.png");
+        false, "document-save.png");
     buttons.paint(getParent());
 
     TabFolder folder = new TabFolder(maincontainer.getComposite(),

--- a/src/de/jost_net/JVerein/gui/view/QIFMitgliederZuordnenView.java
+++ b/src/de/jost_net/JVerein/gui/view/QIFMitgliederZuordnenView.java
@@ -51,7 +51,7 @@ public class QIFMitgliederZuordnenView extends AbstractView
         "Ordnen Sie den externen Namen ein Mitglied aus JVerein zu.", true,
         Color.COMMENT);
     LabelGroup lblGroup = new LabelGroup(maincontainer.getComposite(), "");
-    lblGroup.addLabelPair("alle Mitglieder zeigen",
+    lblGroup.addLabelPair("Alle Mitglieder zeigen",
         detailControl.getCheckBoxAlleMitgliederZeigen());
     lblGroup.addLabelPair("JVerein Mitglied: ",
         detailControl.getMitgliederInput());
@@ -60,7 +60,7 @@ public class QIFMitgliederZuordnenView extends AbstractView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.QIFIMPORT, false, "hquestion-circle.png");
     buttons.addButton("Zuordnung Speichern", detailControl.getSpeichernAction(),
-        null, false, "save.png");
+        null, false, "document-save.png");
     buttons.addButton("Zuordnung Entfernen",
         detailControl.getZuordnenEntfernenAction(), null, false, "eraser.png");
     buttons.paint(getParent());

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -39,9 +39,9 @@ public class SpendenbescheinigungListeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
-    buttons.addButton("neu (manuell)", new SpendenbescheinigungAction(), null,
+    buttons.addButton("Neu (manuell)", new SpendenbescheinigungAction(), null,
         false, "document-new.png");
-    buttons.addButton("neu (automatisch)",
+    buttons.addButton("Neu (automatisch)",
         new SpendenbescheinigungAutoNeuAction(), null, false,
         "document-new.png");
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
@@ -102,9 +102,9 @@ public class SpendenbescheinigungView extends AbstractView
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
     buttons.addButton(control.getPDFStandardButton());
     buttons.addButton(control.getPDFIndividuellButton());
-    buttons.addButton("neu", new SpendenbescheinigungAction(), null, false,
+    buttons.addButton("Neu", new SpendenbescheinigungAction(), null, false,
         "document-new.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -112,7 +112,7 @@ public class SpendenbescheinigungView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
@@ -40,13 +40,13 @@ public class SplitBuchungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPLITBUCHUNG, false, "question-circle.png");
-    buttons.addButton("neu", new SplitbuchungNeuAction(),
+    buttons.addButton("Neu", new SplitbuchungNeuAction(),
         control.getCurrentObject(), false, "document-new.png");
-    buttons.addButton("auflösen", new SplitbuchungAufloesenAction(),
+    buttons.addButton("Auflösen", new SplitbuchungAufloesenAction(),
         control.getCurrentObject(), false, "document-new.png");
     buttons.addButton(control.getSammelueberweisungButton());
 
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -61,7 +61,7 @@ public class SplitBuchungView extends AbstractView
           GUI.getStatusBar().setErrorText(e.getMessage());
         }
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlageView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlageView.java
@@ -44,7 +44,7 @@ public class WiedervorlageView extends AbstractView
         DokumentationUtil.WIEDERVORLAGE, false, "question-circle.png");
     buttons.addButton("Mitglied", new MitgliedDetailAction(),
         control.getWiedervorlage().getMitglied(), false, "user-friends.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -52,7 +52,7 @@ public class WiedervorlageView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragView.java
@@ -50,9 +50,9 @@ public class ZusatzbetragView extends AbstractView
         null, false, "clone.png");
     buttons.addButton("Mitglied", new MitgliedDetailAction(),
         control.getZusatzbetrag().getMitglied(), false, "user-friends.png");
-    buttons.addButton("löschen", new ZusatzbetraegeDeleteAction(),
-        control.getZusatzbetrag(), false, "trash-alt.png");
-    buttons.addButton("speichern", new Action()
+    buttons.addButton("Löschen", new ZusatzbetraegeDeleteAction(),
+        control.getZusatzbetrag(), false, "user-trash-full.png");
+    buttons.addButton("Speichern", new Action()
     {
 
       @Override
@@ -60,7 +60,7 @@ public class ZusatzbetragView extends AbstractView
       {
         control.handleStore();
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     buttons.paint(getParent());
   }
 }


### PR DESCRIPTION
Buttons und Labels für alle Views/Parts/Control angepasst:

- Großschrift in Buttons und Labels/Titels
- Entfernen/Löschen Icon durch user-trash-full.png ersetzt. Dieses wird auch in Hibiscus dafür verwendet.
- Speichern Icon durch document-save.png ersetzt. Dieses wird auch in Hibiscus verwendet.
- Ein Menü Item für Kontoauszug korrigiert. Jetzt so wie im "Daten des Mitglieds" View.