### PR TITLE
Feature gegenbuchung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -16,10 +16,13 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.dialogs.KontoAuswahlDialog;
 import de.jost_net.JVerein.gui.view.BuchungView;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Konto;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.system.OperationCanceledException;
@@ -34,18 +37,35 @@ public class BuchungGegenbuchungAction implements Action
  
     if (context == null || !(context instanceof Buchung))
     {
-      throw new ApplicationException("keine Buchung ausgewählt");
+      throw new ApplicationException("Keine Buchung ausgewählt");
     }
     Buchung b = null;
-    Konto konto;
+    Konto konto = null;
+    Konto konto1 = null;
     try
     {
-      KontoAuswahlDialog d = new KontoAuswahlDialog(
-          KontoAuswahlDialog.POSITION_CENTER, false, false, true);
-      konto = (Konto) d.open();
+      final DBService service = Einstellungen.getDBService();
+      DBIterator<Konto> konten = service.createList(Konto.class);
+      b = (Buchung) context;
+      while (konten.hasNext())
+      {
+        konto1 = konten.next();
+        if ((konto1.getBuchungsart() != null) && (b.getBuchungsart() != null))
+        {
+          if (konto1.getBuchungsartId() == b.getBuchungsartId())
+          {
+            konto = konto1;
+          }
+        }
+      }
+      if (konto == null)
+      {
+        KontoAuswahlDialog d = new KontoAuswahlDialog(
+            KontoAuswahlDialog.POSITION_CENTER, false, false, true);
+        konto = (Konto) d.open();
+      }
       if (konto != null)
       {
-        b = (Buchung) context;
         b.setID(null);
         b.setSplitId(null);
         b.setKonto(konto);

--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -55,6 +55,7 @@ public class BuchungGegenbuchungAction implements Action
           if (konto1.getBuchungsartId() == b.getBuchungsartId())
           {
             konto = konto1;
+            break;
           }
         }
       }

