### PR TITLE
Set versand to fix error message

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -552,14 +552,11 @@ public class MailControl extends AbstractControl
       {
         m.setVersand(new Timestamp(new Date().getTime()));
       }
-      else
-      {
-        m.setVersand(null);
-      }
       m.store();
       for (MailEmpfaenger me : getMail().getEmpfaenger())
       {
         me.setMail(m);
+        me.setVersand(m.getVersand());
         me.store();
       }
       DBIterator<MailEmpfaenger> it = Einstellungen.getDBService()


### PR DESCRIPTION
Vor dem Fix kam eine Fehlermeldung. Das Datum wurde dann im nachhinein gesetzt, war aber unschön zu sehen. Da die DB Spalte nicht null enthalten darf, habe ich den else-Fall auch entfernt.
<img width="1089" alt="image" src="https://github.com/openjverein/jverein/assets/63780296/0151636b-7e4c-4f8e-9523-da1d0b718f3b">
