### PR TITLE
Update BuchungMitgliedskontoZuordnungAction.java

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAction.java
@@ -125,6 +125,11 @@ public class BuchungMitgliedskontoZuordnungAction implements Action
     {
       throw oce;
     }
+    catch (ApplicationException ae)
+    {
+      Logger.error(ae.getLocalizedMessage(), ae);
+      throw new ApplicationException(ae.getLocalizedMessage());
+    }
     catch (Exception e)
     {
       Logger.error("Fehler", e);

--- a/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungMitgliedskontoZuordnungAction.java
@@ -127,7 +127,6 @@ public class BuchungMitgliedskontoZuordnungAction implements Action
     }
     catch (ApplicationException ae)
     {
-      Logger.error(ae.getLocalizedMessage(), ae);
       throw new ApplicationException(ae.getLocalizedMessage());
     }
     catch (Exception e)


### PR DESCRIPTION
Ordnet man einer Buchung ein Mitgliedskonto zu bei dem im Zuordnungsdialog über die Lasche "Soll & Ist" ein Mitglied zu, muss in der Buchung ein Verwendungszweck eingetragen sein. Wenn das nicht so ist, wird eine ApplicationException generiert.
Erfolgt die Zuordnung im Buchung View wird beim Speichern der Buchung der Exception Text ausgegeben.
Beim Setzen der Zuordnung über das Kontextmenü einer Buchung, über den Dialog, wird beim "Übernehmen" die Exception erzeugt. Der alte Code gibt eine allgemeine Fehlermeldung aus. Der Fix zeigt den Text der ursprünglichen ApplicationException an.