### PR TITLE
Spendenbescheinigung: Neu (automatisch)

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -138,7 +138,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
 
   public Button getSpendenbescheinigungErstellenButton()
   {
-    Button b = new Button("erstellen", new Action()
+    Button b = new Button("Erstellen", new Action()
     {
 
       @Override
@@ -148,6 +148,11 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
         {
           @SuppressWarnings("rawtypes")
           List items = spbTree.getItems();
+          
+          //Baum Spendenbescheinigungen enthält keine Einträge
+          if (items == null)
+        	  return;
+
           SpendenbescheinigungNode spn = (SpendenbescheinigungNode) items
               .get(0);
           // Loop über die Mitglieder
@@ -190,11 +195,12 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
             {
               spbescheinigung.setFormular((Formular) getFormular().getValue());
             }
+            //Spendenbescheinigungen erfolgreich erstellt
             spbescheinigung.store();
+            spbTree.removeAll();
+            GUI.getStatusBar()
+            .setSuccessText("Spendenbescheinigung(en) erstellt");
           }
-          GUI.getStatusBar()
-              .setSuccessText("Spendenbescheinigung(en) erstellt");
-          spbTree.removeAll();
         }
         catch (RemoteException e)
         {

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
@@ -44,9 +44,9 @@ public class SpendenbescheinigungAutoNeuView extends AbstractView
     control.getSpendenbescheinigungTree().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(control.getSpendenbescheinigungErstellenButton());
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+            DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+    buttons.addButton(control.getSpendenbescheinigungErstellenButton());
     buttons.paint(getParent());
   }
 }


### PR DESCRIPTION
- Hilfe-Button nach links gerückt
- Erfolgsmeldung beim erstellen erscheint nur noch wenn auch wirklich Spendenbescheinigungen erstellt wurden
- Wenn man nach dem generieren von Spendenbescheinigungen nochmal auf den Button "Erstellen" gedrückt hat, kam es zu einer Exception
- Groß- und Kleinschreibung Button "Erstellen" korrigiert