### PR TITLE
Abrechnungslauf ohne SEPA File Abfrage

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -434,7 +434,7 @@ public class AbrechnungSEPAControl extends AbstractControl
             if (abupar.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI || 
                 abupar.abbuchungsausgabe == Abrechnungsausgabe.KEINE_DATEI)
             {
-              GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt");
+              GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt" + abupar.getText());
             } else {
               GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt, Hibiscus-Lastschrift geschrieben.");
             }

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -262,7 +262,8 @@ public class AbrechnungSEPAControl extends AbstractControl
     Abrechnungsausgabe aus = Abrechnungsausgabe.getByKey(settings
         .getInt("abrechnungsausgabe", Abrechnungsausgabe.SEPA_DATEI.getKey()));
     if (aus != Abrechnungsausgabe.SEPA_DATEI
-        && aus != Abrechnungsausgabe.HIBISCUS)
+        && aus != Abrechnungsausgabe.HIBISCUS
+        && aus != Abrechnungsausgabe.KEINE_DATEI)
     {
       aus = Abrechnungsausgabe.HIBISCUS;
     }
@@ -430,9 +431,10 @@ public class AbrechnungSEPAControl extends AbstractControl
 
             monitor.setPercentComplete(100);
             monitor.setStatus(ProgressMonitor.STATUS_DONE);
-            if (abupar.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI)
+            if (abupar.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI || 
+                abupar.abbuchungsausgabe == Abrechnungsausgabe.KEINE_DATEI)
             {
-              GUI.getStatusBar().setSuccessText(String.format("Abrechnung durchgeführt, SEPA-Datei %s geschrieben.", abupar.sepafileRCUR.getAbsolutePath()));
+              GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt");
             } else {
               GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt, Hibiscus-Lastschrift geschrieben.");
             }
@@ -451,9 +453,16 @@ public class AbrechnungSEPAControl extends AbstractControl
             {
               Logger.error(String.format("error while creating %s", abupar.sepafileRCUR.getAbsolutePath()), e);
               ae = new ApplicationException(String.format("Fehler beim Erstellen der Abbuchungsdatei: %s", abupar.sepafileRCUR.getAbsolutePath()), e);
-            } else {
+            } 
+            else if (abupar.abbuchungsausgabe == Abrechnungsausgabe.HIBISCUS)
+            {
               Logger.error("error while creating debit in Hibiscus", e);
               ae = new ApplicationException("Fehler beim Erstellen der Hibiscus-Lastschrift", e);
+            } 
+            else
+            {
+              Logger.error("error during operation", e);
+              ae = new ApplicationException("Fehler beim Abrechnungslauf", e);
             }
             GUI.getStatusBar().setErrorText(ae.getMessage());
             throw ae;

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -431,13 +431,8 @@ public class AbrechnungSEPAControl extends AbstractControl
 
             monitor.setPercentComplete(100);
             monitor.setStatus(ProgressMonitor.STATUS_DONE);
-            if (abupar.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI || 
-                abupar.abbuchungsausgabe == Abrechnungsausgabe.KEINE_DATEI)
-            {
-              GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt" + abupar.getText());
-            } else {
-              GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt, Hibiscus-Lastschrift geschrieben.");
-            }
+            GUI.getStatusBar().setSuccessText("Abrechnung durchgeführt" + abupar.getText());
+
           }
           catch (ApplicationException ae)
           {

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -40,7 +40,7 @@ import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.io.Ct1Ueberweisung;
 import de.jost_net.JVerein.io.FormularAufbereitung;
 import de.jost_net.JVerein.io.MailSender;
-import de.jost_net.JVerein.keys.Abrechnungsausgabe;
+import de.jost_net.JVerein.keys.Ct1Ausgabe;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Formular;
@@ -204,14 +204,14 @@ public class PreNotificationControl extends AbstractControl
     {
       return ct1ausgabe;
     }
-    Abrechnungsausgabe aus = Abrechnungsausgabe.getByKey(
-        settings.getInt("ct1ausgabe", Abrechnungsausgabe.SEPA_DATEI.getKey()));
-    if (aus != Abrechnungsausgabe.SEPA_DATEI
-        && aus != Abrechnungsausgabe.HIBISCUS)
+    Ct1Ausgabe aus = Ct1Ausgabe.getByKey(
+        settings.getInt("ct1ausgabe", Ct1Ausgabe.SEPA_DATEI.getKey()));
+    if (aus != Ct1Ausgabe.SEPA_DATEI
+        && aus != Ct1Ausgabe.HIBISCUS)
     {
-      aus = Abrechnungsausgabe.HIBISCUS;
+      aus = Ct1Ausgabe.HIBISCUS;
     }
-    ct1ausgabe = new SelectInput(Abrechnungsausgabe.values(), aus);
+    ct1ausgabe = new SelectInput(Ct1Ausgabe.values(), aus);
     ct1ausgabe.setName("Ausgabe");
     return ct1ausgabe;
   }
