### PR TITLE
Fix Arbeitseinsätze prüfen

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzUeberpruefungList.java
+++ b/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzUeberpruefungList.java
@@ -105,7 +105,7 @@ public class ArbeitseinsatzUeberpruefungList extends TablePart implements Part
   public ArrayList<ArbeitseinsatzZeile> getInfo() throws RemoteException
   {
 
-    String sql = "select mitglied.id as id, arbeitseinsatzstunden  sollstunden, beitragsgruppe.arbeitseinsatzbetrag as betrag, sum(stunden)  iststunden from mitglied "
+    String sql = "select mitglied.id as id, arbeitseinsatzstunden sollstunden, beitragsgruppe.arbeitseinsatzbetrag as betrag, sum(stunden) iststunden from mitglied "
         + "  join beitragsgruppe on mitglied.beitragsgruppe = beitragsgruppe.id "
         + "  left join arbeitseinsatz on mitglied.id = arbeitseinsatz.mitglied and year(arbeitseinsatz.datum) = ? "
         + "where  (mitglied.eintritt is null or year(mitglied.eintritt) <= ?) and "
@@ -117,7 +117,7 @@ public class ArbeitseinsatzUeberpruefungList extends TablePart implements Part
       sql += "        and beitragsgruppe.arbeitseinsatzstunden is not null and "
           + "        beitragsgruppe.arbeitseinsatzstunden > 0 ";
     }
-    sql += "group by mitglied.id ";
+    sql += "group by mitglied.id, year(arbeitseinsatz.datum)";
     if (schluessel == ArbeitseinsatzUeberpruefungInput.MINDERLEISTUNG)
     {
       sql += "    having iststunden < arbeitseinsatzstunden or iststunden is null  ";


### PR DESCRIPTION
Bei mir kam es zu SQL Exceptions wenn Arbeitseinsätze für mehrere Jahre existiert haben und zwar bei Minderleistung und passende Leistung in einem speziellen Fall.
Ich hatte in einem Jahr eine Person mit Arbeitsleistung (iststunden > 0) aber keine Sollstunden für diese Person (arbeitseinsatzstunden == null). Die anderen Personen hatten Sollstunden (arbeitseinsatzstunden > 0) aber noch nichts geleistet, also iststunden == null.
Da hätte man wohl weitere having Bedingungen einfügen müssen. Beim Ausprobieren hat es auch mit group by year(arbeitseinsatz.datum) funktioniert.