### PR TITLE
Fix AbrechnungSEPAControl.java

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -50,6 +50,7 @@ import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.hbci.gui.dialogs.PainVersionDialog;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -368,6 +369,14 @@ public class AbrechnungSEPAControl extends AbstractControl
       {
         PainVersionDialog d = new PainVersionDialog(org.kapott.hbci.sepa.SepaVersion.Type.PAIN_008);
         sepaVersion = (SepaVersion) d.open();
+        if (sepaVersion == null)
+        {
+          return;
+        }
+      }
+      catch (OperationCanceledException oce)
+      {
+        throw oce;
       }
       catch (Exception e)
       {


### PR DESCRIPTION
Fehler im Abrechnungslauf bei der SEPA Versionsabfrage.

- Bei ESC und Abbruch Button erscheint eine Fehlermeldung.
- Beim Schliesen über das Schliesen Icon wird mit der Ausgabe weiter gemacht und nicht Abgebrochen.
 
Der Fix behebt beides.