### PR TITLE
Fix MailVorlagenAuswahlDialog Close Fehler

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MailDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailDetailAction.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.util.ApplicationException;
 
 public class MailDetailAction implements Action
@@ -47,11 +48,19 @@ public class MailDetailAction implements Action
             MailVorlagenAuswahlDialog.POSITION_CENTER);
         m = (Mail) Einstellungen.getDBService().createObject(Mail.class, null);
         MailVorlage mv = mvad.open();
-        if (mv != null)
+        if (!mvad.getAbort())
         {
-          m.setBetreff(mv.getBetreff());
-          m.setTxt(mv.getTxt());
+          if (mv != null)
+          {
+            m.setBetreff(mv.getBetreff());
+            m.setTxt(mv.getTxt());
+          }
+          GUI.startView(MailDetailView.class.getName(), m);
         }
+      }
+      catch (OperationCanceledException oce)
+      {
+        throw oce;
       }
       catch (Exception e)
       {
@@ -59,6 +68,5 @@ public class MailDetailAction implements Action
             "Fehler bei der Erzeugung der neuen Mail", e);
       }
     }
-    GUI.startView(MailDetailView.class.getName(), m);
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -37,6 +37,8 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
   private MailVorlageControl control;
 
   private MailVorlage retval;
+  
+  private boolean abort = true;
 
   public MailVorlagenAuswahlDialog(MailVorlageControl control, int position)
   {
@@ -53,6 +55,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
     control.getMailVorlageTable().paint(parent);
 
     ButtonArea b = new ButtonArea();
+    
     b.addButton("Verwenden", new Action()
     {
 
@@ -67,10 +70,23 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
         {
           throw new ApplicationException(e.getMessage());
         }
+        abort = false;
         close();
       }
     }, null, true, "ok.png");
+    
     b.addButton("Ohne Mail-Vorlage", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        abort = false;
+        close();
+      }
+    }, null, true, "go-next.png");
+    
+    b.addButton("Abbrechen", new Action()
     {
 
       @Override
@@ -78,7 +94,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
       {
         close();
       }
-    }, null, true, "go-next.png");
+    }, null, false, "process-stop.png");
     b.paint(parent);
   }
 
@@ -86,6 +102,11 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
   protected MailVorlage getData() throws Exception
   {
     return retval;
+  }
+  
+  public boolean getAbort()
+  {
+    return abort;
   }
 
 }


### PR DESCRIPTION
- Beim Schließen des Fensters mit Schließen Icon wird trotzdem weiter gemacht wie bei Weiter Button. 
- Abbrechen mit ESC führt zu einer Fehlermeldung, sollte aber nicht sein. 
- Verbesserung: Abbrechen Button implementiert