### PR TITLE
Korrigiere Umbenennung und Typo

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstbuchungLoesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstbuchungLoesenAction.java
@@ -41,8 +41,8 @@ public class MitgliedskontoIstbuchungLoesenAction implements Action
     }
   	
     YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-    d.setTitle("Istbuchung vom Mitgliedskonto lösen");
-    d.setText("Wollen Sie die Istbuchung wirklich vom Mitgliedskonto lösen?");
+    d.setTitle("Istbuchung von Sollbuchung lösen");
+    d.setText("Wollen Sie die Istbuchung wirklich von der Sollbuchung lösen?");
 
     try
     {
@@ -71,14 +71,14 @@ public class MitgliedskontoIstbuchungLoesenAction implements Action
         bu.store();
         GUI.getStatusBar().setSuccessText(
 
-        "Istbuchung vom Mitgliedskonto gelöst.");
+        "Istbuchung von Sollbuchung gelöst.");
         Application.getMessagingFactory().sendMessage(
             new MitgliedskontoMessage(mkn.getMitglied()));
       }
       catch (RemoteException e)
       {
         throw new ApplicationException(
-            "Fehler beim lösen der Istbuchung vom Mitgliedskonto");
+            "Fehler beim lösen der Istbuchung von der Sollbuchung");
       }
     }
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -401,7 +401,7 @@ public class MitgliedskontoControl extends AbstractControl
       return spezialsuche1;
     }
     spezialsuche1 = new CheckboxInput(false);
-    spezialsuche1.setName("Erlaube Teilsting Vergleich");
+    spezialsuche1.setName("Erlaube Teilstring Vergleich");
     spezialsuche1.addListener(new Listener()
     {
 
@@ -429,7 +429,7 @@ public class MitgliedskontoControl extends AbstractControl
       return spezialsuche2;
     }
     spezialsuche2 = new CheckboxInput(false);
-    spezialsuche2.setName("Erlaube Teilsting Vergleich");
+    spezialsuche2.setName("Erlaube Teilstring Vergleich");
     spezialsuche2.addListener(new Listener()
     {
 

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -52,7 +52,7 @@ public class MitgliedskontoMenu extends ContextMenu
         new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
         new MitgliedskontoSollbuchungLoeschenAction(), "list-remove.png"));
-    addItem(new SollMitIstItem("Istbuchung vom Mitgliedskonto lösen",
+    addItem(new SollMitIstItem("Istbuchung von Sollbuchung lösen",
         new MitgliedskontoIstbuchungLoesenAction(), "unlocked.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SpendenbescheinigungItem("Geldspendenbescheinigung",


### PR DESCRIPTION
Da war ein Rechtschreibfehler und eine fehlende Umbenennung von Mitgliedskonto in Sollbuchung in den Texten.