### PR TITLE
Fix Adresse erzeugen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/AdresseDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AdresseDetailAction.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.util.ApplicationException;
 
 public class AdresseDetailAction implements Action
@@ -52,12 +53,20 @@ public class AdresseDetailAction implements Action
               PersonenartDialog.POSITION_CENTER);
           String pa = pad.open();
           m.setPersonenart(pa);
+          if (pa == null)
+          {
+            return;
+          }
         }
         else
         {
           m.setPersonenart("n");
         }
       }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
     }
     catch (Exception e)
     {


### PR DESCRIPTION
Ist juristische Personen erlaubt eingestellt und man erzeugt eine Adresse erscheint der Personenart Auswahl Dialog.
Bricht man diesen mit Abbrechen oder Schließen ab kommt es  zu einer Fehlermeldung bzw. Stacktrace.
Ich habe die Korrektur entsprechend der Implemtierung für ein neues Mitglied gemacht.