### PR TITLE
Fix Sort und Formatierung für Buchungsart Input

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -654,17 +654,7 @@ public class BuchungsControl extends AbstractControl
     {
       return suchbuchungsart;
     }
-    DBIterator<Buchungsart> list = Einstellungen.getDBService()
-        .createList(Buchungsart.class);
-    if (Einstellungen.getEinstellung()
-        .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
-    {
-      list.setOrder("ORDER BY nummer");
-    }
-    else
-    {
-      list.setOrder("ORDER BY bezeichnung");
-    }
+
     ArrayList<Buchungsart> liste = new ArrayList<>();
     Buchungsart b1 = (Buchungsart) Einstellungen.getDBService()
         .createObject(Buchungsart.class, null);
@@ -687,11 +677,18 @@ public class BuchungsControl extends AbstractControl
       Date db = cal.getTime();
       cal.add(Calendar.MONTH, - unterdrueckunglaenge);
       Date dv = cal.getTime();
-      String sql = "SELECT buchungsart.* from buchungsart, buchung ";
+      String sql = "SELECT DISTINCT buchungsart.* from buchungsart, buchung ";
       sql += "WHERE buchung.buchungsart = buchungsart.id ";
       sql += "AND buchung.datum >= ? AND buchung.datum <= ? ";
-      sql += "ORDER BY nummer";
-      Logger.debug(sql);
+      if (Einstellungen.getEinstellung()
+          .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
+      {
+        sql += "ORDER BY nummer";
+      }
+      else
+      {
+        sql += "ORDER BY bezeichnung";
+      }
       ResultSetExtractor rs = new ResultSetExtractor()
       {
         @Override
@@ -710,24 +707,25 @@ public class BuchungsControl extends AbstractControl
       ArrayList<Buchungsart> ergebnis = (ArrayList<Buchungsart>) service.execute(sql,
           new Object[] { dv, db }, rs);
       int size = ergebnis.size();
-      Buchungsart bua;
       for (int i = 0; i < size; i++)
       {
-        bua = ergebnis.get(i);
-        liste.add(bua);
-        for (int j = i + 1; j < size; j++)
-        {
-          if (bua.getNummer() == ergebnis.get(j).getNummer())
-          {
-            ergebnis.remove(j);
-            j--;
-            size--;
-          }
-        }
+         liste.add(ergebnis.get(i));
       }
     }
     else
     {
+      DBIterator<Buchungsart> list = Einstellungen.getDBService()
+          .createList(Buchungsart.class);
+      if (Einstellungen.getEinstellung()
+          .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
+      {
+        list.setOrder("ORDER BY nummer");
+      }
+      else
+      {
+        list.setOrder("ORDER BY bezeichnung");
+      }
+      
       while (list.hasNext())
       {
         liste.add(list.next());
@@ -736,7 +734,8 @@ public class BuchungsControl extends AbstractControl
     
     int bwert = settings.getInt(BUCHUNGSART, -2);
     Buchungsart b = null;
-    for (int i = 0; i < liste.size(); i++)
+    int size = liste.size();
+    for (int i = 0; i < size; i++)
     {
       if (liste.get(i).getNummer() == bwert)
       {

--- a/src/de/jost_net/JVerein/gui/input/BuchungsartSearchInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsartSearchInput.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
@@ -61,7 +62,7 @@ public class BuchungsartSearchInput extends SearchInput
         Date db = cal.getTime();
         cal.add(Calendar.MONTH, - unterdrueckunglaenge);
         Date dv = cal.getTime();
-        String sql = "SELECT buchungsart.* from buchungsart, buchung ";
+        String sql = "SELECT DISTINCT buchungsart.* from buchungsart, buchung ";
         sql += "WHERE buchung.buchungsart = buchungsart.id ";
         sql += "AND buchung.datum >= ? AND buchung.datum <= ? ";
         if (text != null)
@@ -69,8 +70,15 @@ public class BuchungsartSearchInput extends SearchInput
           text = "%" + text.toUpperCase() + "%";
           sql += "AND (UPPER(buchungsart.bezeichnung) like ? or buchungsart.nummer like ?) ";
         }
-        sql += "ORDER BY nummer";
-        Logger.debug(sql);
+        if (Einstellungen.getEinstellung()
+            .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
+        {
+          sql += "ORDER BY nummer";
+        }
+        else
+        {
+          sql += "ORDER BY bezeichnung";
+        }
         ResultSetExtractor rs = new ResultSetExtractor()
         {
           @Override
@@ -86,37 +94,20 @@ public class BuchungsartSearchInput extends SearchInput
           }
         };
 
-        ArrayList<Buchungsart> ergebnis;
         if (text != null)
         {
           @SuppressWarnings("unchecked")
           ArrayList<Buchungsart> result = (ArrayList<Buchungsart>) service.execute(sql,
               new Object[] { dv, db, text, text }, rs);
-          ergebnis = result;
+          return result;
         }
         else
         {
           @SuppressWarnings("unchecked")
           ArrayList<Buchungsart> result = (ArrayList<Buchungsart>) service.execute(sql,
               new Object[] { dv, db }, rs);
-          ergebnis = result;
+          return result;
         }
-        int size = ergebnis.size();
-        Buchungsart bua;
-        for (int i = 0; i < size; i++)
-        {
-          bua = ergebnis.get(i);
-          for (int j = i + 1; j < size; j++)
-          {
-            if (bua.getNummer() == ergebnis.get(j).getNummer())
-            {
-              ergebnis.remove(j);
-              j--;
-              size--;
-            }
-          }
-        }
-        return ergebnis;
       }
       else 
       {
@@ -128,6 +119,16 @@ public class BuchungsartSearchInput extends SearchInput
           result.addFilter("(UPPER(bezeichnung) like ? or nummer like ?)",
               new Object[] { text, text });
         }
+        if (Einstellungen.getEinstellung()
+            .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
+        {
+          result.setOrder("ORDER BY nummer");
+        }
+        else
+        {
+          result.setOrder("ORDER BY bezeichnung");
+        }
+        
         return PseudoIterator.asList(result);
       }
     }


### PR DESCRIPTION
Der Fix behebt folgende Probleme:
- Durch DISTINCT im SQL Query gibt es keine doppelten Einträge und damit kann man das Filtern im Code löschen
- Die Sortierung im Dialog war manchmal fix auf "nummer" und hat die Einstellungen nicht berücksichtigt.
- Die Formatierung war oft fix auf "nrbezeichnung" und hat die Einstellungen nicht berücksichtigt.