### PR TITLE
Korrekturen Splitbuchung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
@@ -25,7 +25,6 @@ import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.logging.Logger;
 
 public class SplitbuchungNeuAction implements Action
 {
@@ -45,7 +44,7 @@ public class SplitbuchungNeuAction implements Action
       buch.setMitgliedskonto(master.getMitgliedskonto());
       buch.setName(master.getName());
       buch.setProjekt(master.getProjekt());
-      buch.setSplitId(new Long(master.getID()));
+      buch.setSplitId(Long.valueOf(master.getID()));
       buch.setUmsatzid(master.getUmsatzid());
       buch.setZweck(master.getZweck());
       buch.setSpeicherung(false);
@@ -54,7 +53,7 @@ public class SplitbuchungNeuAction implements Action
     }
     catch (RemoteException e)
     {
-      Logger.error("Fehler", e);
+      GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SplitBuchungMenu.java
@@ -20,11 +20,11 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.gui.action.BuchungAction;
-import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungDeleteAction;
+/*import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungKontoauszugZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungMitgliedskontoZuordnungAction;
-import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
+import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;*/
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
@@ -48,15 +48,16 @@ public class SplitBuchungMenu extends ContextMenu
   {
     addItem(new CheckedSplitBuchungItem("Bearbeiten", new BuchungAction(true),
         "text-x-generic.png"));
-    addItem(new CheckedSplitBuchungItem("Buchungsart zuordnen",
+    /*addItem(new CheckedSplitBuchungItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Mitgliedskonto zuordnen",
         new BuchungMitgliedskontoZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Projekt zuordnen",
         new BuchungProjektZuordnungAction(control), "view-refresh.png"));
     addItem(new CheckedSplitBuchungItem("Kontoauszug zuordnen",
-        new BuchungKontoauszugZuordnungAction(control), "view-refresh.png"));
-    addItem(new DeleteSplitBuchungItem());
+        new BuchungKontoauszugZuordnungAction(control), "view-refresh.png"));*/
+    addItem(new DeleteSplitBuchungItem("Löschen...", 
+        new DeleteSplitBuchungAction(control), "user-trash-full.png"));
     addItem(new RestoreSplitBuchungItem());
   }
 
@@ -88,9 +89,9 @@ public class SplitBuchungMenu extends ContextMenu
 
   private static class DeleteSplitBuchungItem extends CheckedContextMenuItem
   {
-    private DeleteSplitBuchungItem()
+    private DeleteSplitBuchungItem(String text, Action action, String icon)
     {
-      super("Löschen...", new BuchungDeleteAction(true), "user-trash-full.png");
+      super(text, action, icon);
     }
 
     @Override
@@ -112,6 +113,46 @@ public class SplitBuchungMenu extends ContextMenu
     }
   }
 
+  private static class DeleteSplitBuchungAction implements Action
+  {
+    private BuchungsControl control;
+    
+    public DeleteSplitBuchungAction(BuchungsControl control)
+    {
+      this.control = control;
+    }
+
+    @Override
+    public void handleAction(Object context) throws ApplicationException
+    {
+      if (context == null || !(context instanceof Buchung))
+      {
+        throw new ApplicationException("Keine Buchung ausgewählt");
+      }
+      try
+      {
+        Buchung bu = (Buchung) context;
+        if (((Buchung) context).isNewObject())
+        {
+          SplitbuchungsContainer.get().remove(bu);
+        }
+        else
+        {
+          BuchungDeleteAction action = new BuchungDeleteAction(true);
+          action.handleAction(context);
+        }
+        control.refreshSplitbuchungen();
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Fehler beim Löschen der Buchung.";
+        GUI.getStatusBar().setErrorText(fehler);
+        Logger.error(fehler, e);
+      }
+    }
+  } 
+
+  
   private static class RestoreSplitBuchungItem extends CheckedContextMenuItem
   {
     private RestoreSplitBuchungItem()

--- a/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
@@ -53,8 +53,15 @@ public class SplitBuchungView extends AbstractView
       {
         try
         {
-          SplitbuchungsContainer.store();
-          GUI.getStatusBar().setSuccessText("Splitbuchungen gespeichert");
+          if (SplitbuchungsContainer.get().size() != 0)
+          {
+            SplitbuchungsContainer.store();
+            GUI.getStatusBar().setSuccessText("Splitbuchungen gespeichert");
+          }
+          else
+          {
+            GUI.getStatusBar().setErrorText("Hauptbuchung fehlt");
+          }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Beim Implementieren der neuen Splitbuchung Features sind mir einige Dinge aufgefallen.
- Drückt man nach dem Auflösen auf "Neu" wird eine interne Exception erzeugt ohne Ausgabe an den User. Und es passiert auch nichts. Ich gebe jetzt den Fehlertext aus, der in der Exception steht ("Hauptbuchung fehlt").
- Beim Speichern wird immer ausgegeben, dass die Buchung gespeichert wurde, auch wenn nichts gespeichert wurde. Das passiert wenn man nach dem Auflösen auf Speichern drückt. Das gleiche passiert dann jetzt auch nach dem Speichern einer Bulk Splitbuchung wenn man wieder Speichern drückt. Ich fange das jetzt ab und gebe die gleiche Meldung wie oben aus.
- Die Funktion "Löschen" funktioniert nur bei einer bereits gespeicherten Splitbuchung. Editiert man eine neue Splitbuchung kann man erzeugte Buchungseinträge nicht löschen. Durch den Check .isNewObject() wird nichts gemacht. Ich habe das erweitert, so dass man jetzt auch neue Einträge löschen kann. Da diese Buchungen noch nicht gespeichert wurden, lösche ich sie direkt ohne eine Sicherheitsabfrage und die sonstigen Checks beim Löschen. 
- Das Tabellen Menu im Splitbuchung View enthält einige Punkte wie z.B. Projekt zuordnen etc. Diese arbeiten direkt auf der Datenbank und berücksichtigen nicht, dass es sich um Splitbuchungen handelt die im Slitbuchungs View bearbeitet werden wie es z.B. die Löschen Funktion macht. Das führt zu Inkonsistenzen. Wenn man z.B. die Hauptbuchung so ändert wird sie mit der SplitId gespeichert. Verlässt man den View ohne speichern hat man einen falschen Eintrag.
Ich habe diese Menüpunkte jetzt einmal auskommentiert. Man verliert ja nichts, weil man über den Menü Eintrag "Bearbeiten" ja auch alles ändern kann. Das bleibt dann lokal und wir erst beim Speichern abgespeichert und auf Konsistenz geprüft.
Wenn man die Punkte zurückholen will muss man es korrekt implementieren, also ohne speichern editieren  incl. aller Checks wie z.B. Dependency Handling etc. Ich denke aber, das ist nicht nötig.