### PR TITLE
Feature Bulk Auflösen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungAufloesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungAufloesenAction.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
+import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.dialogs.YesNoDialog;
@@ -23,6 +24,13 @@ import de.willuhn.logging.Logger;
 
 public class SplitbuchungAufloesenAction implements Action
 {
+  private BuchungsControl control;
+  
+  public SplitbuchungAufloesenAction(BuchungsControl control)
+  {
+    this.control = control;
+  }
+  
   @Override
   public void handleAction(Object context)
   {
@@ -37,6 +45,7 @@ public class SplitbuchungAufloesenAction implements Action
         return;
       }
       SplitbuchungsContainer.aufloesen();
+      control.refreshSplitbuchungen();
     }
     catch (Exception e)
     {

--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+
+import de.jost_net.JVerein.Messaging.BuchungMessage;
+import de.jost_net.JVerein.io.SplitbuchungsContainer;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Jahresabschluss;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class SplitbuchungBulkAufloesenAction implements Action
+{
+  private ArrayList<Long> geloescht = new ArrayList<>();
+  private Long splitid;
+  
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (context == null
+        || (!(context instanceof Buchung) && !(context instanceof Buchung[])))
+    {
+      throw new ApplicationException("Keine Buchung ausgewählt");
+    }
+    try
+    {
+      Buchung[] b = null;
+      if (context instanceof Buchung)
+      {
+        b = new Buchung[1];
+        b[0] = (Buchung) context;
+      }
+      else if (context instanceof Buchung[])
+      {
+        b = (Buchung[]) context;
+      }
+      if (b == null)
+      {
+        return;
+      }
+      if (b.length == 0)
+      {
+        return;
+      }
+      if (b[0].isNewObject())
+      {
+        return;
+      }
+      YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+      d.setTitle("Splitbuchung" + (b.length > 1 ? "en" : "") + " auflösen");
+      d.setText("Wollen Sie diese Splituchung" + (b.length > 1 ? "en" : "")
+          + " wirklich auflösen?");
+      try
+      {
+        Boolean choice = (Boolean) d.open();
+        if (!choice.booleanValue())
+        {
+          return;
+        }
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Auflösen der Splituchung", e);
+        return;
+      }
+      for (Buchung bu : b)
+      {
+        Jahresabschluss ja = bu.getJahresabschluss();
+        if (ja != null)
+        {
+          throw new ApplicationException(String.format(
+              "Buchung wurde bereits am %s von %s abgeschlossen.",
+              new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
+        }
+        SplitbuchungsContainer.init(bu);
+        splitid = bu.getSplitId();
+        if (!geloescht.contains(splitid))
+        {
+          SplitbuchungsContainer.aufloesen();
+          geloescht.add(splitid);
+        }
+      }
+      int count = geloescht.size();
+      if (count > 0)
+      {
+        GUI.getStatusBar().setSuccessText(String.format(
+            "%d Splituchung" + (count != 1 ? "en" : "") + " aufgelöst.", count));
+      }
+      else
+      {
+        GUI.getStatusBar().setErrorText("Keine Splituchung aufgelöst");
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler beim Auflösen der Splituchung.";
+      GUI.getStatusBar().setErrorText(fehler);
+      Logger.error(fehler, e);
+    }
+    finally
+    {
+      Application.getMessagingFactory().sendMessage(new BuchungMessage(null));
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1325,6 +1325,7 @@ public class BuchungsControl extends AbstractControl
     {
       buchungsList.addItem(b);
     }
+    buchungsList.sort();
   }
 
   public void refreshSplitbuchungen() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.gui.action.BuchungMitgliedskontoZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungNeuAction;
 import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
+import de.jost_net.JVerein.gui.action.SplitbuchungBulkAufloesenAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
@@ -60,6 +61,8 @@ public class BuchungMenu extends ContextMenu
         "edit-copy.png"));
     addItem(new SingleBuchungItem("Splitbuchung", new SplitBuchungAction(),
         "edit-copy.png"));
+    addItem(new AufloesenItem("Auflösen", new SplitbuchungBulkAufloesenAction(),
+        "unlocked.png"));
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Mitgliedskonto zuordnen",
@@ -167,4 +170,39 @@ public class BuchungMenu extends ContextMenu
     }
   }
   
+  private static class AufloesenItem extends CheckedContextMenuItem
+  {
+    private AufloesenItem(String text, Action action, String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      try
+      {
+        if (o instanceof Buchung)
+        {
+          return ((Buchung) o).getSplitId() != null;
+        }
+        if (o instanceof Buchung[])
+        {
+          for (Buchung bu : ((Buchung[]) o))
+          {
+            if (bu.getSplitId() == null)
+            {
+              return false;
+            }
+          }
+          return true;
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+      }
+      return false;
+    }
+  }
 }

--- a/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
@@ -42,8 +42,8 @@ public class SplitBuchungView extends AbstractView
         DokumentationUtil.SPLITBUCHUNG, false, "question-circle.png");
     buttons.addButton("Neu", new SplitbuchungNeuAction(),
         control.getCurrentObject(), false, "document-new.png");
-    buttons.addButton("Auflösen", new SplitbuchungAufloesenAction(),
-        control.getCurrentObject(), false, "document-new.png");
+    buttons.addButton("Auflösen", new SplitbuchungAufloesenAction(control),
+        control.getCurrentObject(), false, "unlocked.png");
     buttons.addButton(control.getSammelueberweisungButton());
 
     buttons.addButton("Speichern", new Action()


### PR DESCRIPTION
Nachdem es jetzt ein Bulk Splitbuchung gibt habe ich auch ein Bulk Auflösen implementiert.
Es kann ja sein, dass man bei Bulk Splitbuchung einen Fehler gemacht hat und alle erzeugten Splitbuchungen wieder auflösen möchte. Momentan geht das nur für jede Buchung einzeln über den Splitbuchung View.
Ich habe jetzt ein Contextmenü in der Buchungsliste eingeführt welches bei selektierten Splitbuchungen aktiv ist. Damit lassen sich alle selektierten Splitbuchungen auflösen.
Sonstiges:
Ich habe ein passenderes Icon für das Auflösen gewählt, auch im Splitbuchung View angepasst.
Nach Splitbuchung Auflösen im Splitbuchung View blieb eine Buchung im View sichtbar die aber nicht mehr in der Liste war. Ich habe ein Refresh der Liste eingebaut.
Beim Auflösen der Splitbuchungen wurde die Buchungsliste umsortiert (ein ähnliches Problem wie ich schon früher gesehen hatte). Es lag daran, dass in der Methode refreshBuchungen() in der Datei BuchungsControl.java ein buchungsList.sort() gefehlt hat.
![Screenshot_20240216_170149](https://github.com/openjverein/jverein/assets/126261667/f0e09093-994b-4b4b-ad9d-6671c715981a)

