### PR TITLE
Fix #163

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -143,7 +143,12 @@ public class BuchungsklasseSaldoView extends AbstractView
 
     LabelGroup quickGroup = new LabelGroup(getParent(), "Schnellzugriff");
     ButtonArea quickBtns = new ButtonArea();
-    for (Integer i = getYearBounds("min"); i < getYearBounds("max") + 1; i++)
+    Calendar calendar = Calendar.getInstance();
+    Integer bis = calendar.get(Calendar.YEAR);
+    calendar.add(Calendar.YEAR, -10);
+    Integer maxmin = calendar.get(Calendar.YEAR);
+    Integer von = java.lang.Math.max(getYearBounds("min"), maxmin);
+    for (Integer i = von; i <= bis ; i++)
     {
       quickBtns.addButton(i.toString(), new QuickAccessAction(control,
           genYearStartDate(i), genYearEndDate(i)), null, false);


### PR DESCRIPTION
Mit dieser Korrektur gehe ich das Problem aus #163 an.
Sollten falsche Buchungen da sein, kann es zu "no more handles" kommen wenn Buchungen in einem weiten Range vorhanden sind. Auch wenn es nicht zu "no more handles" kommen würde, könnte es zu hunderten von Einträgen in der Quick Access Liste kommen. Das ist Unsinn.
Ich habe den Code jetzt so korrigiert, dass die 90 und 30 Tage, das aktuelle Jahr und maximal bis zu 10 zurückliegende Jahre angezeigt werden. Mehr braucht man nicht in der Liste. Zukünftige machen keinen Sinn weil sie sowieso keinen Anfangsstand haben. Und ältere als 10 Jahre wird man auch nicht mehr brauchen. Notfalls kann man ja immer noch den Zeitraum manuell eingeben.
Damit kann es auch bei Buchungen mit unsinnigen Datums Werten keine "no more handles"  mehr geben da die Zahl der Buttons auf maximal 13 begrenzt ist.