### PR TITLE
Intervall für aktive Konten konfigurierbar

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -175,6 +175,8 @@ public class EinstellungControl extends AbstractControl
   private CheckboxInput kontonummer_in_buchungsliste;
   
   private IntegerInput unterdrueckunglaenge;
+  
+  private IntegerInput unterdrueckungkonten;
 
   private CheckboxInput automatische_buchungskorrektur_hibiscus;
 
@@ -958,6 +960,16 @@ public class EinstellungControl extends AbstractControl
           Einstellungen.getEinstellung().getUnterdrueckungLaenge());
     }
     return unterdrueckunglaenge;
+  }
+  
+  public IntegerInput getUnterdrueckungKonten() throws RemoteException
+  {
+    if (null == unterdrueckungkonten)
+    {
+      unterdrueckungkonten = new IntegerInput(
+          Einstellungen.getEinstellung().getUnterdrueckungKonten());
+    }
+    return unterdrueckungkonten;
   }  
   
   public CheckboxInput getKontonummerInBuchungsliste() throws RemoteException 
@@ -971,7 +983,6 @@ public class EinstellungControl extends AbstractControl
     return kontonummer_in_buchungsliste;
   }
 
-  
   public CheckboxInput getAutomatischeBuchungskorrekturHibiscus() throws RemoteException 
   {
     if (automatische_buchungskorrektur_hibiscus != null) 
@@ -1977,6 +1988,8 @@ public class EinstellungControl extends AbstractControl
           .getValue());
       Integer ulength = (Integer) unterdrueckunglaenge.getValue();
       e.setUnterdrueckungLaenge(ulength);
+      Integer klength = (Integer) unterdrueckungkonten.getValue();
+      e.setUnterdrueckungKonten(klength);
       e.setKontonummerInBuchungsliste((Boolean) kontonummer_in_buchungsliste.getValue());
       e.setOptiert((Boolean) getOptiert().getValue());
       e.store();

--- a/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/KontoAuswahlDialog.java
@@ -63,7 +63,7 @@ public class KontoAuswahlDialog extends AbstractDialog<Konto>
       boolean nurHibiscus, boolean nurAktuelleKonten)
   {
     super(position);
-    super.setSize(400, 300);
+    super.setSize(400, 350);
     this.setTitle("Konto-Auswahl");
     this.keinkonto = keinkonto;
     this.nurHibiscus = nurHibiscus;

--- a/src/de/jost_net/JVerein/gui/parts/KontoList.java
+++ b/src/de/jost_net/JVerein/gui/parts/KontoList.java
@@ -20,12 +20,13 @@ package de.jost_net.JVerein.gui.parts;
 
 import java.rmi.RemoteException;
 import java.util.Calendar;
+import java.util.List;
 
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Konto;
-import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.Part;
@@ -36,14 +37,13 @@ import de.willuhn.jameica.gui.parts.TablePart;
  */
 public class KontoList extends TablePart implements Part
 {
-
   public KontoList(Action action, boolean onlyHibiscus,
       boolean nurAktuelleKonten) throws RemoteException
   {
     this(init(onlyHibiscus, nurAktuelleKonten), action);
   }
 
-  public KontoList(GenericIterator konten, Action action)
+  public KontoList(List<Konto> konten, Action action)
   {
     super(konten, action);
 
@@ -73,10 +73,10 @@ public class KontoList extends TablePart implements Part
 	      boolean nurAktuelleKonten) throws RemoteException
   {
     super.removeAll();
-    DBIterator<Konto> i = init(onlyHibiscus, nurAktuelleKonten);
-    while (i.hasNext()) 
+    List<Konto> list = init(onlyHibiscus, nurAktuelleKonten);
+    for (Konto kto: list) 
     {
-      super.addItem(i.next());
+      super.addItem(kto);
     }
   }
   
@@ -86,7 +86,8 @@ public class KontoList extends TablePart implements Part
    * @return Liste der Konten.
    * @throws RemoteException
    */
-  private static DBIterator<Konto> init(boolean onlyHibiscus,
+  @SuppressWarnings("unchecked")
+  private static List<Konto> init(boolean onlyHibiscus,
       boolean nurAktuelleKonten) throws RemoteException
   {
     DBIterator<Konto> i = Einstellungen.getDBService().createList(Konto.class);
@@ -98,10 +99,10 @@ public class KontoList extends TablePart implements Part
     {
       Calendar cal = Calendar.getInstance();
       int year = cal.get(Calendar.YEAR);
-      year = year - 2;
+      year = year - Einstellungen.getEinstellung().getUnterdrueckungKonten();
       i.addFilter("(aufloesung is null or year(aufloesung) >= ?)", year);
     }
     i.setOrder("ORDER BY nummer, bezeichnung");
-    return i;
+    return PseudoIterator.asList(i);
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -38,6 +38,8 @@ public class EinstellungenBuchfuehrungView extends AbstractView
 
     cont.addLabelPair("Beginn Geschäftsjahr (TT.MM.)",
         control.getBeginnGeschaeftsjahr());
+    cont.addLabelPair("Intervall für aktive Konten (Jahre)",
+        control.getUnterdrueckungKonten());
     cont.addLabelPair("Buchungsarten die seit x Monaten nicht benutzt werden unterdrücken",
         control.getUnterdrueckungLaenge());
     cont.addInput(control.getAutoBuchunguebernahme());

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -271,6 +271,11 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public void setUnterdrueckungLaenge(int unterdrueckunglaenge)
       throws RemoteException;
+  
+  public int getUnterdrueckungKonten() throws RemoteException;
+  
+  public void setUnterdrueckungKonten(int unterdrueckungkonten)
+      throws RemoteException;
 
   public Boolean getKontonummerInBuchungsliste() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0433.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0433.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0433 extends AbstractDDLUpdate
+{
+  public Update0433(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("unterdrueckungkonten",
+        COLTYPE.INTEGER, 0, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -1677,6 +1677,23 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   {
     setAttribute("unterdrueckunglaenge", unterdrueckunglaenge);
   }
+  
+  @Override
+  public int getUnterdrueckungKonten() throws RemoteException 
+  {
+    try {
+      return (int) getAttribute("unterdrueckungkonten");
+    } catch (NullPointerException e) {
+      return 2;
+    }
+  }
+
+  @Override
+  public void setUnterdrueckungKonten(int unterdrueckungkonten) throws RemoteException 
+  {
+    setAttribute("unterdrueckungkonten", unterdrueckungkonten);
+  }
+
 
   @Override
   public Boolean getKontonummerInBuchungsliste() throws RemoteException


### PR DESCRIPTION
Im Gegensatz zum Intervall zur Unterdrückung von Buchungsarten war das Intervall für aktive Konten fix auf 2 Jahre.
Ich habe das Intervall jetzt konfigurierbar gemacht. Den Defaultwert habe ich bei 2 gelassen.
Auch habe ich den Konto Auswahl Dialog etwas vergrößert  damit ich nicht immer scrollen muss.
In Kontolist habe ich auf List umgestellt um Warnings zu beseitigen.