### PR TITLE
Fix Buchung speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -964,7 +964,18 @@ public class BuchungsControl extends AbstractControl
     {
       Object auswahl = mitgliedskonto.getValue();
       if (null == auswahl)
-        return null;
+      {
+        if (mitgliedskonto.getText().length() == 0 )
+        {
+          // Konto wird gelöscht da "Entfernen" ausgewählt
+          return null;
+        }
+        else
+        {
+          // Dialog wurde ohne Auswahl geschlossen aber nicht mit "Entfernen"
+          return b.getMitgliedskonto();
+        }
+      }
 
       if (auswahl instanceof Mitgliedskonto)
         return (Mitgliedskonto) auswahl;

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -22,8 +22,6 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TabFolder;
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
@@ -40,6 +38,7 @@ import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.util.Container;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
+import de.willuhn.jameica.system.OperationCanceledException;
 
 /**
  * Ein Dialog, ueber den man ein Mitgliedskonto auswaehlen kann.
@@ -61,7 +60,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
 
   private Buchung buchung;
   
-  private boolean abort = false;
+  private boolean abort = true;
 
   public MitgliedskontoAuswahlDialog(Buchung buchung)
   {
@@ -158,6 +157,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
         if (o instanceof Mitgliedskonto)
         {
           choosen = o;
+          abort = false;
           close();
         }
         else
@@ -167,6 +167,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
           if (o instanceof Mitglied)
           {
             choosen = o;
+            abort = false;
             close();
           }
         }
@@ -181,6 +182,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
       public void handleAction(Object context)
       {
         choosen = null;
+        abort = false;
         close();
       }
     }, null, false, "user-trash-full.png");
@@ -191,18 +193,10 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
-        abort = true;
-        close();
+        throw new OperationCanceledException();
       }
     }, null, false, "process-stop.png");
     
-    getShell().addListener(SWT.Close,new Listener()
-    {
-      public void handleEvent(Event event)
-      {
-        abort = true;
-      }
-    });
     b.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/input/MitgliedskontoauswahlInput.java
+++ b/src/de/jost_net/JVerein/gui/input/MitgliedskontoauswahlInput.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.input;
 import java.rmi.RemoteException;
 import java.util.Date;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
@@ -101,7 +102,8 @@ public class MitgliedskontoauswahlInput
       {
         try
         {
-          getMitgliedskontoAuswahl().setText("");
+          if (event.detail != SWT.CANCEL)
+            getMitgliedskontoAuswahl().setText("");
           return;
         }
         catch (RemoteException er)


### PR DESCRIPTION
Wird im Buchungview das Mitgliedskonto editiert gibt es folgende Fehler.
- Wird der Auswahldialog mit ESC beendet wird der Text im View gelöscht, beim Speichern bleibt korrekter Weise das Mitgliedskonto erhalten.
- Wird der Auswahldialog mit dem Schließen Icon geschlossen, bleibt die Anzeige im Text erhalten, beim Speichern wird aber das Mitgliedskonto gelöscht.