### PR TITLE
Fix MitgliedDetailAction

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.util.ApplicationException;
 
 public class MitgliedDetailAction implements Action
@@ -65,6 +66,10 @@ public class MitgliedDetailAction implements Action
           PersonenartDialog pad = new PersonenartDialog(
               PersonenartDialog.POSITION_CENTER);
           String pa = pad.open();
+          if (pa == null)
+          {
+            return;
+          }
           m.setPersonenart(pa);
         }
         else
@@ -80,6 +85,10 @@ public class MitgliedDetailAction implements Action
       {
         GUI.startView(new AdresseDetailView(), m);
       }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
     }
     catch (Exception e)
     {

--- a/src/de/jost_net/JVerein/gui/dialogs/PersonenartDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/PersonenartDialog.java
@@ -42,7 +42,7 @@ public class PersonenartDialog extends AbstractDialog<String>
     super(position);
 
     setTitle("Personenart");
-    setSize(450, 200);
+    setSize(400, 140);
   }
 
   @Override


### PR DESCRIPTION
Wenn in den Einstellungen "Juristische Personen erlaubt" ausgewählt ist und man ein neues Mtglied erzeugt erscheint der Personenart Dialog.
- Bei ESC und Abbruch Button erscheint eine Fehlermeldung.
- Beim Schliesen über das Schliesen Icon kommt es zu einer Stacktrace Ausgabe.
 
Der Fix behebt beides.