### PR TITLE
Verbesserung und Fix  Auswahl Dialog/Views

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -188,7 +188,7 @@ public class ArbeitseinsatzControl extends AbstractControl
               "Fehler beim Start der PDF-Ausgabe der Arbeitseinsatzüberprüfung");
         }
       }
-    }, null, true, "file-pdf.png");
+    }, null, false, "file-pdf.png");
     return b;
   }
 
@@ -211,7 +211,7 @@ public class ArbeitseinsatzControl extends AbstractControl
               "Fehler beim Start der CSV-Ausgabe der Arbeitseinsatzüberprüfung");
         }
       }
-    }, null, true, "xsd.png");
+    }, null, false, "xsd.png");
     return b;
   }
 
@@ -234,7 +234,7 @@ public class ArbeitseinsatzControl extends AbstractControl
               "Fehler beim der Zusatzbetragsgenerierung");
         }
       }
-    }, null, true, "euro-sign.png");
+    }, null, false, "euro-sign.png");
     return b;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -544,7 +544,7 @@ public class BuchungsartControl extends AbstractControl
               "Fehler beim Start der PDF-Ausgabe der Buchungsarten");
         }
       }
-    }, null, true, "file-pdf.png");
+    }, null, false, "file-pdf.png");
     return b;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -65,7 +65,7 @@ public class BuchungsklasseSaldoControl extends SaldoControl
       {
         starteAuswertung(AuswertungPDF);
       }
-    }, null, true, "file-pdf.png"); // "true" defines this button as the default
+    }, null, false, "file-pdf.png");
     // button
     return b;
   }
@@ -79,7 +79,7 @@ public class BuchungsklasseSaldoControl extends SaldoControl
       {
         starteAuswertung(AuswertungCSV);
       }
-    }, null, true, "xsd.png"); // "true" defines this button as the default
+    }, null, false, "xsd.png");
     // button
     return b;
   }

--- a/src/de/jost_net/JVerein/gui/control/JahressaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahressaldoControl.java
@@ -64,7 +64,7 @@ public class JahressaldoControl extends SaldoControl
       {
         starteAuswertung();
       }
-    }, null, true, "file-pdf.png"); // "true" defines this button as the default
+    }, null, false, "file-pdf.png");
     // button
     return b;
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -337,7 +337,6 @@ public class MitgliedskontoControl extends AbstractControl
     this.vondatum = new DateInput(d, new JVDateFormatTTMMJJJJ());
     this.vondatum.setTitle("Anfangsdatum");
     this.vondatum.setText("Bitte Anfangsdatum wählen");
-    vondatum.addListener(new FilterListener());
     return vondatum;
   }
 
@@ -364,7 +363,6 @@ public class MitgliedskontoControl extends AbstractControl
     this.bisdatum = new DateInput(d, new JVDateFormatTTMMJJJJ());
     this.bisdatum.setTitle("Endedatum");
     this.bisdatum.setText("Bitte Endedatum wählen");
-    bisdatum.addListener(new FilterListener());
     return bisdatum;
   }
 
@@ -449,7 +447,6 @@ public class MitgliedskontoControl extends AbstractControl
     }
     suchname = new TextInput("", 30);
     suchname.setName("Name");
-    suchname.addListener(new FilterListener());
     return suchname;
   }
 
@@ -461,7 +458,6 @@ public class MitgliedskontoControl extends AbstractControl
     }
     suchname2 = new TextInput("", 30);
     suchname2.setName("Name");
-    suchname2.addListener(new FilterListener());
     return suchname2;
   }
 
@@ -1039,6 +1035,32 @@ public class MitgliedskontoControl extends AbstractControl
       }
       refresh();
     }
+  }
+  
+  public void refreshMitgliedskontoList()
+  {
+    try
+    {
+      getMitgliedskontoList(action, null);
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+    }
+    refresh();
+  }
+  
+  public void refreshMitgliedskontoList2()
+  {
+    try
+    {
+      refreshMitgliedkonto2();
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+    }
+
   }
 
   public static class MitgliedskontoTreeFormatter implements TreeFormatter

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -60,7 +60,7 @@ public class ProjektSaldoControl extends SaldoControl
       {
         starteAuswertung();
       }
