### PR TITLE
Fix Mitglied speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -3136,8 +3136,15 @@ public class MitgliedControl extends AbstractControl
       {
         if (externemitgliedsnummer != null)
         {
-          m.setExterneMitgliedsnummer(
-              (String) getExterneMitgliedsnummer().getValue());
+          String mitgliedsnummer = (String) getExterneMitgliedsnummer().getValue();
+          if (mitgliedsnummer != null && !mitgliedsnummer.isEmpty())
+          {
+            m.setExterneMitgliedsnummer(mitgliedsnummer);
+          }
+          else
+          {
+            throw new ApplicationException("Externe Mitgliedsnummer fehlt");
+          }
         }
       }
       else

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -257,7 +257,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     if (Einstellungen.getEinstellung().getExterneMitgliedsnummer() == false)
       return;
 
-    if (getExterneMitgliedsnummer() == null)
+    if (getExterneMitgliedsnummer() == null || getExterneMitgliedsnummer().isEmpty())
     {
       throw new ApplicationException("Externe Mitgliedsnummer fehlt");
     }


### PR DESCRIPTION
Ist externe Mitgliedsnummer eingeschaltet und man erzeugt ein neues Mitglied und gibt aber keine externe Mitgliedsnummer ein, kommt es zu einer SQL Exception und einer allgemeinen Fehlermeldung.
Jetzt wird ausgegeben, dass die externe Mitgliedsnummer fehlt.