@@ -281,7 +281,7 @@ public class PreNotificationControl extends AbstractControl
       {
         try
         {
-          Abrechnungsausgabe aa = (Abrechnungsausgabe) ct1ausgabe.getValue();
+          Ct1Ausgabe aa = (Ct1Ausgabe) ct1ausgabe.getValue();
           settings.setAttribute("ct1ausgabe", aa.getKey());
           if (ausfuehrungsdatum.getValue() == null)
           {
@@ -408,9 +408,9 @@ public class PreNotificationControl extends AbstractControl
   {
     Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
     File file = null;
-    Abrechnungsausgabe aa = Abrechnungsausgabe.getByKey(
-        settings.getInt("ct1ausgabe", Abrechnungsausgabe.SEPA_DATEI.getKey()));
-    if (aa == Abrechnungsausgabe.SEPA_DATEI)
+    Ct1Ausgabe aa = Ct1Ausgabe.getByKey(
+        settings.getInt("ct1ausgabe", Ct1Ausgabe.SEPA_DATEI.getKey()));
+    if (aa == Ct1Ausgabe.SEPA_DATEI)
     {
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
       fd.setText("SEPA-Ausgabedatei wählen.");
@@ -439,8 +439,8 @@ public class PreNotificationControl extends AbstractControl
     }
     String faelligkeitsdatum = settings.getString("faelligkeitsdatum", null);
     Date faell = Datum.toDate(faelligkeitsdatum);
-    Abrechnungsausgabe ct1ausgabe = Abrechnungsausgabe.getByKey(
-        settings.getInt("ct1ausgabe", Abrechnungsausgabe.SEPA_DATEI.getKey()));
+    Ct1Ausgabe ct1ausgabe = Ct1Ausgabe.getByKey(
+        settings.getInt("ct1ausgabe", Ct1Ausgabe.SEPA_DATEI.getKey()));
     String verwendungszweck = settings.getString("verwendungszweck", "");
     Ct1Ueberweisung ct1ueberweisung = new Ct1Ueberweisung();
     int anzahl = ct1ueberweisung.write(abrl, file, faell, ct1ausgabe,

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -155,6 +155,7 @@ public class AbrechnungSEPA
     }
 
     ArrayList<Zahler> z = lastschrift.getZahler();
+    // Wenn keine Buchungen vorhanden sind, wird kein File erzeugt.
     if ((param.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI) && !z.isEmpty())
     {
       writeSepaFile(param, lastschrift, z);
@@ -248,8 +249,13 @@ public class AbrechnungSEPA
     }
     if (param.abbuchungsausgabe == Abrechnungsausgabe.HIBISCUS)
     {
-      buchenHibiscus(param, z);
-      monitor.log("Hibiscus-Lastschrift erzeugt.");
+      // Wenn keine Buchungen vorhanden sind, wird nichts an Hibiscus übergeben.
+      if (z.size() != 0)
+      {
+        buchenHibiscus(param, z);
+        monitor.log("Hibiscus-Lastschrift erzeugt.");
+        param.setText(String.format(", Hibiscus-Lastschrift erzeugt."));
+      }
     }
     if (param.pdffileRCUR != null)
     {
@@ -664,9 +670,6 @@ public class AbrechnungSEPA
 
   private void writeSepaFile(AbrechnungSEPAParam param, Basislastschrift lastschrift, ArrayList<Zahler> alle_zahler) throws Exception
   {
-    if (alle_zahler.isEmpty()) {
-      return;
-    }
     Properties ls_properties = new Properties();
     ls_properties.setProperty("src.bic", lastschrift.getBIC());
     ls_properties.setProperty("src.iban", lastschrift.getIBAN());
@@ -707,11 +710,6 @@ public class AbrechnungSEPA
   private void buchenHibiscus(AbrechnungSEPAParam param, ArrayList<Zahler> z)
       throws ApplicationException
   {
-    if (z.size() == 0)
-    {
-      // Wenn keine Buchungen vorhanden sind, wird nichts an Hibiscus übergeben.
-      return;
-    }
     try
     {
       SepaLastschrift[] lastschriften = new SepaLastschrift[z.size()];

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.io;
 
+import java.math.RoundingMode;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -293,17 +294,17 @@ public class AbrechnungSEPA
         {
           list.addFilter(
               "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
-              new Object[] { new Integer(Zahlungsrhythmus.HALBJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.MONATLICH) });
+              new Object[] { Integer.valueOf(Zahlungsrhythmus.HALBJAEHRLICH),
+                  Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH),
+                  Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
         }
         if (param.abbuchungsmodus == Abrechnungsmodi.JAVIMO)
         {
           list.addFilter(
               "(zahlungsrhytmus = ? or zahlungsrhytmus = ? or zahlungsrhytmus = ?)",
-              new Object[] { new Integer(Zahlungsrhythmus.JAEHRLICH),
-                  new Integer(Zahlungsrhythmus.VIERTELJAEHRLICH),
-                  new Integer(Zahlungsrhythmus.MONATLICH) });
+              new Object[] { Integer.valueOf(Zahlungsrhythmus.JAEHRLICH),
+                  Integer.valueOf(Zahlungsrhythmus.VIERTELJAEHRLICH),
+                  Integer.valueOf(Zahlungsrhythmus.MONATLICH) });
         }
         if (param.abbuchungsmodus == Abrechnungsmodi.VIMO)
         {
@@ -443,7 +444,7 @@ public class AbrechnungSEPA
         zahler.setPersonId(m.getID());
         zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
         zahler.setBetrag(
-            new BigDecimal(betr).setScale(2, BigDecimal.ROUND_HALF_UP));
+            new BigDecimal(betr).setScale(2, RoundingMode.HALF_UP));
         new BIC(m.getBic()); // Prüfung des BIC
         zahler.setBic(m.getBic());
         new IBAN(m.getIban()); // Prüfung der IBAN
@@ -538,7 +539,7 @@ public class AbrechnungSEPA
             zahler.setPersonId(m.getID());
             zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
             zahler.setBetrag(new BigDecimal(z.getBetrag()).setScale(2,
-                BigDecimal.ROUND_HALF_UP));
+                RoundingMode.HALF_UP));
             new BIC(m.getBic());
             new IBAN(m.getIban());
             zahler.setBic(m.getBic());
@@ -615,7 +616,7 @@ public class AbrechnungSEPA
         zahler.setPersonId(kt.getID());
         zahler.setPersonTyp(JVereinZahlerTyp.KURSTEILNEHMER);
         zahler.setBetrag(new BigDecimal(kt.getBetrag()).setScale(2,
-            BigDecimal.ROUND_HALF_UP));
+            RoundingMode.HALF_UP));
         new BIC(kt.getBic());
         new IBAN(kt.getIban());
         zahler.setBic(kt.getBic());
@@ -838,7 +839,7 @@ public class AbrechnungSEPA
       }
       if (buchungsart != null)
       {
-        buchung.setBuchungsart(new Long(buchungsart.getID()));
+        buchung.setBuchungsart(Long.valueOf(buchungsart.getID()));
       }
       buchung.store();
     }

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -159,6 +159,7 @@ public class AbrechnungSEPA
     {
       writeSepaFile(param, lastschrift, z);
       monitor.log(String.format("SEPA-Datei %s geschrieben.", param.sepafileRCUR.getAbsolutePath()));
+      param.setText(String.format(", SEPA-Datei %s geschrieben.", param.sepafileRCUR.getAbsolutePath()));
     }
 
     BigDecimal summemitgliedskonto = new BigDecimal("0");

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -154,7 +154,7 @@ public class AbrechnungSEPA
     }
 
     ArrayList<Zahler> z = lastschrift.getZahler();
