### PR TITLE
Fix MitgliedskontoMenü Exception

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -228,7 +228,7 @@ public class MitgliedskontoMenu extends ContextMenu
               }
             }
           }
-          catch (RemoteException e)
+          catch (Exception e)
           {
             return false;
           }


### PR DESCRIPTION
Es kam zu einem Absturz (Nullpointer Exception) wenn der Buchung keine Buchungsart zugeordnet war.