### PR TITLE
Restarbeiten Icons und Labels

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -133,7 +133,7 @@ public class DokumentControl extends AbstractControl
       {
         speichern(verzeichnis);
       }
-    }, null, true, "save.png");
+    }, null, true, "document-save.png");
     return speichernButton;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -1044,7 +1044,7 @@ public class MitgliedskontoControl extends AbstractControl
           item.setExpanded(false);
           break;
         case MitgliedskontoNode.IST:
-          item.setImage(0, SWTUtil.getImage("object-group.png"));
+          item.setImage(0, SWTUtil.getImage("coins.png"));
           break;
       }
     }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -203,7 +203,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
               "Fehler bei der Aufbereitung der Spendenbescheinigung");
         }
       }
-    }, null, false, "save.png");
+    }, null, false, "document-save.png");
     return b;
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenMitgliedskontenZuordnungDialog.java
@@ -125,9 +125,9 @@ public class BuchungenMitgliedskontenZuordnungDialog extends AbstractDialog<Obje
 
     group.addLabelPair("Startdatum", dateFrom);
     group.addLabelPair("Enddatum", dateUntil);
-    group.addLabelPair("nach eindeutiger IBAN", useIban);
-    group.addLabelPair("nach " + (Einstellungen.getEinstellung().getExterneMitgliedsnummer().booleanValue() ? "Ext. Mitgliedsnummer" : "Mitgliedsnummer"), useMemberNumber);
-    group.addLabelPair("nach eindeutigen Vorname und Nachname", useName);
+    group.addLabelPair("Nach eindeutiger IBAN", useIban);
+    group.addLabelPair("Nach " + (Einstellungen.getEinstellung().getExterneMitgliedsnummer().booleanValue() ? "Ext. Mitgliedsnummer" : "Mitgliedsnummer"), useMemberNumber);
+    group.addLabelPair("Nach eindeutigen Vorname und Nachname", useName);
     ButtonArea buttons = new ButtonArea();
 
     Button button = new Button("Zuordnungen suchen", new Action()

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -45,17 +45,17 @@ public class MitgliedskontoMenu extends ContextMenu
   public MitgliedskontoMenu()
   {
     addItem(new MitgliedItem("Neue Sollbuchung",
-        new MitgliedskontoDetailSollNeuAction(), "calculator.png"));
+        new MitgliedskontoDetailSollNeuAction(), "list-add.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SollItem("Sollbuchung bearbeiten",
-        new MitgliedskontoDetailAction(), "calculator.png"));
+        new MitgliedskontoDetailAction(), "edit-copy.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
-        new MitgliedskontoDetailSollLoeschenAction(), "calculator.png"));
+        new MitgliedskontoDetailSollLoeschenAction(), "list-remove.png"));
     addItem(new SollMitIstItem("Istbuchung vom Mitgliedskonto lösen",
-        new MitgliedskontoIstLoesenAction(), "calculator.png"));
+        new MitgliedskontoIstLoesenAction(), "unlocked.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SpendenbescheinigungItem("Spendenbescheinigung erstellen",
-        new SpendenbescheinigungAction(), "calculator.png"));
+        new SpendenbescheinigungAction(), "file-invoice.png"));
   }
 
   private static class MitgliedItem extends CheckedContextMenuItem

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -130,7 +130,7 @@ public class MyExtension implements Extension
       jverein.addChild(abrechnung);
 
       jverein.addChild(new MyItem(jverein, "Mitgliedskonten",
-          new MitgliedskontoListeAction(), "exchange-alt.png"));
+          new MitgliedskontoListeAction(), "calculator.png"));
       jverein.addChild(new MyItem(jverein, "Rechnungen",
           new MitgliedskontoRechnungAction(), "file-invoice.png"));
       jverein.addChild(new MyItem(jverein, "Mahnungen",
@@ -194,14 +194,14 @@ public class MyExtension implements Extension
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Konten",
           new KontoListAction(), "list.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Anfangsbestände",
-          new AnfangsbestandListAction(), "square.png"));
+          new AnfangsbestandListAction(), "euro-sign.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungen",
           new BuchungsListeAction(), "euro-sign.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Hibiscus-Buchungen",
           new BuchungsuebernahmeAction(), "hibiscus-icon-64x64.png"));