-    if (param.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI)
+    if ((param.abbuchungsausgabe == Abrechnungsausgabe.SEPA_DATEI) && !z.isEmpty())
     {
       writeSepaFile(param, lastschrift, z);
       monitor.log(String.format("SEPA-Datei %s geschrieben.", param.sepafileRCUR.getAbsolutePath()));

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
@@ -70,6 +70,8 @@ public class AbrechnungSEPAParam
   public final DBService service;
 
   public Konto konto;
+  
+  private String text = "";
 
   public AbrechnungSEPAParam(AbrechnungSEPAControl ac, File sepafileRCUR, SepaVersion sepaVersion, String pdffileRCUR)
       throws ApplicationException, RemoteException
@@ -143,6 +145,15 @@ public class AbrechnungSEPAParam
     {
       service = null;
     }
-
+  }
+  
+  public String getText()
+  {
+    return text;
+  }
+  
+  public void setText(String in)
+  {
+    text = in;
   }
 }

--- a/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
+++ b/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
@@ -72,6 +72,9 @@ public class Ct1Ueberweisung
 
       case HIBISCUS:
         return hibiscusausgabe(abrl, file, faell, ct1ausgabe, verwendungszweck);
+        
+      case KEINE_DATEI:
+        return 0;
 
     }
     return -1;

