### PR TITLE
NEW: Sent E-Mail from SpendenbescheinigungListeView

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
@@ -1,0 +1,106 @@
+/**********************************************************************
+* Copyright (c) by Alexander Dippe
+* This program is free software: you can redistribute it and/or modify it under the terms of the 
+* GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+* even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+* the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with this program.  If not, 
+* see <http://www.gnu.org/licenses/>.
+* 
+* https://openjverein.github.io
+**********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * E-Mail senden Formular anhand des zugewiesenen Spenders
+ */
+public class SpendenbescheinigungEmailAction implements Action
+{
+
+  /**
+   * Versenden einer E-Mail anhand der Spendenbescheinigung die in der View
+   * markiert ist.
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    Spendenbescheinigung[] spbArr = null;
+    if (context instanceof TablePart)
+    {
+      TablePart tp = (TablePart) context;
+      context = tp.getSelection();
+    }
+    if (context == null)
+    {
+      throw new ApplicationException("Keine Spendenbescheinigung ausgewählt.");
+    }
+    else if (context instanceof Spendenbescheinigung)
+    {
+      spbArr = new Spendenbescheinigung[] { (Spendenbescheinigung) context };
+    }
+    else if (context instanceof Spendenbescheinigung[])
+    {
+      spbArr = (Spendenbescheinigung[]) context;
+    }
+    else
+    {
+      return;
+    }
+    try
+    {
+      if (spbArr.length > 1)
+      {
+        String fehler = "Bitte nur eine Spendenbescheinigung auswählen.";
+        GUI.getStatusBar().setErrorText(fehler);
+        Logger.error(fehler);
+      }
+      else
+      {
+        for (Spendenbescheinigung spb : spbArr)
+        {
+          if (spb.isNewObject())
+          {
+            continue;
+          }
+          Mitglied member = spb.getMitglied();
+          if (member == null || member.getEmail() == null
+              || member.getEmail().length() == 0)
+          {
+            String fehler = "Kein Mitglied zugewiesen";
+            GUI.getStatusBar().setErrorText(fehler);
+            Logger.error(fehler);
+            continue;
+          }
+          if (member.getEmail() == null || member.getEmail().length() == 0)
+          {
+            String fehler = "Mitglied hat keine E-Mail Adresse";
+            GUI.getStatusBar().setErrorText(fehler);
+            Logger.error(fehler);
+            continue;
+          }
+          MitgliedMailSendenAction mailSendenAction = new MitgliedMailSendenAction();
+          mailSendenAction.handleAction(member);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler senden der Spendenbescheinigung.";
+      GUI.getStatusBar().setErrorText(fehler);
+      Logger.error(fehler, e);
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
@@ -37,7 +37,7 @@ public class SpendenbescheinigungEmailAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    Spendenbescheinigung[] spbArr = null;
+    Spendenbescheinigung spb = null;
     if (context instanceof TablePart)
     {
       TablePart tp = (TablePart) context;
@@ -49,11 +49,7 @@ public class SpendenbescheinigungEmailAction implements Action
     }
     else if (context instanceof Spendenbescheinigung)
     {
-      spbArr = new Spendenbescheinigung[] { (Spendenbescheinigung) context };
-    }
-    else if (context instanceof Spendenbescheinigung[])
-    {
-      spbArr = (Spendenbescheinigung[]) context;
+      spb = (Spendenbescheinigung) context;
     }
     else
     {
@@ -61,40 +57,22 @@ public class SpendenbescheinigungEmailAction implements Action
     }
     try
     {
-      if (spbArr.length > 1)
+      Mitglied member = spb.getMitglied();
+      if (member == null || member.getEmail() == null
+          || member.getEmail().length() == 0)
       {
-        String fehler = "Bitte nur eine Spendenbescheinigung auswählen.";
+        String fehler = "Kein Mitglied zugewiesen";
         GUI.getStatusBar().setErrorText(fehler);
         Logger.error(fehler);
       }
-      else
+      if (member.getEmail() == null || member.getEmail().length() == 0)
       {
-        for (Spendenbescheinigung spb : spbArr)
-        {
-          if (spb.isNewObject())
-          {
-            continue;
-          }
-          Mitglied member = spb.getMitglied();
-          if (member == null || member.getEmail() == null
-              || member.getEmail().length() == 0)
-          {
-            String fehler = "Kein Mitglied zugewiesen";
-            GUI.getStatusBar().setErrorText(fehler);
-            Logger.error(fehler);
-            continue;
-          }
-          if (member.getEmail() == null || member.getEmail().length() == 0)
-          {
-            String fehler = "Mitglied hat keine E-Mail Adresse";
-            GUI.getStatusBar().setErrorText(fehler);
-            Logger.error(fehler);
-            continue;
-          }
-          MitgliedMailSendenAction mailSendenAction = new MitgliedMailSendenAction();
-          mailSendenAction.handleAction(member);
-        }
+        String fehler = "Mitglied hat keine E-Mail Adresse";
+        GUI.getStatusBar().setErrorText(fehler);
+        Logger.error(fehler);
       }
+      MitgliedMailSendenAction mailSendenAction = new MitgliedMailSendenAction();
+      mailSendenAction.handleAction(member);
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
 import de.willuhn.jameica.gui.parts.ContextMenuItem;
 
@@ -42,7 +43,7 @@ public class SpendenbescheinigungMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Drucken (individuell)",
         new SpendenbescheinigungPrintAction(false), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem("E-Mail an Spender",
+    addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new DuplicateMenuItem("Als Vorlage für neue Spende",

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.menu;
 
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungDeleteAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungDuplizierenAction;
+import de.jost_net.JVerein.gui.action.SpendenbescheinigungEmailAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.jameica.gui.Action;
@@ -41,10 +42,13 @@ public class SpendenbescheinigungMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("Drucken (individuell)",
         new SpendenbescheinigungPrintAction(false), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedContextMenuItem("E-Mail an Spender",
+        new SpendenbescheinigungEmailAction(), "envelope-open.png"));
+    addItem(ContextMenuItem.SEPARATOR);
     addItem(new DuplicateMenuItem("Als Vorlage für neue Spende",
         new SpendenbescheinigungDuplizierenAction(), "edit-copy.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem("Löschen...",
+    addItem(new CheckedContextMenuItem("Löschen",
         new SpendenbescheinigungDeleteAction(), "user-trash-full.png"));
   }
 


### PR DESCRIPTION
Mit der Erweiterung kann man das E-Mail Formular aus der Spendenbescheinigung Liste View öffnen.
Die Spendenbescheinigung wird der E-Mail **nicht** als Anhang angefügt. Ich bin noch am überlegen ob das möglich/sinnvoll ist.

Rechtlich geht das wohl nur für Geldzuwendungen und es müssen die Voraussetzungen für maschinell erstellte Spendenbescheinigungen erfüllt sein (entsprechend R 10b.1 Abs. 4 EStR).

Folgende Restriktionen sind umgesetzt:
1. Es ist eine Spendenbescheinigung ausgewählt
2. Der Buchung der Spendenbescheinigung ist ein Mitglied/Adressat zugewiesen
3. Das Mitglied/Adressat hat eine E-Mail Adresse hinterlegt

Zu 1:
<img width="1096" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/dfa2254a-eaa0-46eb-9f1c-4bbedaf24434">

Zu 2:
<img width="1003" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/363c1988-a969-4076-b584-c25c6feae0f4">