### PR TITLE
SEPA XML-Version in Einstellungen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -368,11 +368,18 @@ public class AbrechnungSEPAControl extends AbstractControl
       settings.setAttribute("lastdir.sepa", sepafilercur.getParent());
       try
       {
-        PainVersionDialog d = new PainVersionDialog(org.kapott.hbci.sepa.SepaVersion.Type.PAIN_008);
-        sepaVersion = (SepaVersion) d.open();
-        if (sepaVersion == null)
+        if (Einstellungen.getEinstellung().getSepaVersion() != null)
         {
-          return;
+          sepaVersion = Einstellungen.getEinstellung().getSepaVersion();
+        }
+        else
+        {
+          PainVersionDialog d = new PainVersionDialog(org.kapott.hbci.sepa.SepaVersion.Type.PAIN_008);
+          sepaVersion = (SepaVersion) d.open();
+          if (sepaVersion == null)
+          {
+            return;
+          }
         }
       }
       catch (OperationCanceledException oce)

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -19,10 +19,12 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 import java.text.DecimalFormat;
 import java.util.Date;
+import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
+import org.kapott.hbci.sepa.SepaVersion;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.BICInput;
@@ -221,6 +223,8 @@ public class EinstellungControl extends AbstractControl
   private SelectInput zahlungsrhytmus;
 
   private SelectInput sepaland;
+  
+  private SelectInput sepaversion;
 
   private Input altersgruppen;
 
@@ -1250,6 +1254,21 @@ public class EinstellungControl extends AbstractControl
     sepaland = new SEPALandInput(sl);
     return sepaland;
   }
+  
+  public SelectInput getSepaVersion() throws RemoteException
+  {
+    if (sepaversion != null)
+    {
+      return sepaversion;
+    }
+    List<SepaVersion> list = SepaVersion.getKnownVersions(
+        org.kapott.hbci.sepa.SepaVersion.Type.PAIN_008);
+    sepaversion = new SelectInput(list, 
+        Einstellungen.getEinstellung().getSepaVersion());
+    sepaversion.setAttribute("file");
+    sepaversion.setPleaseChoose("Bitte auswählen");
+    return sepaversion;
+  }
 
   public Input getAltersgruppen() throws RemoteException
   {
@@ -1851,6 +1870,7 @@ public class EinstellungControl extends AbstractControl
       e.setZahlungsweg(zw.getKey());
       SEPALandObject slo = (SEPALandObject) getDefaultSEPALand().getValue();
       e.setDefaultLand(slo.getLand().getKennzeichen());
+      e.setSepaVersion((SepaVersion) sepaversion.getValue());
       e.setSEPADatumOffset((Integer) sepadatumoffset.getValue());
       e.setAbrlAbschliessen((Boolean) abrlabschliessen.getValue());
       e.store();

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
@@ -41,6 +41,8 @@ public class EinstellungenAbrechnungView extends AbstractView
     cont.addInput(control.getZahlungsweg());
     cont.addInput(control.getSEPADatumOffset());
     cont.addInput(control.getDefaultSEPALand());
+    cont.addLabelPair("SEPA XML-Version",
+        control.getSepaVersion());
     cont.addLabelPair("Arbeitsstunden Modell",
         control.getArbeitsstundenmodel());
     cont.addLabelPair("Abrechnungslauf abschlieﬂen",

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -18,11 +18,11 @@ package de.jost_net.JVerein.rmi;
 
 import java.rmi.RemoteException;
 import java.util.Date;
+import org.kapott.hbci.sepa.SepaVersion;
 
 import de.jost_net.JVerein.io.IBankverbindung;
 import de.jost_net.JVerein.keys.Beitragsmodel;
 import de.willuhn.datasource.rmi.DBObject;
-import de.willuhn.jameica.gui.input.CheckboxInput;
 
 public interface Einstellung extends DBObject, IBankverbindung
 {
@@ -528,5 +528,10 @@ public interface Einstellung extends DBObject, IBankverbindung
   public Boolean getOptiert() throws RemoteException;
 
   public void setOptiert(Boolean optiert) throws RemoteException;
+  
+  public void setSepaVersion(SepaVersion sepaversion)
+      throws RemoteException;
+
+  public SepaVersion getSepaVersion() throws RemoteException;
 
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0431.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0431.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0431 extends AbstractDDLUpdate
+{
+  public Update0431(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung",
+        new Column("sepaversion", COLTYPE.VARCHAR, 50, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.server;
 import java.io.Serializable;
 import java.rmi.RemoteException;
 import java.util.Date;
+import org.kapott.hbci.sepa.SepaVersion;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.JVereinPlugin;
@@ -29,9 +30,6 @@ import de.jost_net.JVerein.keys.Beitragsmodel;
 import de.jost_net.JVerein.keys.BuchungBuchungsartAuswahl;
 import de.jost_net.JVerein.rmi.Einstellung;
 import de.jost_net.JVerein.rmi.Felddefinition;
-import de.jost_net.OBanToo.SEPA.BIC;
-import de.jost_net.OBanToo.SEPA.IBAN;
-import de.jost_net.OBanToo.SEPA.SEPAException;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -835,7 +833,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     Double d = (Double) getAttribute("spendenbescheinigungminbetrag");
     if (d == null)
     {
-      d = new Double(0);
+      d = Double.valueOf(0.0d);
     }
     return (d);
   }
@@ -1330,7 +1328,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     {
       DBIterator<Felddefinition> it = Einstellungen.getDBService()
           .createList(Felddefinition.class);
-      hasZus = new Boolean(it.size() > 0);
+      hasZus = Boolean.valueOf(it.size() > 0);
     }
     return hasZus;
   }
@@ -1699,7 +1697,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     Integer offset = (Integer) getAttribute("sepadatumoffset");
     if (offset == null)
     {
-      offset = new Integer(0);
+      offset = Integer.valueOf(0);
     }
     return offset;
   }
@@ -1752,6 +1750,30 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   public void setAbrlAbschliessen(Boolean abschliessen) throws RemoteException
   {
     setAttribute("abrlabschliessen", Boolean.valueOf(abschliessen));
+  }
+  
+  @Override
+  public SepaVersion getSepaVersion() throws RemoteException
+  {
+    String sepaversion = (String) getAttribute("sepaversion");
+    if (sepaversion == null || !(sepaversion.length() > 0))
+    {
+      return null;
+    }
+    return  SepaVersion.byURN(sepaversion);
+  }
+
+  @Override
+  public void setSepaVersion(SepaVersion sepaversion) throws RemoteException
+  {
+    if (sepaversion == null)
+    {
+      setAttribute("sepaversion", null);
+    }
+    else
+    {
+      setAttribute("sepaversion", sepaversion.getFile());
+    }
   }
 
 }


### PR DESCRIPTION
Das Feature erlaubt die SEPA XML-Version in den Einstellungen->Abrechnung zu konfigurieren.
Ist dort ein Wert gesetzt erfolgt nicht mehr jedes Mal eine Abfrage beim Generieren einer XML Datei.
![Screenshot_3](https://github.com/openjverein/jverein/assets/126261667/de00df3a-0057-4bd2-9cd4-9cf88595fecc)
