### PR TITLE
Fix Splitbuchung Exception

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -542,6 +542,10 @@ public class BuchungsControl extends AbstractControl
     }
     buchungsart = new BuchungsartInput().getBuchungsartInput(buchungsart,
         getBuchung().getBuchungsart());
+    if (!getBuchung().getSpeicherung())
+    {
+      buchungsart.setMandatory(true);
+    }
     return buchungsart;
   }
 
@@ -896,6 +900,7 @@ public class BuchungsControl extends AbstractControl
       }
       else
       {
+        b.plausi();
         Buchungsart b_art = b.getBuchungsart();
         if (b_art.getSteuersatz() > 0) {
           Buchung b_steuer = getDependentBuchungen().get(0);     


### PR DESCRIPTION
Bei einer Splitbuchung ist die Buchungsart zwingend notwendig. Ist sie nicht gesetzt gibt es eine interne Exception ohne Ausgabe einer Meldung. Bei dem Original JVerein kam noch eine entsprechende Meldung.
Der Grund für die Exception ist die Nullpointer Exception beim Zugriff auf die nicht gesetzte Buchungsart (Steuer ist ein neues Feature das es früher nicht gab). Es werden aber nur RemoteExceptions abgefangen.
Ich habe den Plausi Check vorgeschaltet. Damit gibt es eine korrekte Ausgabe.
Gleichzeitig mache ich das Buchungsart Feld mandatory bei einer Splitbuchung.