### PR TITLE
Feature: Mitglied zu Nicht-Mitglied umwandeln

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/MitgliedNextBGruppePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/MitgliedNextBGruppePart.java
@@ -67,7 +67,7 @@ public class MitgliedNextBGruppePart implements Part
 
     tab = new TabFolder(cont.getComposite(), SWT.NONE);
     tab.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-    TabGroup tg1 = new TabGroup(tab, "zukünftige Beitragsgruppen");
+    TabGroup tg1 = new TabGroup(tab, "Zukünftige Beitragsgruppen");
 
     control.getMitgliedBeitraegeTabelle().paint(tg1.getComposite());
   }


### PR DESCRIPTION
Da ich früher nicht wusste, dass man Nicht-Mitglieder eingeben kann, hatte ich diese als Mitglieder mit einer speziellen Beitragsgruppe geführt.
Das wollte ich korrigieren. Es gab aber nur das Feature um ein Nicht-Mitglied in ein Mitglied umzuwandeln. Darum habe ich nun den umgekehrten Weg implementiert.
P.S: Habe noch die Tab Überschrift in Großbuchstaben umgewandelt.