-      buchfuehrung.addChild(new MyItem(buchfuehrung, "Projekte",
-          new ProjektSaldoAction(), "exchange-alt.png"));
-      buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungsklassen",
+      buchfuehrung.addChild(new MyItem(buchfuehrung, "Projektsaldo",
+          new ProjektSaldoAction(), "euro-sign.png"));
+      buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungsklassensaldo",
           new BuchungsklasseSaldoAction(), "euro-sign.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Jahressaldo",
           new JahressaldoAction(), "euro-sign.png"));
@@ -273,7 +273,7 @@ public class MyExtension implements Extension
           .addChild(new MyItem(einstellungenbuchfuehrung, "QIF Datei-Import",
               new QIFBuchungsImportViewAction(), "file-import.png"));
       einstellungenbuchfuehrung.addChild(new MyItem(einstellungenbuchfuehrung,
-          "Projekte", new ProjektListAction(), "exchange-alt.png"));
+          "Projekte", new ProjektListAction(), "screwdriver.png"));
       administration.addChild(einstellungenbuchfuehrung);
 
       administration
@@ -313,10 +313,10 @@ public class MyExtension implements Extension
       einstellungenerweitert = new MyItem(einstellungenerweitert, "Erweitert",
           null);
       einstellungenerweitert.addChild(new MyItem(einstellungenerweitert,
-          "Diagnose-Backup erstellen", new BackupCreateAction(), "save.png"));
+          "Diagnose-Backup erstellen", new BackupCreateAction(), "document-save.png"));
       einstellungenerweitert.addChild(
           new MyItem(einstellungenerweitert, "Diagnose-Backup importieren",
-              new BackupRestoreAction(), "undo.png"));
+              new BackupRestoreAction(), "file-import.png"));
       administration.addChild(einstellungenerweitert);
       jverein.addChild(administration);
       jverein.addChild(new MyItem(jverein, "Dokumentation",

--- a/src/de/jost_net/JVerein/gui/navigation/MyItem.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyItem.java
@@ -69,7 +69,7 @@ public class MyItem implements NavigationItem
   {
     if (action == null)
     {
-      return SWTUtil.getImage(icon != null ? icon : "folder1.png");
+      return SWTUtil.getImage(icon != null ? icon : "folder.png");
     }
     else
     {
@@ -85,7 +85,7 @@ public class MyItem implements NavigationItem
   {
     if (action == null)
     {
-      return SWTUtil.getImage(icon != null ? icon : "folder1-open.png");
+      return SWTUtil.getImage(icon != null ? icon : "folder-open.png");
     }
     else
     {

--- a/src/de/jost_net/JVerein/gui/view/ImportView.java
+++ b/src/de/jost_net/JVerein/gui/view/ImportView.java
@@ -270,7 +270,7 @@ public class ImportView extends AbstractView
           {
             doImport();
           }
-        });
+        }, null, false, "file-import.png");
     buttons.addButton(importbt);
     buttons.paint(getParent());
     /*


### PR DESCRIPTION
- Großschrift für Labels von Dialogen
- Sonstige Save Icons ersetzt durch document-save.png
- Folder Icons im Tree ersetzt durch die aus Jameica/Hibiscus
- Import Icon für Diagnosedaten im Tree ersetzt ("file-import.png" statt "undo.png")
- Icon für Projekte in Tree ersetzt durch screwdriver.png
- Icon für Mitgliedskonten in Tree ersetzt durch calculator.png. Ist jetzt gleiches Icon wie im Mitgliedskonto View
- Menu Items im Mitgliedskonten Tree sinnvoll gestaltet
- Icon für die Zahlungen im Mitgliedskonten Tree durch coins.png ersetzt statt object-group.png