### PR TITLE
Plausicheck bei leerem Betragsfeld

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -313,6 +313,7 @@ public class BuchungsControl extends AbstractControl
     {
       konto.focus();
     }
+    konto.setMandatory(true);
     return konto;
   }
 
@@ -394,6 +395,7 @@ public class BuchungsControl extends AbstractControl
       betrag = new DecimalInput(getBuchung().getBetrag(),
           Einstellungen.DECIMALFORMAT);
     }
+    betrag.setMandatory(true);
     return betrag;
   }
 
@@ -418,6 +420,7 @@ public class BuchungsControl extends AbstractControl
     this.datum = new DateInput(d, new JVDateFormatTTMMJJJJ());
     this.datum.setTitle("Datum");
     this.datum.setText("Bitte Datum wählen");
+    datum.setMandatory(true);
     return datum;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -231,7 +231,7 @@ public class BuchungsControl extends AbstractControl
     else
     {
       // Nötig um für den Check den letzten gesetzten Wert zu löschen
-      b.setStringBetrag(null);
+      b.setBetragNull();
     }
     b.setZweck((String) getZweck().getValue());
     b.setDatum((Date) getDatum().getValue());
@@ -385,7 +385,7 @@ public class BuchungsControl extends AbstractControl
       return betrag;
     }
 
-    if (getBuchung().isNewObject() && getBuchung().getStringBetrag() == null)
+    if (getBuchung().isNewObject() && getBuchung().isBetragNull())
     {
       betrag = new DecimalInput(Einstellungen.DECIMALFORMAT);
     }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -228,6 +228,11 @@ public class BuchungsControl extends AbstractControl
     {
       b.setBetrag((Double) getBetrag().getValue());
     }
+    else
+    {
+      // Nötig um für den Check den letzten gesetzten Wert zu löschen
+      b.setStringBetrag(null);
+    }
     b.setZweck((String) getZweck().getValue());
     b.setDatum((Date) getDatum().getValue());
     b.setArt((String) getArt().getValue());

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -385,7 +385,7 @@ public class BuchungsControl extends AbstractControl
       return betrag;
     }
 
-    if (getBuchung().isNewObject() && getBuchung().getBetrag() == 0d)
+    if (getBuchung().isNewObject() && getBuchung().getStringBetrag() == null)
     {
       betrag = new DecimalInput(Einstellungen.DECIMALFORMAT);
     }

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -51,9 +51,9 @@ public interface Buchung extends DBObject
 
   public void setIban(String iban) throws RemoteException;
 
-  public String getStringBetrag() throws RemoteException;
+  public boolean isBetragNull() throws RemoteException;
   
-  public void setStringBetrag(String betrag) throws RemoteException;
+  public void setBetragNull() throws RemoteException;
   
   public double getBetrag() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -51,10 +51,12 @@ public interface Buchung extends DBObject
 
   public void setIban(String iban) throws RemoteException;
 
-  public double getBetrag() throws RemoteException;
-
+  public String getStringBetrag() throws RemoteException;
+  
   public void setStringBetrag(String betrag) throws RemoteException;
   
+  public double getBetrag() throws RemoteException;
+
   public void setBetrag(double betrag) throws RemoteException;
 
   public String getZweck() throws RemoteException;

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -53,6 +53,8 @@ public interface Buchung extends DBObject
 
   public double getBetrag() throws RemoteException;
 
+  public void setStringBetrag(String betrag) throws RemoteException;
+  
   public void setBetrag(double betrag) throws RemoteException;
 
   public String getZweck() throws RemoteException;

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -98,7 +98,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new ApplicationException("Bitte Datum eingeben");
     }
-    if (getStringBetrag() == null)
+    if (isBetragNull())
     {
       throw new ApplicationException("Bitte Betrag eingeben");
     }
@@ -286,25 +286,16 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   }
 
   @Override
-  public String getStringBetrag() throws RemoteException
+  public boolean isBetragNull() throws RemoteException
   {
     Double d = (Double) getAttribute("betrag");
-    if (d == null)
-      return null;
-    return d.toString();
+    return d == null;
   }
 
   @Override