-    }, null, true, "file-pdf.png"); // "true" defines this button as the default
+    }, null, false, "file-pdf.png");
     // button
     return b;
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedskontoAuswahlDialog.java
@@ -33,12 +33,14 @@ import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.util.Container;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
 
 /**
  * Ein Dialog, ueber den man ein Mitgliedskonto auswaehlen kann.
@@ -91,6 +93,17 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     TextInput suNa = control.getSuchName();
     suNa.setValue(buchung.getName());
     grNurIst.addLabelPair("Name", suNa);
+    ButtonArea button1 = new ButtonArea();
+    Button suchen1 = new Button("Suchen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        control.refreshMitgliedskontoList();
+      }
+    }, null, true, "search.png");
+    button1.addButton(suchen1);
+    grNurIst.addButtonArea(button1);
     grNurIst.addLabelPair("Differenz",
         control.getDifferenz(DIFFERENZ.FEHLBETRAG));
     Action action = new Action()
@@ -104,6 +117,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
           return;
         }
         choosen = context;
+        abort = false;
         close();
       }
     };
@@ -122,6 +136,17 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
     grSollIst.addText(text, true);
     control.getSuchName2(true).setValue(buchung.getName());
     grSollIst.addLabelPair("Name", control.getSuchName2(false));
+    ButtonArea button2 = new ButtonArea();
+    Button suchen2 = new Button("Suchen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        control.refreshMitgliedskontoList2();
+      }
+    }, null, true, "search.png");
+    button2.addButton(suchen2);
+    grSollIst.addButtonArea(button2);
     grSollIst.addInput(control.getSpezialSuche());
 
     final Action action2 = new Action()
@@ -135,6 +160,7 @@ public class MitgliedskontoAuswahlDialog extends AbstractDialog<Object>
           return;
         }
         choosen = context;
+        abort = false;
         close();
       }
     };

--- a/src/de/jost_net/JVerein/gui/view/AdressenSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/AdressenSucheView.java
@@ -24,7 +24,9 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.util.ApplicationException;
 
 public class AdressenSucheView extends AbstractAdresseSucheView
 {
@@ -44,8 +46,19 @@ public class AdressenSucheView extends AbstractAdresseSucheView
   {
     LabelGroup group = new LabelGroup(getParent(), "Filter");
     TextInput suchName = control.getSuchname();
-    suchName.addListener(new FilterListener());
     group.addInput(suchName);
+    
+    ButtonArea button = new ButtonArea();
+    Button suchen = new Button("Suchen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        TabRefresh();
+      }
+    }, null, true, "search.png");
+    button.addButton(suchen);
+    group.addButtonArea(button);
 
     Input adrtyp = control.getSuchAdresstyp(2);
     adrtyp.addListener(new FilterListener());

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
@@ -77,7 +77,7 @@ public class ArbeitseinsatzUeberpruefungView extends AbstractView
         DokumentationUtil.ARBEITSEINSATZ, false, "question-circle.png");
     buttons2.addButton(control.getPDFAusgabeButton());
     buttons2.addButton(control.getCSVAusgabeButton());
-    buttons2.addButton(control.getArbeitseinsatzAusgabeButton());
+    buttons2.addButton(butArbeitseinsaetze);
     buttons2.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
@@ -28,6 +28,7 @@ import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
@@ -58,65 +59,51 @@ public class MitgliederSucheView extends AbstractAdresseSucheView
     Input mitglstat = control.getMitgliedStatus();
     mitglstat.addListener(new FilterListener());
     left.addLabelPair("Mitgliedschaft", mitglstat);
-    TextInput suchexternemitgliedsnummer = control
-        .getSuchExterneMitgliedsnummer();
-    suchexternemitgliedsnummer.addListener(new FilterListener());
     if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
     {
       left.addLabelPair("Externe Mitgliedsnummer",
           control.getSuchExterneMitgliedsnummer());
     }
     DialogInput mitgleigenschaften = control.getEigenschaftenAuswahl();
-    mitgleigenschaften.addListener(new FilterListener());
     left.addLabelPair("Eigenschaften", mitgleigenschaften);
-
     SelectInput mitglbeitragsgruppe = control.getBeitragsgruppeAusw();
     mitglbeitragsgruppe.addListener(new FilterListener());
     left.addLabelPair("Beitragsgruppe", mitglbeitragsgruppe);
 
     SimpleContainer middle = new SimpleContainer(cl.getComposite());
     TextInput suchName = control.getSuchname();
-    suchName.addListener(new FilterListener());
     middle.addInput(suchName);
-
     DateInput mitglgebdatvon = control.getGeburtsdatumvon();
-    mitglgebdatvon.addListener(new FilterListener());
     middle.addLabelPair("Geburtsdatum von", mitglgebdatvon);
     DateInput mitglgebdatbis = control.getGeburtsdatumbis();
-    mitglgebdatbis.addListener(new FilterListener());
     middle.addLabelPair("Geburtsdatum bis", mitglgebdatbis);
     SelectInput mitglgeschlecht = control.getGeschlecht();
     mitglgeschlecht.setMandatory(false);
     mitglgeschlecht.addListener(new FilterListener());
     middle.addLabelPair("Geschlecht", mitglgeschlecht);
     DateInput stichtag = control.getStichtag();
-    stichtag.addListener(new FilterListener());
     middle.addLabelPair("Stichtag", stichtag);
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     DateInput mitgleintrittvon = control.getEintrittvon();
-    mitgleintrittvon.addListener(new FilterListener());
     right.addLabelPair("Eintrittsdatum von", mitgleintrittvon);
     DateInput mitgleintrittbis = control.getEintrittbis();
-    mitgleintrittbis.addListener(new FilterListener());
     right.addLabelPair("Eintrittsdatum bis", mitgleintrittbis);
     DateInput mitglaustrittvon = control.getAustrittvon();
-    mitglaustrittvon.addListener(new FilterListener());
     right.addLabelPair("Austrittsdatum von", mitglaustrittvon);
     DateInput mitglaustrittbis = control.getAustrittbis();
-    mitglaustrittbis.addListener(new FilterListener());
     right.addLabelPair("Austrittsdatum bis", mitglaustrittbis);
 
-    DialogInput mitglzusatzfelder = control.getZusatzfelderAuswahl();
-    mitglzusatzfelder.addListener(new FilterListener());
     if (Einstellungen.getEinstellung().hasZusatzfelder())
     {
+      DialogInput mitglzusatzfelder = control.getZusatzfelderAuswahl();
+      mitglzusatzfelder.addListener(new FilterListener());
       left.addLabelPair("Zusatzfelder", mitglzusatzfelder);
     }
-    ColumnLayout bc = new ColumnLayout(right.getComposite(), 2);
-    bc.add(control.getProfileButton());
-
-    bc.add(new Button("Filter-Reset", new Action()
+    
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton(control.getProfileButton());
+    buttons.addButton(new Button("Filter-Reset", new Action()
     {
 
       @Override
@@ -151,6 +138,16 @@ public class MitgliederSucheView extends AbstractAdresseSucheView
 
       }
     }, null, false, "eraser.png"));
+    Button suchen = new Button("Suchen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        TabRefresh();
+      }
+    }, null, true, "search.png");
+    buttons.addButton(suchen);
+    group.addButtonArea(buttons);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoListeView.java
@@ -23,10 +23,12 @@ import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction.EXPORT_TYP;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.menu.Mitgliedskonto2Menu;
 import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.util.ApplicationException;
 
 public class MitgliedskontoListeView extends AbstractView
 {
@@ -43,6 +45,18 @@ public class MitgliedskontoListeView extends AbstractView
         control.getVondatum(MitgliedskontoControl.DATUM_MITGLIEDSKONTO));
     group.addLabelPair("Bis",
         control.getBisdatum(MitgliedskontoControl.DATUM_MITGLIEDSKONTO));
+    
+    ButtonArea button = new ButtonArea();
+    Button suchen = new Button("Suchen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        control.refreshMitgliedskontoList();
+      }
+    }, null, true, "search.png");
+    button.addButton(suchen);
+    group.addButtonArea(button);
     group.addLabelPair("Differenz", control.getDifferenz());
 
     control.getMitgliedskontoList(new MitgliedDetailAction(),


### PR DESCRIPTION
Beim Testen des Mitgliedskonten Auswahl Dialog und View habe ich festgestellt, dass bei jedem Klick in die Datums und Name Felder ein Query ausgelöst wird. Auch während des Editieren der Einträge. Allerdings erfolgt kein Update in der Anzeige. Auch beim Wechsel vom Eclipse in JVerein wird ein Query ausgelöst. Als ich einen Breackpoint im Query hatte bin ich fast kontinuierlich auf den Breakpoint gelaufen. Das ist nicht gut.
Ich habe jetzt einen Suchen Button eingeführt. Beim Editieren der Datums Felder und des Namen Feldes passiert jetzt kein Query mehr.
Ein Query passiert entweder wenn man den Suchen Button drückt oder einen neuen Eintrag im Differenz Feld auswählt.

Dan war noch ein Bug in den Actions. Da muss abort=false gesetzt werden weil sonst gedacht wird, dass die Doppel Klick Aktion abgebrochen wurde und die Selektion wird nicht berücksichtigt.