### PR TITLE
Doppelklick auf Dokument zeigt das Dokument an

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Messaging.DokumentMessage;
+import de.jost_net.JVerein.gui.action.DokumentShowAction;
 import de.jost_net.JVerein.gui.menu.DokumentMenu;
 import de.jost_net.JVerein.gui.parts.DokumentPart;
 import de.jost_net.JVerein.gui.view.DokumentView;
@@ -200,7 +201,7 @@ public class DokumentControl extends AbstractControl
     docs.addFilter("referenz = ?", new Object[] { doc.getReferenz() });
     docs.setOrder("ORDER BY datum desc");
 
-    docsList = new TablePart(docs, null /* new KontoAction() */);
+    docsList = new TablePart(docs, new DokumentShowAction());
     docsList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     docsList.addColumn("Bemerkung", "bemerkung");


### PR DESCRIPTION
Wenn man das jameica.messaging Plugin aktiviert und im OpenJVerein die Dokumentenspeicherung in den Einstellungen aktiviert ist, konnte man die Dokumente nur per "Rechtsklich > anzeigen" öffnen. Dies geht nun per Doppelklick mit der linken Maustaste.

![feature-show-document-action](https://github.com/openjverein/jverein/assets/63780296/83cfa676-1a53-4670-bf3c-a111d8b582df)
