### PR TITLE
Lösungsversuch 2 zu #159

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -80,7 +80,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     TabFolder folder = new TabFolder(parent, SWT.NONE);
     folder.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-    TabGroup tabNurIst = new TabGroup(folder, "nur Ist", false, 1);
+    TabGroup tabNurIst = new TabGroup(folder, "Nur Ist-Buchung erzeugen", false, 1);
     Container grNurIst = new SimpleContainer(tabNurIst.getComposite());
     grNurIst.addHeadline("Auswahl des Mitgliedskontos");
     if (text == null || text.length() == 0)
@@ -111,7 +111,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     mitgliedskontolist.paint(tabNurIst.getComposite());
 
     //
-    TabGroup tabSollIst = new TabGroup(folder, "Soll u. Ist", true, 1);
+    TabGroup tabSollIst = new TabGroup(folder, "Soll-Buchung und Ist-Buchung erzeugen", true, 1);
     Container grSollIst = new SimpleContainer(tabSollIst.getComposite());
     grSollIst.addHeadline("Auswahl des Mitgliedskontos");
 


### PR DESCRIPTION
Inzwischen habe ich einiges dazu gelernt und das Problem der alten Implementierung verstanden.
- Der Code hat im ResultSetExtractor für den Vergleich auf Fehlbetrag/Überzahlung den Vergleich mit  mk.getIstSumme() gemacht. Die Summe ist aber kein Attribut der Mitgliedkonto. Es wird per Query geholt. Damit wird im ResultSetExtractor für jedes gefundene Mitgliedskonto nochmal ein Query gemacht. Hat man etwa 100 Mitglieder die schon 10 oder mehr Jahre Beiträge bezahlen kommen da schnell über 1.000 Queries zusammen.
- Dieses habe ich korrigiert und den Vergleich in das Query integriert. Das eliminiert schon viele Queries.
- Als weiteres wurden im ResultSetExtractor Mitgliedskonten erzeugt die später dann wieder verschmissen werden wenn sich ein besserer Match ergibt.
- Ich habe das geändert und speichere nur die IDs der gefundenen Mitgliedskonten. Erst wenn das Query vorbei ist erzeuge ich nur die endgültigen Mitgliedskonten die auch angezeigt werden.
- Im ResultSetExtractor wurden der Mitglied Name und Vorname über  mk.getMitglied().getName() geholt. Da Name aber kein Attribut des Mitgliedkonto ist weiß ich nicht wie das geholt wurde. Noch ein Query auf das Mitglied?
- Da diese ja im RS sind nehme ich sie gleich von da.

Jetzt gibt es dann in jedem Fall nur ein Query. Allerdings wird der Match jetzt für jedes Mitgliedskonto und nicht nur für jedes Mitglied gemacht im Vergleich zu meinem ersten Vorschlag. 
Ich könnte mir vorstellen, dass diese Implementierung hier noch besser ist als die in #182.

PS: Den Vergleich mit Zweck habe ich auch entfernt und die Länge der Namen auf >2 reduziert.

Ich weiß jetzt nicht wie wir weiter vorgehen. Sollte man zwei Testbuilds machen und es Lukas messen lassen was schneller ist. Oder glauben wir gleich, dass diese hier besser ist, da sie nur ein einziges Query macht?

Endgültig sollte natürlich nur einer der beiden Pull Requests übernommen werden.