### PR TITLE
Einige Korrekturen und Fixes

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -18,19 +18,17 @@ package de.jost_net.JVerein.gui.control;
 
 import java.io.File;
 import java.rmi.RemoteException;
-import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Calendar;
+import java.util.Date;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.parts.KontensaldoList;
-import de.jost_net.JVerein.io.JahressaldoPDF;
+import de.jost_net.JVerein.io.KontenSaldoPDF;
 import de.jost_net.JVerein.io.SaldoZeile;
 import de.jost_net.JVerein.util.Dateiname;
-import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -138,19 +136,10 @@ public class KontensaldoControl extends SaldoControl
 
       final File file = new File(s);
       settings.setAttribute("lastdir", file.getParent());
-      Calendar cal = Calendar.getInstance();
-      cal.setTime(getDatumvon().getDate());
-      int jahr = cal.get(Calendar.YEAR);
-      Geschaeftsjahr gj = new Geschaeftsjahr(jahr);
-
-      auswertungSaldoPDF(zeile, file, gj);
+      auswertungSaldoPDF(zeile, file, getDatumvon().getDate(),
+          getDatumbis().getDate());
     }
     catch (RemoteException e)
-    {
-      throw new ApplicationException(
-          "Fehler beim Aufbau des Reports: " + e.getMessage());
-    }
-    catch (ParseException e)
     {
       throw new ApplicationException(
           "Fehler beim Aufbau des Reports: " + e.getMessage());
@@ -158,7 +147,7 @@ public class KontensaldoControl extends SaldoControl
   }
 
   private void auswertungSaldoPDF(final ArrayList<SaldoZeile> zeile,
-      final File file, final Geschaeftsjahr gj)
+      final File file, final Date datumvon, final Date datumbis)
   {
     BackgroundTask t = new BackgroundTask()
     {
@@ -168,7 +157,7 @@ public class KontensaldoControl extends SaldoControl
       {
         try
         {
-          new JahressaldoPDF(zeile, file, gj);
+          new KontenSaldoPDF(zeile, file, datumvon, datumbis);
           GUI.getCurrentView().reload();
         }
         catch (ApplicationException ae)

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2548,7 +2548,7 @@ public class MitgliedControl extends AbstractControl
     {
       return suchexternemitgliedsnummer;
     }
-    suchexternemitgliedsnummer = new TextInput("", 50);
+    suchexternemitgliedsnummer = new TextInput(settings.getString(mitgliedtyp + ".suchExterneMitgliedsNummer",""), 50);
     return suchexternemitgliedsnummer;
   }
 
@@ -2793,7 +2793,14 @@ public class MitgliedControl extends AbstractControl
       settings.setAttribute("status.mitglied",
           (String) getMitgliedStatus().getValue());
     }
-
+    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
+    {
+      String tmp = (String) getSuchExterneMitgliedsnummer().getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute(mitgliedtyp + ".suchExterneMitgliedsNummer",tmp);
+      }
+    }
     if (geburtsdatumvon != null)
     {
       Date tmp = (Date) getGeburtsdatumvon().getValue();

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2800,6 +2800,10 @@ public class MitgliedControl extends AbstractControl
       {
         settings.setAttribute(mitgliedtyp + ".suchExterneMitgliedsNummer",tmp);
       }
+      else
+      {
+        settings.setAttribute(mitgliedtyp + ".suchExterneMitgliedsNummer","");
+      }
     }
     if (geburtsdatumvon != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -1006,10 +1006,7 @@ public class MitgliedskontoControl extends AbstractControl
       {
         try
         {
-          settings.setAttribute(datumverwendung + "datumvon",
-              new JVDateFormatTTMMJJJJ().format(von.getValue()));
-          settings.setAttribute(datumverwendung + "datumbis",
-              new JVDateFormatTTMMJJJJ().format(bis.getValue()));
+          saveDefaults();
           new Kontoauszug(currentObject, (Date) von.getValue(), (Date) bis.getValue());
         }
         catch (Exception e)

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -163,6 +163,8 @@ public class MitgliedskontoControl extends AbstractControl
 
   private TextInput suchname = null;
 
+  private TextInput suchname1 = null;
+
   private TextInput suchname2 = null;
 
   private SelectInput differenz = null;
@@ -469,17 +471,31 @@ public class MitgliedskontoControl extends AbstractControl
     return differenz;
   }
 
+  // Für SollbuchungListeView
   public TextInput getSuchName()
   {
     if (suchname != null && !suchname.getControl().isDisposed())
     {
       return suchname;
     }
-    suchname = new TextInput("", 30);
+    suchname = new TextInput(settings.getString("sollbuchung.suchname",""), 30);
     suchname.setName("Name");
     return suchname;
   }
 
+  // Für SollbuchungAuswahlDialog
+  public TextInput getSuchName1(boolean newcontrol)
+  {
+    if (!newcontrol && suchname1 != null)
+    {
+      return suchname1;
+    }
+    suchname1 = new TextInput("", 30);
+    suchname1.setName("Name");
+    return suchname1;
+  }
+  
+  //Für SollbuchungAuswahlDialog
   public TextInput getSuchName2(boolean newcontrol)
   {
     if (!newcontrol && suchname2 != null)
@@ -546,33 +562,46 @@ public class MitgliedskontoControl extends AbstractControl
   
   public void saveDefaults()
   {	  
-	  if (this.vondatum != null)
-	    {
-	      Date tmp = (Date) getVondatum("kontoauszugdatumvon").getValue();
-	      if (tmp != null)
-	      {
-	        settings.setAttribute("kontoauszugdatumvon",
-	            new JVDateFormatTTMMJJJJ().format(tmp));
-	      }
-	      else
-	      {
-	        settings.setAttribute("kontoauszugdatumvon", "");
-	      }
-	    }
+    if (this.suchname != null)
+    {
+      String tmp = (String) getSuchName().getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute("sollbuchung.suchname", tmp);
+      }
+      else
+      {
+        settings.setAttribute("sollbuchung.suchname", "");
+      }
+    }
+    
+    if (this.vondatum != null)
+    {
+      Date tmp = (Date) getVondatum("kontoauszugdatumvon").getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute("kontoauszugdatumvon",
+            new JVDateFormatTTMMJJJJ().format(tmp));
+      }
+      else
+      {
+        settings.setAttribute("kontoauszugdatumvon", "");
+      }
+    }
 
-	    if (this.bisdatum != null)
-	    {
-	      Date tmp = (Date) getBisdatum("kontoauszugdatumbis").getValue();
-	      if (tmp != null)
-	      {
-	        settings.setAttribute("kontoauszugdatumbis",
-	            new JVDateFormatTTMMJJJJ().format(tmp));
-	      }
-	      else
-	      {
-	        settings.setAttribute("kontoauszugbatumbis", "");
-	      }
-	    }	  
+    if (this.bisdatum != null)
+    {
+      Date tmp = (Date) getBisdatum("kontoauszugdatumbis").getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute("kontoauszugdatumbis",
+            new JVDateFormatTTMMJJJJ().format(tmp));
+      }
+      else
+      {
+        settings.setAttribute("kontoauszugbatumbis", "");
+      }
+    }	  
   }
   
   public void handleStore()

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -554,27 +554,9 @@ public class MitgliedskontoControl extends AbstractControl
     txt.setName("Text");
     return txt;
   }