--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.dialogs.KontoAuswahlDialog;
+import de.jost_net.JVerein.gui.view.BuchungView;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Konto;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
+
+public class BuchungGegenbuchungAction implements Action
+{
+  
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+ 
+    if (context == null || !(context instanceof Buchung))
+    {
+      throw new ApplicationException("keine Buchung ausgewählt");
+    }
+    Buchung b = null;
+    Konto konto;
+    try
+    {
+      KontoAuswahlDialog d = new KontoAuswahlDialog(
+          KontoAuswahlDialog.POSITION_CENTER, false, false, true);
+      konto = (Konto) d.open();
+      if (konto != null)
+      {
+        b = (Buchung) context;
+        b.setID(null);
+        b.setSplitId(null);
+        b.setKonto(konto);
+        b.setBetrag(-b.getBetrag());
+        b.setAuszugsnummer(null);
+        b.setBlattnummer(null);
+        GUI.startView(new BuchungView(), b);
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (Exception e)
+    {
+      GUI.getStatusBar().setErrorText("Fehler bei der Gegenbuchung.");
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -18,10 +18,12 @@ package de.jost_net.JVerein.gui.menu;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungDeleteAction;
 import de.jost_net.JVerein.gui.action.BuchungDuplizierenAction;
+import de.jost_net.JVerein.gui.action.BuchungGegenbuchungAction;
 import de.jost_net.JVerein.gui.action.BuchungKontoauszugZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungMitgliedskontoZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungNeuAction;
@@ -29,6 +31,9 @@ import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
@@ -52,6 +57,8 @@ public class BuchungMenu extends ContextMenu
     addItem(new CheckedSingleContextMenuItem("Bearbeiten",
         new BuchungAction(false), "text-x-generic.png"));
     addItem(new SingleBuchungItem("Duplizieren", new BuchungDuplizierenAction(),
+        "edit-copy.png"));
+    addItem(new SingleGegenBuchungItem("Gegenbuchung", new BuchungGegenbuchungAction(),
         "edit-copy.png"));
     addItem(new SingleBuchungItem("Splitbuchung", new SplitBuchungAction(),
         "edit-copy.png"));
@@ -128,4 +135,37 @@ public class BuchungMenu extends ContextMenu
       return false;
     }
   }
+    
+  private static class SingleGegenBuchungItem extends CheckedSingleContextMenuItem
+  {
+    private SingleGegenBuchungItem(String text, Action action, String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      if (o instanceof Buchung)
+      {
+        Buchung b = (Buchung) o;
+        try
+        {
+          if ((b.getSplitId() != null) && (b.getSplitTyp() != SplitbuchungTyp.SPLIT))
+          {
+            return false;
+          }
+          Buchungsart bua = (Buchungsart) Einstellungen.getDBService().createObject(Buchungsart.class,
+              b.getBuchungsartId() + "");
+          return bua.getArt() == ArtBuchungsart.UMBUCHUNG;
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+      }
+      return false;
+    }
+  }
+  
 }

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -18,7 +18,6 @@ package de.jost_net.JVerein.gui.menu;
 
 import java.rmi.RemoteException;
 
-import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungDeleteAction;
@@ -31,7 +30,6 @@ import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.rmi.Buchung;
-import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.willuhn.jameica.gui.Action;
@@ -155,9 +153,10 @@ public class BuchungMenu extends ContextMenu
           {
             return false;
           }
-          Buchungsart bua = (Buchungsart) Einstellungen.getDBService().createObject(Buchungsart.class,
-              b.getBuchungsartId() + "");
-          return bua.getArt() == ArtBuchungsart.UMBUCHUNG;
+          if (b.getBuchungsart() != null)
+          {
+            return b.getBuchungsart().getArt() == ArtBuchungsart.UMBUCHUNG;
+          }
         }
         catch (RemoteException e)
         {

--- a/src/de/jost_net/JVerein/gui/view/KontoView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoView.java
@@ -40,6 +40,7 @@ public class KontoView extends AbstractView
     group.addLabelPair("Konto-Eröffnung", control.getEroeffnung());
     group.addLabelPair("Konto-Auflösung", control.getAufloesung());
     group.addLabelPair("Hibiscus-Konto", control.getHibiscusId());
+    group.addLabelPair("Gegenbuchung-Buchungsart", control.getBuchungsart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/rmi/Konto.java
+++ b/src/de/jost_net/JVerein/rmi/Konto.java
@@ -44,6 +44,12 @@ public interface Konto extends DBObject
   public Integer getHibiscusId() throws RemoteException;
 
   public void setHibiscusId(Integer HibiscusId) throws RemoteException;
+  
+  public Buchungsart getBuchungsart() throws RemoteException;
+
+  public Long getBuchungsartId() throws RemoteException;
+
+  public void setBuchungsart(Long buchungsart) throws RemoteException;
 
   public DBIterator<Konto> getKontenEinesJahres(Geschaeftsjahr gj)
       throws RemoteException;

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -198,7 +198,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     }
     if (o instanceof Integer)
     {
-      l = new Long((Integer) o);
+      l = Long.valueOf(((Integer) o).longValue());
     }
     if (l == null)
     {
@@ -215,7 +215,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new RemoteException("Konto fehlt!");
     }
-    setAttribute("konto", new Long(konto.getID()));
+    setAttribute("konto", Long.valueOf(konto.getID()));
   }
 
   @Override
@@ -278,7 +278,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public void setBetrag(double d) throws RemoteException
   {
-    setAttribute("betrag", new Double(d));
+    setAttribute("betrag", Double.valueOf(d));
   }
 
   @Override
@@ -381,7 +381,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   public void setAbrechnungslauf(Abrechnungslauf abrechnungslauf)
       throws RemoteException
   {
-    setAttribute("abrechnungslauf", new Long(abrechnungslauf.getID()));
+    setAttribute("abrechnungslauf", Long.valueOf(abrechnungslauf.getID()));
   }
 
   @Override
@@ -408,7 +408,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     if (mitgliedskonto != null)
     {
-      setAttribute("mitgliedskonto", new Long(mitgliedskonto.getID()));
+      setAttribute("mitgliedskonto", Long.valueOf(mitgliedskonto.getID()));
     }
     else
     {
@@ -439,7 +439,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     if (projekt != null)
     {
-      setAttribute("projekt", new Long(projekt.getID()));
+      setAttribute("projekt", Long.valueOf(projekt.getID()));
     }
     else
     {
@@ -570,7 +570,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       try
       {
-        return new Long(getID());
+        return Long.valueOf(getID());
       }
       catch (Exception e)
       {

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0429.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0429.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0429 extends AbstractDDLUpdate
+{
+  public Update0429(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("konto", new Column("buchungsart",
+        COLTYPE.BIGINT, 0, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/KontoImpl.java
+++ b/src/de/jost_net/JVerein/server/KontoImpl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.datasource.db.AbstractDBObject;
@@ -203,5 +204,39 @@ public class KontoImpl extends AbstractDBObject implements Konto
   {
     super.store();
     Cache.get(Konto.class, false).put(this); // Cache aktualisieren
+  }
+  
+  @Override
+  public Buchungsart getBuchungsart() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsart");
+    if (l == null)
+    {
+      return null; // Keine Buchungsart zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsart.class, true);
+    return (Buchungsart) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsartId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsart().getID());
+  }
+
+  @Override
+  public void setBuchungsart(Long buchungsart) throws RemoteException
+  {
+    setAttribute("buchungsart", buchungsart);
+  }
+  
+  @Override
+  public Object getAttribute(String fieldName) throws RemoteException
+  {
+    if ("buchungsart".equals(fieldName))
+      return getBuchungsart();
+
+    return super.getAttribute(fieldName);
   }
 }


### PR DESCRIPTION
Das Feature soll das Erstellen einer Gegenbuchung bei Umbuchungen in ein offline Konto vereinfachen.
Bei einer Umbuchung in ein offline Konto erhält man den Buchungseintrag nicht über Hibiscus und muss ihn deshalb manuell erzeugen.
Bisher benutze ich die Copy Funktion, lösche dann Kontoauszugsdaten, invertiere den Betrag und setzte das andere Konto. Das geht aber nicht immer weil die Copy Funktion nicht bei Elementen einer Splitbuchung existiert. Das ist aber nötig, z.B. Abbuchung eines Darlehens. Diese splitte ich in Zins und Tilgung. Die Tilgung braucht dann eine Gegenbuchung im offline Darlehenskonto.

Das neue Feature schaut jetzt so aus:

- Es gibt einen neuen Menüpunkt Gegenbuchung in der Buchungsliste
![Screenshot_1](https://github.com/openjverein/jverein/assets/126261667/780da2e0-4f6c-40c6-8e23-ad4ead66dd61)
- Der Eintrag ist freigeschaltet wenn die Buchung eine Buchungsart hat und diese von der Art Umbuchung ist. Auch bei Splitbuchung Elementen ist es erlaubt.
- Selektiert man den Menüpunkt erscheint ein Dialog zur Auswahl des Gegenkontos.
- Anschließend wird die neue Buchung angezeigt. Das Gegenkonto ist gesetzt, die Kontoauszugsdaten gelöscht, der Betrag invertiert und die Buchung von der Splitbuchung gelöst.
- Um die Auswahl der Gegenkontos zu automatisieren habe ich beim Konto ein neues Attribut für eine Buchungsart eingeführt.
![Screenshot_2](https://github.com/openjverein/jverein/assets/126261667/5dab7a9e-9fec-47fd-bb5b-43feabcfe73a)
- Ist bei einem Konto eine Buchungsart gesetzt und sie stimmt mit der Buchungsart der selektierten Buchung überein, wird dieses Konto automatisch übernommen und es erscheint kein Kontoauswahl Dialog
- Man kann beim Konto nur Buchungsarten der Art Umbuchung setzen
- Auch kann man eine Buchungsart nur bei einem Konto setzen. Bei weiteren Konten werden bereits genutzte Buchungsarten nicht angeboten.

Ich hoffe, das können auch noch Andere brauchen.