### PR TITLE
Set max length of buchungsklasse bezeichnung to 255

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
@@ -84,7 +84,7 @@ public class BuchungsklasseControl extends AbstractControl
     {
       return bezeichnung;
     }
-    bezeichnung = new TextInput(getBuchungsklasse().getBezeichnung(), 100);
+    bezeichnung = new TextInput(getBuchungsklasse().getBezeichnung(), 255);
     return bezeichnung;
   }
 

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0428.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0428.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0428 extends AbstractDDLUpdate
+{
+  public Update0428(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(alterColumn("buchungsklasse",
+        new Column("bezeichnung", COLTYPE.VARCHAR, 255, null, false, false)));
+  }
+}


### PR DESCRIPTION
Update bezeichnung max length from 100 to 255 letters

Damit die Bezeichnungen der Datev Standardkontenrahmen ausgeschrieben werden können werden teilweise mehr als 100 Zeichen benötigt. Das Update setzt die maximal Länge auf 255 Zeichen.