### PR TITLE
Zusatzbeitrag Vorlage Dialog Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
+++ b/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.gui.parts.ZusatzbetragPart;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -42,30 +43,35 @@ public class ZusatzbetragVorlageAuswahlAction implements Action
     {
       ZusatzbetragVorlageDialog zbvd = new ZusatzbetragVorlageDialog();
       ZusatzbetragVorlage zbv = zbvd.open();
-      part.getBetrag().setValue(zbv.getBetrag());
-      part.getBuchungstext().setValue(zbv.getBuchungstext());
-      part.getEndedatum().setValue(zbv.getEndedatum());
-      part.getFaelligkeit().setValue(zbv.getFaelligkeit());
-      part.getIntervall().setValue(zbv.getIntervall());
-      part.getBuchungsart().setValue(zbv.getBuchungsart());
-      for (Object obj : part.getIntervall().getList())
+      if (zbv != null)
       {
-        IntervallZusatzzahlung ivz = (IntervallZusatzzahlung) obj;
-        if (zbv.getIntervall() == ivz.getKey())
+        part.getBetrag().setValue(zbv.getBetrag());
+        part.getBuchungstext().setValue(zbv.getBuchungstext());
+        part.getEndedatum().setValue(zbv.getEndedatum());
+        part.getFaelligkeit().setValue(zbv.getFaelligkeit());
+        part.getIntervall().setValue(zbv.getIntervall());
+        part.getBuchungsart().setValue(zbv.getBuchungsart());
+        for (Object obj : part.getIntervall().getList())
         {
-          part.getIntervall().setPreselected(ivz);
-          break;
+          IntervallZusatzzahlung ivz = (IntervallZusatzzahlung) obj;
+          if (zbv.getIntervall() == ivz.getKey())
+          {
+            part.getIntervall().setPreselected(ivz);
+            break;
+          }
         }
+        part.getStartdatum(false).setValue(zbv.getStartdatum());
       }
-      part.getStartdatum(false).setValue(zbv.getStartdatum());
     }
-    catch (OperationCanceledException e)
+    catch (OperationCanceledException oce)
     {
-      // Nothing to do
+      throw oce;
     }
     catch (Exception e)
     {
-      Logger.error("ZusatzbetragVorlageDialog kann nicht geöffnet werden", e);
+      Logger.error("Fehler", e);
+      GUI.getStatusBar().setErrorText(
+          "Fehler bei der Zusatzbeitrag Vorlagen Auswahl");
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
@@ -58,12 +58,23 @@ public class ZusatzbetragVorlageDialog
   {
     this.getZusatzbetragVorlagen().paint(parent);
     ButtonArea b = new ButtonArea();
+    b.addButton("Übernehmen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        selected = (ZusatzbetragVorlage) tab.getSelection();
+        close();
+      }
+    }, null, true, "ok.png");
     b.addButton("Abbrechen", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
-        throw new OperationCanceledException();
+        selected = null;
+        close();
       }
     }, null, false, "process-stop.png");
     b.paint(parent);


### PR DESCRIPTION
Schließen des Dialogs ZusatzbetragVorlageDialog führte zu einer Exception weil ein null Returnwert nicht abgeprüft wurde. Habe die Prüfung eingeführt.
Man konnte eine Vorlage nur durch doppel Klick übernehmen. Ich habe noch einen Übernehmen Button eingeführt. Das ist ja bei anderen Dialogen auch üblich.