### PR TITLE
Fix MailDetailView ESC Handling

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/MailDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailDetailView.java
@@ -36,6 +36,7 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -84,6 +85,10 @@ public class MailDetailView extends AbstractView
         try
         {
           mead.open();
+        }
+        catch (OperationCanceledException oce)
+        {
+          throw oce;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Beim Abbrechen des Mail-Empfänger Dialogs mit ESC oder Close wird im JVerein-Mail View bei der Aktion "Hinzufügen" eine Fehlermeldung ausgegeben. Jetzt nicht mehr.