### PR TITLE
Gespeicherte Mail öffnen ging nicht

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MailDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailDetailAction.java
@@ -55,7 +55,6 @@ public class MailDetailAction implements Action
             m.setBetreff(mv.getBetreff());
             m.setTxt(mv.getTxt());
           }
-          GUI.startView(MailDetailView.class.getName(), m);
         }
       }
       catch (OperationCanceledException oce)
@@ -68,5 +67,6 @@ public class MailDetailAction implements Action
             "Fehler bei der Erzeugung der neuen Mail", e);
       }
     }
+    GUI.startView(MailDetailView.class.getName(), m);
   }
 }


### PR DESCRIPTION
Man konnte keine gespeicherten Mails öffnen. Hatte ich wohl in einem früheren Request kaputt gemacht.