-  public void setStringBetrag(String betrag) throws RemoteException
+  public void setBetragNull() throws RemoteException
   {
-    if (betrag == null)
-    {
-      setAttribute("betrag", null);
-    }
-    else
-    {
-      setAttribute("betrag", Double.parseDouble(betrag));
-    }
+    setAttribute("betrag", null);
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -98,6 +98,10 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new ApplicationException("Bitte Datum eingeben");
     }
+    if (getStringBetrag() == null)
+    {
+      throw new ApplicationException("Bitte Betrag eingeben");
+    }
     Calendar cal1 = Calendar.getInstance();
     cal1.setTime(getDatum());
     Calendar cal2 = Calendar.getInstance();
@@ -198,7 +202,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     }
     if (o instanceof Integer)
     {
-      l = new Long((Integer) o);
+      l = Long.valueOf(((Integer) o).longValue());
     }
     if (l == null)
     {
@@ -215,7 +219,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new RemoteException("Konto fehlt!");
     }
-    setAttribute("konto", new Long(konto.getID()));
+    setAttribute("konto", Long.valueOf(konto.getID()));
   }
 
   @Override
@@ -278,9 +282,30 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public void setBetrag(double d) throws RemoteException
   {
-    setAttribute("betrag", new Double(d));
+    setAttribute("betrag", Double.valueOf(d));
   }
 
+  private String getStringBetrag() throws RemoteException
+  {
+    Double d = (Double) getAttribute("betrag");
+    if (d == null)
+      return null;
+    return d.toString();
+  }
+
+  @Override
+  public void setStringBetrag(String betrag) throws RemoteException
+  {
+    if (betrag == null)
+    {
+      setAttribute("betrag", null);
+    }
+    else
+    {
+      setAttribute("betrag", Double.parseDouble(betrag));
+    }
+  }
+  
   @Override
   public String getZweck() throws RemoteException
   {
@@ -381,7 +406,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   public void setAbrechnungslauf(Abrechnungslauf abrechnungslauf)
       throws RemoteException
   {
-    setAttribute("abrechnungslauf", new Long(abrechnungslauf.getID()));
+    setAttribute("abrechnungslauf", Long.valueOf(abrechnungslauf.getID()));
   }
 
   @Override
@@ -408,7 +433,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     if (mitgliedskonto != null)
     {
-      setAttribute("mitgliedskonto", new Long(mitgliedskonto.getID()));
+      setAttribute("mitgliedskonto", Long.valueOf(mitgliedskonto.getID()));
     }
     else
     {
@@ -439,7 +464,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     if (projekt != null)
     {
-      setAttribute("projekt", new Long(projekt.getID()));
+      setAttribute("projekt", Long.valueOf(projekt.getID()));
     }
     else
     {
@@ -570,7 +595,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       try
       {
-        return new Long(getID());
+        return Long.valueOf(getID());
       }
       catch (Exception e)
       {

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -285,7 +285,8 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     setAttribute("betrag", Double.valueOf(d));
   }
 
-  private String getStringBetrag() throws RemoteException
+  @Override
+  public String getStringBetrag() throws RemoteException
   {
     Double d = (Double) getAttribute("betrag");
     if (d == null)


### PR DESCRIPTION
Wird eine neue Buchung erzeugt und man speichert ohne einen Betrag einzugeben, kommt es zu einer unspezifischen Fehlermeldung.
Editiert man eine bestehende Buchung, löscht den Betrag und speichert dann, dann gibt es die Meldung, dass gespeichert wurde. Der Betrag wird aber nicht gelöscht und der alte bleibt erhalten.
Der Fix fügt einen Plausi Check hinzu. Er prüft auf ein leeres Eingabefeld und meldet, dass ein Betrag eingegeben werden muss. Die Eingabe von 0€ ist weiter möglich.

Deprecated new wurden durch .valueOf() ersetzt weil die Datei sowieso editiert wurde.