-
-  private void refresh()
-  { 
-	  saveDefaults();
-  }
   
   public void saveDefaults()
   {	  
-    if (this.suchname != null)
-    {
-      String tmp = (String) getSuchName().getValue();
-      if (tmp != null)
-      {
-        settings.setAttribute("sollbuchung.suchname", tmp);
-      }
-      else
-      {
-        settings.setAttribute("sollbuchung.suchname", "");
-      }
-    }
-    
     if (this.vondatum != null)
     {
       Date tmp = (Date) getVondatum("kontoauszugdatumvon").getValue();
@@ -695,7 +677,7 @@ public class MitgliedskontoControl extends AbstractControl
     this.action = action;
     @SuppressWarnings("rawtypes")
     GenericIterator mitgliedskonten = getMitgliedskontoIterator();
-    settings.setAttribute("differenz", getDifferenz().getValue().toString());
+    settings.setAttribute(datumverwendung + "differenz", getDifferenz().getValue().toString());
     if (mitgliedskontoList == null)
     {
       mitgliedskontoList = new TablePart(mitgliedskonten, action);
@@ -807,6 +789,7 @@ public class MitgliedskontoControl extends AbstractControl
   {
     @SuppressWarnings("rawtypes")
     GenericIterator mitgliedskonten = getMitgliedskontoIterator();
+    settings.setAttribute(datumverwendung + "differenz", getDifferenz().getValue().toString());
     mitgliedskontoList.removeAll();
     while (mitgliedskonten.hasNext())
     {
@@ -1023,6 +1006,10 @@ public class MitgliedskontoControl extends AbstractControl
       {
         try
         {
+          settings.setAttribute(datumverwendung + "datumvon",
+              new JVDateFormatTTMMJJJJ().format(von.getValue()));
+          settings.setAttribute(datumverwendung + "datumbis",
+              new JVDateFormatTTMMJJJJ().format(bis.getValue()));
           new Kontoauszug(currentObject, (Date) von.getValue(), (Date) bis.getValue());
         }
         catch (Exception e)
@@ -1104,7 +1091,6 @@ public class MitgliedskontoControl extends AbstractControl
           Logger.error("Fehler", e);
         }
       }
-      refresh();
     }
   }
   
@@ -1113,13 +1099,13 @@ public class MitgliedskontoControl extends AbstractControl
   {
     try
     {
+      settings.setAttribute("sollbuchung.suchname", getSuchName().getValue().toString());
       getMitgliedskontoList(action, null);
     }
     catch (RemoteException e)
     {
       Logger.error("Fehler", e);
     }
-    refresh();
   }
   
   // Für SollbuchungAuswahlDialog
@@ -1133,7 +1119,6 @@ public class MitgliedskontoControl extends AbstractControl
     {
       Logger.error("Fehler", e);
     }
-    settings.setAttribute("differenz", getDifferenz().getValue().toString());
   }
   
   // Für SollbuchungAuswahlDialog

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -117,7 +117,7 @@ public class ProjektSaldoControl extends SaldoControl
       ArrayList<ProjektSaldoZeile> zeile = saldoList.getInfo();
 
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
-      fd.setText("Ausgabedatei w?hlen.");
+      fd.setText("Ausgabedatei wählen.");
       //
       Settings settings = new Settings(this.getClass());
       //

--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
@@ -36,7 +36,6 @@ import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
-import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
@@ -108,9 +107,8 @@ public class SollbuchungAuswahlDialog extends AbstractDialog<Object>
     TabGroup tabNurIst = new TabGroup(folder, "Istbuchung einer Sollbuchung zuordnen", false, 1);
     LabelGroup grNurIst = new LabelGroup(tabNurIst.getComposite(), "Filter");
 
-    TextInput suNa = control.getSuchName();
-    suNa.setValue(buchung.getName());
-    grNurIst.addLabelPair("Name", suNa);
+    control.getSuchName1(true).setValue(buchung.getName());
+    grNurIst.addLabelPair("Name", control.getSuchName1(false));
     grNurIst.addLabelPair("Differenz",
         control.getDifferenz(DIFFERENZ.FEHLBETRAG));
     grNurIst.addInput(control.getSpezialSuche1());

--- a/src/de/jost_net/JVerein/io/KontenSaldoPDF.java
+++ b/src/de/jost_net/JVerein/io/KontenSaldoPDF.java
@@ -19,26 +19,28 @@ package de.jost_net.JVerein.io;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
+import java.util.Date;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Element;
 
-import de.jost_net.JVerein.util.Geschaeftsjahr;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class JahressaldoPDF
+public class KontenSaldoPDF
 {
 
-  public JahressaldoPDF(ArrayList<SaldoZeile> zeile, final File file,
-      Geschaeftsjahr gj) throws ApplicationException
+  public KontenSaldoPDF(ArrayList<SaldoZeile> zeile, final File file,
+      final Date datumvon, final Date datumbis) throws ApplicationException
   {
     try
     {
       FileOutputStream fos = new FileOutputStream(file);
-      String subtitle = gj.toString();
-      Reporter reporter = new Reporter(fos, "Jahressaldo", subtitle,
+      String subtitle = new JVDateFormatTTMMJJJJ().format(datumvon) + " - "
+          + new JVDateFormatTTMMJJJJ().format(datumbis);
+      Reporter reporter = new Reporter(fos, "Kontensaldo", subtitle,
           zeile.size());
 
       reporter.addHeaderColumn("Konto-\nnummer", Element.ALIGN_CENTER, 50,

--- a/src/de/jost_net/JVerein/io/Mahnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Mahnungsausgabe.java
@@ -37,7 +37,7 @@ public class Mahnungsausgabe extends AbstractMitgliedskontoDokument
         .getValue();
     if (form == null)
     {
-      throw new IOException("kein Mahnungsformular ausgewählt");
+      throw new IOException("Kein Mahnungsformular ausgewählt");
     }
     Formular formular = (Formular) Einstellungen.getDBService().createObject(
         Formular.class, form.getID());

--- a/src/de/jost_net/JVerein/io/ProjektSaldoPDF.java
+++ b/src/de/jost_net/JVerein/io/ProjektSaldoPDF.java
@@ -42,7 +42,7 @@ public class ProjektSaldoPDF
       FileOutputStream fos = new FileOutputStream(file);
       String subtitle = new JVDateFormatTTMMJJJJ().format(datumvon) + " - "
           + new JVDateFormatTTMMJJJJ().format(datumbis);
-      Reporter reporter = new Reporter(fos, "Projekte-Saldo", subtitle,
+      Reporter reporter = new Reporter(fos, "Projekt-Saldo", subtitle,
           zeile.size());
       makeHeader(reporter);
 

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -40,7 +40,7 @@ public class Rechnungsausgabe extends AbstractMitgliedskontoDokument
         .getValue();
     if (form == null)
     {
-      throw new IOException("kein Rechnungsformular ausgewählt");
+      throw new IOException("Kein Rechnungsformular ausgewählt");
     }
     Formular formular = (Formular) Einstellungen.getDBService()
         .createObject(Formular.class, form.getID());


### PR DESCRIPTION
Konten-Saldo:
- JahressaldoPDF.java in KontenSaldoPDF.java umbenannt.
- Ausgabezeitraum im Report umgestellt von GJ auf den ausgewählten Zeitbereich.
- Das korrigiert die falsche Angabe des Zeitbereichs im Report.
- Report Überschrift auf Kontensaldo geändert.
Projekt-Saldo PDF/Control:
- Typos korrigiert.
Suchname für Sollbuchungen:
- Der gleiche Suchname war für den SollbuchungenView und SollbuchungAuswahlDialog verwendet
- In MitgliedskontoControl einen eigenen Suchname1 für den SollbuchungAuswahlDialog eingeführt
- In MitgliedskontoControl den Suchname in die Settings aufgenommen. So bleibt der Wert im SollbuchungenView erhalten. Der Wert im Dialog wird immer mit dem Namen aus der Buchung initialisiert.
MitgliedControl:
- Externe Mitgliedsnummer in Settings aufgenommen. Damit bleibt der Wert bei View Wechsel erhalten.
Mahnungs-, Rechnungsausgabe:
- Großschrift
Kontoauszug:
- Defaults (Von, Bis Datum)  speichern bei Reportgenerierung