--- a/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
+++ b/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
@@ -34,7 +34,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.LastschriftMap;
 import de.jost_net.JVerein.Variable.VarTools;
-import de.jost_net.JVerein.keys.Abrechnungsausgabe;
+import de.jost_net.JVerein.keys.Ct1Ausgabe;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.util.JVDateFormatDATETIME;
@@ -62,7 +62,7 @@ public class Ct1Ueberweisung
   }
 
   public int write(Abrechnungslauf abrl, File file, Date faell,
-      Abrechnungsausgabe ct1ausgabe, String verwendungszweck) throws Exception
+      Ct1Ausgabe ct1ausgabe, String verwendungszweck) throws Exception
   {
     Velocity.init();
     switch (ct1ausgabe)
@@ -72,16 +72,12 @@ public class Ct1Ueberweisung
 
       case HIBISCUS:
         return hibiscusausgabe(abrl, file, faell, ct1ausgabe, verwendungszweck);
-        
-      case KEINE_DATEI:
-        return 0;
-
     }
     return -1;
   }
 
   private int dateiausgabe(Abrechnungslauf abrl, File file, Date faell,
-      Abrechnungsausgabe ct1ausgabe, String verwendungszweck) throws Exception
+      Ct1Ausgabe ct1ausgabe, String verwendungszweck) throws Exception
   {
     ueb = new Ueberweisung();
     ueb.setAusfuehrungsdatum(faell);
@@ -110,7 +106,7 @@ public class Ct1Ueberweisung
   }
 
   private int hibiscusausgabe(Abrechnungslauf abrl, File file, Date faell,
-      Abrechnungsausgabe ct1ausgabe, String verwendungszweck) throws Exception
+      Ct1Ausgabe ct1ausgabe, String verwendungszweck) throws Exception
   {
     try
     {

--- a/src/de/jost_net/JVerein/keys/Abrechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/keys/Abrechnungsausgabe.java
@@ -22,7 +22,7 @@ package de.jost_net.JVerein.keys;
 public enum Abrechnungsausgabe
 {
 
-  SEPA_DATEI(1, "Datei"), HIBISCUS(2, "Hibiscus");
+  SEPA_DATEI(1, "Datei"), HIBISCUS(2, "Hibiscus"), KEINE_DATEI(3, "Keine");
   private final String text;
 
   private final int key;

--- a/src/de/jost_net/JVerein/keys/Ct1Ausgabe.java
+++ b/src/de/jost_net/JVerein/keys/Ct1Ausgabe.java
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.keys;
+
+/**
+ * Abrechnungsausgabe
+ */
+public enum Ct1Ausgabe
+{
+
+  SEPA_DATEI(1, "Datei"), HIBISCUS(2, "Hibiscus");
+  private final String text;
+
+  private final int key;
+
+  Ct1Ausgabe(int key, String text)
+  {
+    this.key = key;
+    this.text = text;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public String getText()
+  {
+    return text;
+  }
+
+  public static Ct1Ausgabe getByKey(int key)
+  {
+    for (Ct1Ausgabe ara : Ct1Ausgabe.values())
+    {
+      if (ara.getKey() == key)
+      {
+        return ara;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return getText();
+  }
+}


### PR DESCRIPTION
Erlaube einen Abrechnungslauf ohne eine XML Datei zu generieren.

Ich habe Abrechnungsläufe wo alle Mitglieder per Überweisung bezahlen. Da brauche ich die Abfrage nach dem Dateinamen für die XML Datei nicht. Ich erlaube darum als Abrechnungsausgabe neben Datei und Hibiscus auch "Keine". Damit wird der Lauf durchgeführt aber kein XML erzeugt.
Meine erste Idee war die Abfrage nach dem Filenamen erst zu machen wenn bekannt ist ob eine SEPA Lastschrift enthalten ist oder nicht. Da die Berechnung aber in eine Hintergrund Task stattfindet dachte ich, dass man da wohl keine GUI Abfrage einfügen sollte.
Da ich weiß, dass keine Lastschriften enthalten sind klappt das auch mit der expliziten Auswahl.
Damit wäre es auch möglich kein XML zu erzeugen obwohl es SEPA Lastschriften gibt. Das wäre der Fall wenn jemand den Lauf machen will aber die Lastschriften anderweitig generiert z.B. anderes Tool.
Da das Feature sonst nicht stört sollte es so ok sein.