### PR TITLE
Update SammelüberweisungAuswahlDialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -108,6 +108,7 @@ import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -606,13 +607,17 @@ public class BuchungsControl extends AbstractControl
             refreshSplitbuchungen();
           }
         }
+        catch (OperationCanceledException oce)
+        {
+          throw oce;
+        }
         catch (Exception e)
         {
           e.printStackTrace();
         }
       }
 
-    }, null, false, "stock_navigator-shift-right.png");
+    }, null, false, "list.png");
     return sammelueberweisungButton;
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
@@ -63,6 +63,16 @@ public class SammelueberweisungAuswahlDialog
   {
     this.getSammelueberweisungen().paint(parent);
     ButtonArea b = new ButtonArea();
+    b.addButton("Übernehmen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        selected = (SepaSammelUeberweisung) sammelueberweisung.getSelection();
+        close();
+      }
+    }, null, true, "ok.png");
     b.addButton("Abbrechen", new Action()
     {
 


### PR DESCRIPTION
- Behandle OperationCanceledException  ohne e.printStackTrace.
- Ersetze Icon weil es das verwendete Icon nicht gibt.
- Übernehmen Button im Dialog eingeführt.

PS: Ich weiß nicht wie man Sammelüberweisungen erzeugt. Konnte den Button darum nicht wirklich testen.