### PR TITLE
Fix internen  Fehler und Auswertung Bug

### DIFF
--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -78,10 +78,13 @@ public class MitgliedQuery
     ArrayList<Object> bedingungen = new ArrayList<>();
 
     sql = "select distinct mitglied.*, ucase(name), ucase(vorname) ";
-    String sort = (String) control.getSortierung().getValue();
-    if (sort.equals("Geburtstagsliste"))
+    if (control.isSortierungAktiv())
     {
-      sql += ", month(geburtsdatum), day(geburtsdatum) ";
+      String sort = (String) control.getSortierung().getValue();
+      if (sort.equals("Geburtstagsliste"))
+      {
+        sql += ", month(geburtsdatum), day(geburtsdatum) ";
+      }
     }
     sql += "from mitglied ";
     Settings settings = control.getSettings();
@@ -408,25 +411,29 @@ public class MitgliedQuery
         bedingungen.add(Integer.valueOf(bg.getID()));
       }
     }
-    if (sort.equals("Name, Vorname"))
+    if (control.isSortierungAktiv())
     {
-      sql += " ORDER BY ucase(name), ucase(vorname)";
-    }
-    else if (sort.equals("Eintrittsdatum"))
-    {
-      sql += " ORDER BY eintritt";
-    }
-    else if (sort.equals("Geburtsdatum"))
-    {
-      sql += " ORDER BY geburtsdatum";
-    }
-    else if (sort.equals("Geburtstagsliste"))
-    {
-      sql += " ORDER BY month(geburtsdatum), day(geburtsdatum)";
-    }
-    else
-    {
-      sql += " ORDER BY name, vorname";
+      String sort = (String) control.getSortierung().getValue();
+      if (sort.equals("Name, Vorname"))
+      {
+        sql += " ORDER BY ucase(name), ucase(vorname)";
+      }
+      else if (sort.equals("Eintrittsdatum"))
+      {
+        sql += " ORDER BY eintritt";
+      }
+      else if (sort.equals("Geburtsdatum"))
+      {
+        sql += " ORDER BY geburtsdatum";
+      }
+      else if (sort.equals("Geburtstagsliste"))
+      {
+        sql += " ORDER BY month(geburtsdatum), day(geburtsdatum)";
+      }
+      else
+      {
+        sql += " ORDER BY name, vorname";
+      }
     }
     Logger.debug(sql);
 

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -430,11 +430,12 @@ public class MitgliedQuery
       {
         sql += " ORDER BY month(geburtsdatum), day(geburtsdatum)";
       }
-      else
-      {
-        sql += " ORDER BY name, vorname";
-      }
     }
+    else
+    {
+      sql += " ORDER BY name, vorname";
+    }
+    
     Logger.debug(sql);
 
     ResultSetExtractor rs = new ResultSetExtractor()

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -313,13 +313,13 @@ public class MitgliedQuery
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
 
-    if (batch && control.getSterbedatumvon().getValue() != null  && adresstyp == 1)
+    if (batch && adresstyp == 1 && control.getSterbedatumvon().getValue() != null)
     {
       addCondition("sterbetag >= ?");
       Date d = (Date) control.getSterbedatumvon().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
-    if (batch && control.getSterbedatumbis().getValue() != null  && adresstyp == 1)
+    if (batch && adresstyp == 1 && control.getSterbedatumbis().getValue() != null)
     {
       addCondition("sterbetag <= ?");
       Date d = (Date) control.getSterbedatumbis().getValue();
@@ -332,19 +332,19 @@ public class MitgliedQuery
       String g = (String) control.getGeschlecht().getValue();
       bedingungen.add(g);
     }
-    if (control.getEintrittvon().getValue() != null  && adresstyp == 1)
+    if (adresstyp == 1 && control.getEintrittvon().getValue() != null)
     {
       addCondition("eintritt >= ?");
       Date d = (Date) control.getEintrittvon().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
-    if (control.getEintrittbis().getValue() != null  && adresstyp == 1)
+    if (adresstyp == 1 && control.getEintrittbis().getValue() != null)
     {
       addCondition("eintritt <= ?");
       Date d = (Date) control.getEintrittbis().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
-    if (control.isAustrittbisAktiv()  && adresstyp == 1)
+    if (adresstyp == 1 && control.isAustrittbisAktiv())
     {
       if (control.getAustrittvon().getValue() != null)
       {
@@ -366,17 +366,18 @@ public class MitgliedQuery
         addCondition("(austritt is null or austritt > current_date())");
       }
     }
-    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
+    if (adresstyp == 1 && Einstellungen.getEinstellung().getExterneMitgliedsnummer())
     {
       try
       {
-        if (control.getSuchExterneMitgliedsnummer().getValue() != null  && adresstyp == 1)
+        if (control.getSuchExterneMitgliedsnummer().getValue() != null)
         {
           String ext = (String) control.getSuchExterneMitgliedsnummer()
               .getValue();
           if (ext.length() > 0)
           {
             addCondition("externemitgliedsnummer = ?");
+            bedingungen.add(ext);
           }
         }
       }
@@ -385,11 +386,15 @@ public class MitgliedQuery
         // Workaround für einen Bug in IntegerInput
       }
     }
-    Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
-        .getValue();
-    if (bg != null  && adresstyp == 1)
+    if (adresstyp == 1)
     {
-      addCondition("beitragsgruppe = ? ");
+      Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
+          .getValue();
+      if (bg != null)
+      {
+        addCondition("beitragsgruppe = ? ");
+        bedingungen.add(Integer.valueOf(bg.getID()));
+      }
     }
     if (sort.equals("Name, Vorname"))
     {
@@ -428,27 +433,6 @@ public class MitgliedQuery
       }
     };
 
-    try
-    {
-      if (Einstellungen.getEinstellung().getExterneMitgliedsnummer()
-          && control.getSuchExterneMitgliedsnummer().getValue() != null  && adresstyp == 1)
-      {
-        String ext = (String) control.getSuchExterneMitgliedsnummer()
-            .getValue();
-        if (ext.length() > 0)
-        {
-          bedingungen.add(control.getSuchExterneMitgliedsnummer().getValue());
-        }
-      }
-    }
-    catch (NullPointerException e)
-    {
-      // Workaround f. Bug in IntegerInput
-    }
-    if (bg != null && adresstyp == 1)
-    {
-      bedingungen.add(Integer.valueOf(bg.getID()));
-    }
     return (ArrayList<Mitglied>) service.execute(sql, bedingungen.toArray(),
         rs);
   }

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -340,11 +340,11 @@ public class MitgliedQuery
       Date d = (Date) control.getSterbedatumbis().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
-    if (control.isGeschlechtAktiv() && control.getGeschlecht().getText() != null
-        && !control.getGeschlecht().getText().equals("Bitte auswählen"))
+    if (control.isSuchGeschlechtAktiv() && control.getSuchGeschlecht().getText() != null
+        && !control.getSuchGeschlecht().getText().equals("Bitte auswählen"))
     {
       addCondition("geschlecht = ?");
-      String g = (String) control.getGeschlecht().getValue();
+      String g = (String) control.getSuchGeschlecht().getValue();
       bedingungen.add(g);
     }
     if (control.isEintrittvonAktiv() && control.getEintrittvon().getValue() != null)

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -359,20 +359,22 @@ public class MitgliedQuery
       Date d = (Date) control.getEintrittbis().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
+    if (control.isAustrittvonAktiv() && control.getAustrittvon().getValue() != null)
+    {
+      addCondition("austritt >= ?");
+      Date d = (Date) control.getAustrittvon().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    if (control.isAustrittbisAktiv() && control.getAustrittbis().getValue() != null)
+    {
+      addCondition("austritt <= ?");
+      Date d = (Date) control.getAustrittbis().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    
     if (control.isAustrittbisAktiv())
     {
-      if (control.getAustrittvon().getValue() != null)
-      {
-        addCondition("austritt >= ?");
-        Date d = (Date) control.getAustrittvon().getValue();
-        bedingungen.add(new java.sql.Date(d.getTime()));
-      }
-      if (control.getAustrittbis().getValue() != null)
-      {
-        addCondition("austritt <= ?");
-        Date d = (Date) control.getAustrittbis().getValue();
-        bedingungen.add(new java.sql.Date(d.getTime()));
-      }
+      // Was soll das? Das wird nie durchlaufen!
       if (control.getSterbedatumvon() == null
           && control.getSterbedatumbis() == null
           && control.getAustrittvon().getValue() == null
@@ -381,6 +383,7 @@ public class MitgliedQuery
         addCondition("(austritt is null or austritt > current_date())");
       }
     }
+    
     if (control.isSuchExterneMitgliedsnummerActive())
     {
       try

--- a/src/de/jost_net/JVerein/gui/action/AuswertungAdressenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AuswertungAdressenAction.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.action;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.view.AuswertungAdresseView;
+import de.jost_net.JVerein.gui.view.AuswertungNichtMitgliedView;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -53,7 +53,7 @@ public class AuswertungAdressenAction implements Action
       }
     }
 
-    GUI.startView(AuswertungAdresseView.class.getName(), m);
+    GUI.startView(AuswertungNichtMitgliedView.class.getName(), m);
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -474,6 +474,11 @@ public class MitgliedControl extends AbstractControl
     });
     return suchadresstyp;
   }
+  
+  public boolean isSuchAdresstypActive()
+  {
+    return suchadresstyp != null;
+  }
 
   public SelectInput getAdresstyp() throws RemoteException
   {
@@ -707,6 +712,11 @@ public class MitgliedControl extends AbstractControl
     geschlecht.setMandatory(true);
     geschlecht.setName("Geschlecht");
     return geschlecht;
+  }
+  
+  public boolean isGeschlechtAktiv()
+  {
+    return geschlecht != null;
   }
 
   public SelectInput getZahlungsweg() throws RemoteException
@@ -1389,6 +1399,11 @@ public class MitgliedControl extends AbstractControl
     beitragsgruppeausw.setName("Beitragsgruppe");
     return beitragsgruppeausw;
   }
+  
+  public boolean isBeitragsgruppeAuswAktiv()
+  {
+    return beitragsgruppeausw != null;
+  }
 
   /**
    * Liefert ein Part zurück, das den Familienverband anzeigt. Da Container
@@ -2000,6 +2015,11 @@ public class MitgliedControl extends AbstractControl
     geburtsdatumvon.setName("Geburtsdatum von");
     return geburtsdatumvon;
   }
+  
+  public boolean isGeburtsdatumvonAktiv()
+  {
+    return geburtsdatumvon != null;
+  }
 
   public DateInput getGeburtsdatumbis()
   {
@@ -2038,6 +2058,11 @@ public class MitgliedControl extends AbstractControl
     });
     geburtsdatumbis.setName("Geburtsdatum bis");
     return geburtsdatumbis;
+  }
+  
+  public boolean isGeburtsdatumbisAktiv()
+  {
+    return geburtsdatumbis != null;
   }
 
   public DateInput getSterbedatumvon()
@@ -2078,6 +2103,11 @@ public class MitgliedControl extends AbstractControl
     sterbedatumvon.setName("Sterbedatum von");
     return sterbedatumvon;
   }
+  
+  public boolean isSterbedatumvonAktiv()
+  {
+    return sterbedatumvon != null;
+  }
 
   public DateInput getSterbedatumbis()
   {
@@ -2116,6 +2146,11 @@ public class MitgliedControl extends AbstractControl
     });
     sterbedatumbis.setName("Sterbedatum bis");
     return sterbedatumbis;
+  }
+  
+  public boolean isSterbedatumbisAktiv()
+  {
+    return sterbedatumbis != null;
   }
 
   public DateInput getEintrittvon()
@@ -2157,9 +2192,9 @@ public class MitgliedControl extends AbstractControl
     return eintrittvon;
   }
 
-  public boolean isEintrittbisAktiv()
+  public boolean isEintrittvonAktiv()
   {
-    return eintrittbis != null;
+    return eintrittvon != null;
   }
 
   public DateInput getEintrittbis()
@@ -2201,6 +2236,11 @@ public class MitgliedControl extends AbstractControl
     return eintrittbis;
   }
 
+  public boolean isEintrittbisAktiv()
+  {
+    return eintrittbis != null;
+  }
+
   public DateInput getAustrittvon()
   {
     if (austrittvon != null)
@@ -2240,9 +2280,9 @@ public class MitgliedControl extends AbstractControl
     return austrittvon;
   }
 
-  public boolean isAustrittbisAktiv()
+  public boolean isAustrittvonAktiv()
   {
-    return austrittbis != null;
+    return austrittvon != null;
   }
 
   public DateInput getAustrittbis()
@@ -2283,6 +2323,11 @@ public class MitgliedControl extends AbstractControl
     austrittbis.setName("Austritt bis");
     return austrittbis;
   }
+  
+  public boolean isAustrittbisAktiv()
+  {
+    return austrittbis != null;
+  }
 
   public TextInput getSuchname()
   {
@@ -2295,6 +2340,11 @@ public class MitgliedControl extends AbstractControl
           50);
     suchname.setName("Name");
     return suchname;
+  }
+  
+  public boolean isSuchnameAktiv()
+  {
+    return suchname != null;
   }
 
   public DateInput getStichtag()
@@ -2334,6 +2384,11 @@ public class MitgliedControl extends AbstractControl
     });
     stichtag.setName("Stichtag");
     return stichtag;
+  }
+  
+  public boolean isStichtagAktiv()
+  {
+    return stichtag != null;
   }
 
   public DateInput getStichtag(boolean jahresende)
@@ -2429,6 +2484,11 @@ public class MitgliedControl extends AbstractControl
     });
     return eigenschaftenabfrage;
   }
+  
+  public boolean isEigenschaftenAuswahlAktiv()
+  {
+    return eigenschaftenabfrage != null;
+  }
 
   public void resetEigenschaftenAuswahl()
   {
@@ -2451,6 +2511,11 @@ public class MitgliedControl extends AbstractControl
     setZusatzfelderAuswahl();
     zusatzfelderabfrage.setName("Zusatzfelder");
     return zusatzfelderabfrage;
+  }
+  
+  public boolean isZusatzfelderAuswahlAktiv()
+  {
+    return zusatzfelderabfrage != null;
   }
 
   public void resetZusatzfelderAuswahl()
@@ -2537,19 +2602,19 @@ public class MitgliedControl extends AbstractControl
     return sortierung;
   }
 
-  public boolean isMitgliedStatusAktiv()
-  {
-    return status != null;
-  }
-
   public TextInput getSuchExterneMitgliedsnummer()
   {
     if (suchexternemitgliedsnummer != null)
     {
       return suchexternemitgliedsnummer;
     }
-    suchexternemitgliedsnummer = new TextInput("", 50);
+    suchexternemitgliedsnummer = new TextInput(settings.getString(mitgliedtyp + ".suchExterneMitgliedsNummer",""), 50);
     return suchexternemitgliedsnummer;
+  }
+  
+  public boolean isSuchExterneMitgliedsnummerActive()
+  {
+    return suchexternemitgliedsnummer != null;
   }
 
   public Input getMitgliedStatus()
@@ -2565,6 +2630,11 @@ public class MitgliedControl extends AbstractControl
     return status;
   }
 
+  public boolean isMitgliedStatusAktiv()
+  {
+    return status != null;
+  }
+
   public SelectInput getMailauswahl() throws RemoteException
   {
     if (mailAuswahl != null)
@@ -2574,6 +2644,11 @@ public class MitgliedControl extends AbstractControl
     mailAuswahl = new MailAuswertungInput(1);
     mailAuswahl.setName("Mail");
     return mailAuswahl;
+  }
+  
+  public boolean isMailauswahlAktiv()
+  {
+    return mailAuswahl != null;
   }
 
   public Button getStartAuswertungButton()
@@ -2772,11 +2847,14 @@ public class MitgliedControl extends AbstractControl
     }
     lastrefresh = System.currentTimeMillis();
     saveDefaults();
-    part.removeAll();
-    ArrayList<Mitglied> mitglieder = new MitgliedQuery(this, false).get(atyp);
-    for (Mitglied m : mitglieder)
+    if (part != null)
     {
-      part.addItem(m);
+      part.removeAll();
+      ArrayList<Mitglied> mitglieder = new MitgliedQuery(this, false).get(atyp);
+      for (Mitglied m : mitglieder)
+      {
+        part.addItem(m);
+      }
     }
     return part;
   }
@@ -2793,7 +2871,19 @@ public class MitgliedControl extends AbstractControl
       settings.setAttribute("status.mitglied",
           (String) getMitgliedStatus().getValue());
     }
-
+    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer() &&
+        suchexternemitgliedsnummer != null)
+    {
+      String tmp = (String) getSuchExterneMitgliedsnummer().getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute(mitgliedtyp + ".suchExterneMitgliedsNummer",tmp);
+      }
+      else
+      {
+        settings.setAttribute(mitgliedtyp + ".suchExterneMitgliedsNummer","");
+      }
+    }
     if (geburtsdatumvon != null)
     {
       Date tmp = (Date) getGeburtsdatumvon().getValue();

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -494,6 +494,11 @@ public class MitgliedControl extends AbstractControl
     adresstyp.setName("Mitgliedstyp");
     return adresstyp;
   }
+  
+  public boolean isAdresstypActive()
+  {
+    return adresstyp != null;
+  }
 
   public TextInput getExterneMitgliedsnummer() throws RemoteException
   {
@@ -706,7 +711,8 @@ public class MitgliedControl extends AbstractControl
     {
       return geschlecht;
     }
-    geschlecht = new GeschlechtInput(getMitglied().getGeschlecht());
+    geschlecht = new GeschlechtInput(
+        settings.getString(mitgliedtyp + ".geschlecht", ""));
     geschlecht.setName("Geschlecht");
     geschlecht.setPleaseChoose("Bitte auswählen");
     geschlecht.setMandatory(true);
@@ -1375,7 +1381,7 @@ public class MitgliedControl extends AbstractControl
       return beitragsgruppeausw;
     }
     Beitragsgruppe bg = null;
-    String beitragsgru = settings.getString("mitglied.beitragsgruppe", "");
+    String beitragsgru = settings.getString(mitgliedtyp + ".beitragsgruppe", "");
     if (beitragsgru.length() > 0)
     {
       try
@@ -2072,7 +2078,7 @@ public class MitgliedControl extends AbstractControl
       return sterbedatumvon;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.sterbedatumvon", null);
+    String tmp = settings.getString(mitgliedtyp + ".sterbedatumvon", null);
     if (tmp != null)
     {
       try
@@ -2116,7 +2122,7 @@ public class MitgliedControl extends AbstractControl
       return sterbedatumbis;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.sterbedatumbis", null);
+    String tmp = settings.getString(mitgliedtyp + ".sterbedatumbis", null);
     if (tmp != null)
     {
       try
@@ -2160,7 +2166,7 @@ public class MitgliedControl extends AbstractControl
       return eintrittvon;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.eintrittvon", null);
+    String tmp = settings.getString(mitgliedtyp + ".eintrittvon", null);
     if (tmp != null)
     {
       try
@@ -2204,7 +2210,7 @@ public class MitgliedControl extends AbstractControl
       return eintrittbis;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.eintrittbis", null);
+    String tmp = settings.getString(mitgliedtyp + ".eintrittbis", null);
     if (tmp != null)
     {
       try
@@ -2248,7 +2254,7 @@ public class MitgliedControl extends AbstractControl
       return austrittvon;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.austrittvon", null);
+    String tmp = settings.getString(mitgliedtyp + ".austrittvon", null);
     if (tmp != null)
     {
       try
@@ -2292,7 +2298,7 @@ public class MitgliedControl extends AbstractControl
       return austrittbis;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.austrittbis", null);
+    String tmp = settings.getString(mitgliedtyp + ".austrittbis", null);
     if (tmp != null)
     {
       try
@@ -2354,7 +2360,7 @@ public class MitgliedControl extends AbstractControl
       return stichtag;
     }
     Date d = null;
-    String tmp = settings.getString("mitglied.stichtag", null);
+    String tmp = settings.getString(mitgliedtyp + ".stichtag", null);
     if (tmp != null)
     {
       try
@@ -2973,12 +2979,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getSterbedatumvon().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.sterbedatumvon",
+        settings.setAttribute(mitgliedtyp + ".sterbedatumvon",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.sterbedatumvon", "");
+        settings.setAttribute(mitgliedtyp + ".sterbedatumvon", "");
       }
     }
 
@@ -2987,12 +2993,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getSterbedatumbis().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.sterbedatumbis",
+        settings.setAttribute(mitgliedtyp + ".sterbedatumbis",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.sterbedatumbis", "");
+        settings.setAttribute(mitgliedtyp + ".sterbedatumbis", "");
       }
     }
 
@@ -3001,12 +3007,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getEintrittvon().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.eintrittvon",
+        settings.setAttribute(mitgliedtyp + ".eintrittvon",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.eintrittvon", "");
+        settings.setAttribute(mitgliedtyp + ".eintrittvon", "");
       }
     }
 
@@ -3015,12 +3021,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getEintrittbis().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.eintrittbis",
+        settings.setAttribute(mitgliedtyp + ".eintrittbis",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.eintrittbis", "");
+        settings.setAttribute(mitgliedtyp + ".eintrittbis", "");
       }
     }
 
@@ -3029,12 +3035,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getAustrittvon().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.austrittvon",
+        settings.setAttribute(mitgliedtyp + ".austrittvon",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.austrittvon", "");
+        settings.setAttribute(mitgliedtyp + ".austrittvon", "");
       }
     }
 
@@ -3043,12 +3049,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getAustrittbis().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.austrittbis",
+        settings.setAttribute(mitgliedtyp + ".austrittbis",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.austrittbis", "");
+        settings.setAttribute(mitgliedtyp + ".austrittbis", "");
       }
     }
     if (stichtag != null)
@@ -3056,12 +3062,12 @@ public class MitgliedControl extends AbstractControl
       Date tmp = (Date) getStichtag().getValue();
       if (tmp != null)
       {
-        settings.setAttribute("mitglied.stichtag",
+        settings.setAttribute(mitgliedtyp + ".stichtag",
             new JVDateFormatTTMMJJJJ().format(tmp));
       }
       else
       {
-        settings.setAttribute("mitglied.stichtag", "");
+        settings.setAttribute(mitgliedtyp + "stichtag", "");
       }
     }
 
@@ -3089,11 +3095,24 @@ public class MitgliedControl extends AbstractControl
           .getValue();
       if (tmpbg != null)
       {
-        settings.setAttribute("mitglied.beitragsgruppe", tmpbg.getID());
+        settings.setAttribute(mitgliedtyp + ".beitragsgruppe", tmpbg.getID());
       }
       else
       {
-        settings.setAttribute("mitglied.beitragsgruppe", "");
+        settings.setAttribute(mitgliedtyp + ".beitragsgruppe", "");
+      }
+    }
+    
+    if (geschlecht != null)
+    {
+      String tmp = (String) getGeschlecht().getValue();
+      if (tmp != null && !getGeschlecht().getText().equals("Bitte auswählen"))
+      {
+        settings.setAttribute(mitgliedtyp + ".geschlecht", tmp);
+      }
+      else
+      {
+        settings.setAttribute(mitgliedtyp + ".geschlecht", "");
       }
     }
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -711,6 +711,20 @@ public class MitgliedControl extends AbstractControl
     {
       return geschlecht;
     }
+    geschlecht = new GeschlechtInput(getMitglied().getGeschlecht());
+    geschlecht.setName("Geschlecht");
+    geschlecht.setPleaseChoose("Bitte auswählen");
+    geschlecht.setMandatory(true);
+    geschlecht.setName("Geschlecht");
+    return geschlecht;
+  }
+  
+  public GeschlechtInput getSuchGeschlecht() throws RemoteException
+  {
+    if (geschlecht != null)
+    {
+      return geschlecht;
+    }
     geschlecht = new GeschlechtInput(
         settings.getString(mitgliedtyp + ".geschlecht", ""));
     geschlecht.setName("Geschlecht");
@@ -720,7 +734,7 @@ public class MitgliedControl extends AbstractControl
     return geschlecht;
   }
   
-  public boolean isGeschlechtAktiv()
+  public boolean isSuchGeschlechtAktiv()
   {
     return geschlecht != null;
   }
@@ -3111,8 +3125,8 @@ public class MitgliedControl extends AbstractControl
     
     if (geschlecht != null)
     {
-      String tmp = (String) getGeschlecht().getValue();
-      if (tmp != null && !getGeschlecht().getText().equals("Bitte auswählen"))
+      String tmp = (String) getSuchGeschlecht().getValue();
+      if (tmp != null && !getSuchGeschlecht().getText().equals("Bitte auswählen"))
       {
         settings.setAttribute(mitgliedtyp + ".geschlecht", tmp);
       }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2194,7 +2194,7 @@ public class MitgliedControl extends AbstractControl
         }
       }
     });
-    eintrittvon.setName("Eintritt von");
+    eintrittvon.setName("Eintrittsdatum von");
     return eintrittvon;
   }
 
@@ -2238,7 +2238,7 @@ public class MitgliedControl extends AbstractControl
         }
       }
     });
-    eintrittbis.setName("Eintritt bis");
+    eintrittbis.setName("Eintrittsdatum bis");
     return eintrittbis;
   }
 
@@ -2282,7 +2282,7 @@ public class MitgliedControl extends AbstractControl
         }
       }
     });
-    austrittvon.setName("Austritt von");
+    austrittvon.setName("Austrittsdatum von");
     return austrittvon;
   }
 
@@ -2326,7 +2326,7 @@ public class MitgliedControl extends AbstractControl
         }
       }
     });
-    austrittbis.setName("Austritt bis");
+    austrittbis.setName("Austrittsdatum bis");
     return austrittbis;
   }
   
@@ -2529,6 +2529,7 @@ public class MitgliedControl extends AbstractControl
     settings.setAttribute(mitgliedtyp + ".eigenschaften", "");
     settings.setAttribute(zusatzfelderstring + "selected", 0);
     setZusatzfelderAuswahl();
+    zad.reset();
   }
 
   public Input getAusgabe() throws RemoteException
@@ -2606,6 +2607,11 @@ public class MitgliedControl extends AbstractControl
     sortierung = new SelectInput(sort, "Name, Vorname");
     sortierung.setName("Sortierung");
     return sortierung;
+  }
+  
+  public boolean isSortierungAktiv()
+  {
+    return sortierung != null;
   }
 
   public TextInput getSuchExterneMitgliedsnummer()
@@ -3067,7 +3073,7 @@ public class MitgliedControl extends AbstractControl
       }
       else
       {
-        settings.setAttribute(mitgliedtyp + "stichtag", "");
+        settings.setAttribute(mitgliedtyp + ".stichtag", "");
       }
     }
 
@@ -3566,7 +3572,7 @@ public class MitgliedControl extends AbstractControl
       {
         fd.setFilterPath(path);
       }
-      fd.setFileName(new Dateiname("auswertung", dateinamensort,
+      fd.setFileName(new Dateiname("auswertungmitglied", dateinamensort,
           Einstellungen.getEinstellung().getDateinamenmuster(),
           ausw.getDateiendung()).get());
       fd.setFilterExtensions(new String[] { "*." + ausw.getDateiendung() });
@@ -3643,6 +3649,25 @@ public class MitgliedControl extends AbstractControl
     list = new MitgliedQuery(this, true).get(Integer.parseInt(atyp.getID()));
     try
     {
+      String sort = (String) sortierung.getValue();
+      String dateinamensort = "";
+      if (sort.equals("Name, Vorname"))
+      {
+        dateinamensort = "name";
+      }
+      else if (sort.equals("Eintrittsdatum"))
+      {
+        dateinamensort = "eintrittsdatum";
+      }
+      else if (sort.equals("Geburtsdatum"))
+      {
+        dateinamensort = "geburtsdatum";
+      }
+      else if (sort.equals("Geburtstagsliste"))
+      {
+        dateinamensort = "geburtstagsliste";
+      }
+      
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
       fd.setText("Ausgabedatei wählen.");
 
@@ -3652,7 +3677,7 @@ public class MitgliedControl extends AbstractControl
       {
         fd.setFilterPath(path);
       }
-      fd.setFileName(new Dateiname("auswertungnichtmitglied", "",
+      fd.setFileName(new Dateiname("auswertungnichtmitglied", dateinamensort,
           Einstellungen.getEinstellung().getDateinamenmuster(),
           ausw.getDateiendung()).get());
       fd.setFilterExtensions(new String[] { "*." + ausw.getDateiendung() });
@@ -3861,7 +3886,7 @@ public class MitgliedControl extends AbstractControl
       try
       {
         Adresstyp at = (Adresstyp) getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
-        if (at != null)
+        if (at != null && at.getID() != null)
         {
           refreshMitgliedTable(Integer.parseInt(at.getID()));
         }

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
@@ -256,11 +256,6 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
         }
       }
       settings.setAttribute(zusatzfelder + "counter", counter);
-      int selected = settings.getInt(zusatzfelder + "selected", 0);
-      if (selected == 0)
-      {
-        reset();
-      }
     }
 
     ButtonArea buttons = new ButtonArea();
@@ -360,36 +355,83 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
   public void reset()
   {
     int counter = 0;
-    for (Input f : felder)
+    if (felder == null)
     {
-      counter++;
-      if (f instanceof CheckboxInput)
+      try
       {
-        settings.setAttribute(zusatzfeld + counter + ".value", "false");
-        f.setValue(false);
+        DBIterator<Felddefinition> it = Einstellungen.getDBService()
+            .createList(Felddefinition.class);
+        while (it.hasNext())
+        {
+          counter++;
+          Felddefinition fd = (Felddefinition) it.next();
+          switch (fd.getDatentyp())
+          {
+          case Datentyp.ZEICHENFOLGE:
+          {
+            settings.getString(zusatzfeld + counter + ".value", "");
+            break;
+          }
+          case Datentyp.DATUM:
+          {
+            settings.setAttribute(zusatzfeld + counter + ".value", "");
+            break;
+          }
+          case Datentyp.GANZZAHL:
+          {
+            settings.setAttribute(zusatzfeld + counter + ".value", -1);
+            break;
+          }
+          case Datentyp.JANEIN:
+          {
+            settings.setAttribute(zusatzfeld + counter + ".value", "false");
+            break;
+          }
+          case Datentyp.WAEHRUNG:
+          {
+            settings.getString(zusatzfeld + counter + ".value", "");
+            break;
+          }
+          }
+        }
       }
-      if (f instanceof IntegerInput)
+      catch (RemoteException e)
       {
-        settings.setAttribute(zusatzfeld + counter + ".value", -1);
-        f.setValue(-1);
+        //
       }
-      else if (f instanceof DecimalInput)
+    }
+    else
+    {
+      for (Input f : felder)
       {
-        settings.setAttribute(zusatzfeld + counter + ".value", "");
-        f.setValue(null);
-      }
-      else if (f instanceof DateInput)
-      {
-        settings.setAttribute(zusatzfeld + counter + ".value", "");
-        f.setValue(null);
-      }
-      else
-      {
-        settings.setAttribute(zusatzfeld + counter + ".value", "");
-        f.setValue("");
+        counter++;
+        if (f instanceof CheckboxInput)
+        {
+          settings.setAttribute(zusatzfeld + counter + ".value", "false");
+          f.setValue(false);
+        }
+        else if (f instanceof IntegerInput)
+        {
+          settings.setAttribute(zusatzfeld + counter + ".value", -1);
+          f.setValue(-1);
+        }
+        else if (f instanceof DecimalInput)
+        {
+          settings.setAttribute(zusatzfeld + counter + ".value", "");
+          f.setValue(null);
+        }
+        else if (f instanceof DateInput)
+        {
+          settings.setAttribute(zusatzfeld + counter + ".value", "");
+          f.setValue(null);
+        }
+        else
+        {
+          settings.setAttribute(zusatzfeld + counter + ".value", "");
+          f.setValue("");
+        }
       }
     }
     settings.setAttribute(zusatzfelder + "selected", 0);
-
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
@@ -369,7 +369,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           {
           case Datentyp.ZEICHENFOLGE:
           {
-            settings.getString(zusatzfeld + counter + ".value", "");
+            settings.setAttribute(zusatzfeld + counter + ".value", "");
             break;
           }
           case Datentyp.DATUM:
@@ -389,7 +389,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           }
           case Datentyp.WAEHRUNG:
           {
-            settings.getString(zusatzfeld + counter + ".value", "");
+            settings.setAttribute(zusatzfeld + counter + ".value", "");
             break;
           }
           }

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedSucheView.java
@@ -127,7 +127,6 @@ public abstract class AbstractMitgliedSucheView extends AbstractView
   {
     try
     {
-      control.saveDefaults();
       Adresstyp at = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
       if (at != null)
       {

--- a/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
@@ -16,9 +16,12 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.rmi.RemoteException;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.MitgliedControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.Input;
@@ -29,14 +32,18 @@ import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class AuswertungMitgliedView extends AbstractView
-{
+{  
+  final MitgliedControl control = new MitgliedControl(this);
+  
+  public AuswertungMitgliedView() throws RemoteException
+  {
+    control.getSuchAdresstyp(Mitgliedstyp.MITGLIED).getValue();
+  }
 
   @Override
   public void bind() throws Exception
   {
     GUI.getView().setTitle("Auswertung Mitgliedsdaten");
-
-    final MitgliedControl control = new MitgliedControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Filter");
 

--- a/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
@@ -53,6 +53,11 @@ public class AuswertungMitgliedView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     Input mitglstat = control.getMitgliedStatus();
     left.addInput(mitglstat);
+    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
+    {
+      left.addLabelPair("Externe Mitgliedsnummer",
+          control.getSuchExterneMitgliedsnummer());
+    }
     left.addInput(control.getEigenschaftenAuswahl());
     left.addInput(control.getBeitragsgruppeAusw());
 
@@ -66,10 +71,10 @@ public class AuswertungMitgliedView extends AbstractView
     middle.addInput(control.getMailauswahl());
     middle.addInput(control.getGeburtsdatumvon());
     middle.addInput(control.getGeburtsdatumbis());
-
     SelectInput inpGeschlecht = control.getGeschlecht();
     inpGeschlecht.setMandatory(false);
     middle.addInput(inpGeschlecht);
+    middle.addInput(control.getStichtag(false));
 
     // right
     SimpleContainer right = new SimpleContainer(cl.getComposite());
@@ -78,7 +83,6 @@ public class AuswertungMitgliedView extends AbstractView
 
     right.addInput(control.getAustrittvon());
     right.addInput(control.getAustrittbis());
-    right.addInput(control.getStichtag(false));
 
     if (Einstellungen.getEinstellung().getSterbedatum())
     {

--- a/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
@@ -25,7 +25,6 @@ import de.jost_net.JVerein.gui.control.MitgliedControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.Input;
-import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -71,9 +70,7 @@ public class AuswertungMitgliedView extends AbstractView
     middle.addInput(control.getMailauswahl());
     middle.addInput(control.getGeburtsdatumvon());
     middle.addInput(control.getGeburtsdatumbis());
-    SelectInput inpGeschlecht = control.getGeschlecht();
-    inpGeschlecht.setMandatory(false);
-    middle.addInput(inpGeschlecht);
+    middle.addInput(control.getSuchGeschlecht());
     middle.addInput(control.getStichtag(false));
 
     // right

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -48,23 +49,34 @@ public class AuswertungNichtMitgliedView extends AbstractView
     ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
     SimpleContainer left = new SimpleContainer(cl.getComposite());
 
+    left.addInput(control.getMailauswahl());
     left.addInput(control.getAdresstyp());
     left.addInput(control.getEigenschaftenAuswahl());
-
     if (Einstellungen.getEinstellung().hasZusatzfelder())
     {
       left.addInput(control.getZusatzfelderAuswahl());
     }
-    left.addInput(control.getGeburtsdatumvon());
-    left.addInput(control.getGeburtsdatumbis());
-
-    left.addInput(control.getMailauswahl());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
 
-    right.addInput(control.getAusgabe());
-    right.addInput(control.getAuswertungUeberschrift());
+    right.addInput(control.getGeburtsdatumvon());
+    right.addInput(control.getGeburtsdatumbis());
+    SelectInput inpGeschlecht = control.getGeschlecht();
+    inpGeschlecht.setMandatory(false);
+    right.addInput(inpGeschlecht);
+    
+    // Zweite Gruppe: Ausgabe
+    LabelGroup group2 = new LabelGroup(getParent(), "Ausgabe");
 
+    ColumnLayout cl2 = new ColumnLayout(group2.getComposite(), 2);
+    SimpleContainer left2 = new SimpleContainer(cl2.getComposite());
+    SimpleContainer right2 = new SimpleContainer(cl2.getComposite());
+
+    left2.addInput(control.getSortierung());
+    left2.addInput(control.getAuswertungUeberschrift());
+    right2.addInput(control.getAusgabe());
+
+    // Button-Bereich
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.AUSWERTUNGMITGLIEDER, false, "question-circle.png");

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -16,9 +16,12 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.rmi.RemoteException;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.MitgliedControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -26,15 +29,19 @@ import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
-public class AuswertungAdresseView extends AbstractView
+public class AuswertungNichtMitgliedView extends AbstractView
 {
+  final MitgliedControl control = new MitgliedControl(this);
+  
+  public AuswertungNichtMitgliedView() throws RemoteException
+  {
+    control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+  }
 
   @Override
   public void bind() throws Exception
   {
     GUI.getView().setTitle("Auswertung Nicht-Mitgliederdaten");
-
-    final MitgliedControl control = new MitgliedControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Filter");
 

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -24,7 +24,6 @@ import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -61,9 +60,7 @@ public class AuswertungNichtMitgliedView extends AbstractView
 
     right.addInput(control.getGeburtsdatumvon());
     right.addInput(control.getGeburtsdatumbis());
-    SelectInput inpGeschlecht = control.getGeschlecht();
-    inpGeschlecht.setMandatory(false);
-    right.addInput(inpGeschlecht);
+    right.addInput(control.getSuchGeschlecht());
     
     // Zweite Gruppe: Ausgabe
     LabelGroup group2 = new LabelGroup(getParent(), "Ausgabe");

--- a/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
@@ -78,8 +78,7 @@ public class MitgliederSucheView extends AbstractMitgliedSucheView
     middle.addLabelPair("Geburtsdatum von", mitglgebdatvon);
     DateInput mitglgebdatbis = control.getGeburtsdatumbis();
     middle.addLabelPair("Geburtsdatum bis", mitglgebdatbis);
-    SelectInput mitglgeschlecht = control.getGeschlecht();
-    mitglgeschlecht.setMandatory(false);
+    SelectInput mitglgeschlecht = control.getSuchGeschlecht();
     mitglgeschlecht.addListener(new FilterListener());
     middle.addLabelPair("Geschlecht", mitglgeschlecht);
     DateInput stichtag = control.getStichtag();
@@ -122,7 +121,7 @@ public class MitgliederSucheView extends AbstractMitgliedSucheView
           control.getSuchname().setValue("");
           control.getGeburtsdatumvon().setValue(null);
           control.getGeburtsdatumbis().setValue(null);
-          control.getGeschlecht().setValue(null);
+          control.getSuchGeschlecht().setValue(null);
           control.getEintrittvon().setValue(null);
           control.getEintrittbis().setValue(null);
           control.getAustrittvon().setValue(null);

--- a/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
@@ -65,7 +65,6 @@ public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
     if (Einstellungen.getEinstellung().hasZusatzfelder())
     {
       DialogInput mitglzusatzfelder = control.getZusatzfelderAuswahl();
-      mitglzusatzfelder.addListener(new FilterListener());
       left.addLabelPair("Zusatzfelder", mitglzusatzfelder);
     }
     

--- a/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
@@ -73,8 +73,7 @@ public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
     right.addLabelPair("Geburtsdatum von", mitglgebdatvon);
     DateInput mitglgebdatbis = control.getGeburtsdatumbis();
     right.addLabelPair("Geburtsdatum bis", mitglgebdatbis);
-    SelectInput mitglgeschlecht = control.getGeschlecht();
-    mitglgeschlecht.setMandatory(false);
+    SelectInput mitglgeschlecht = control.getSuchGeschlecht();
     mitglgeschlecht.addListener(new FilterListener());
     right.addLabelPair("Geschlecht", mitglgeschlecht);
     
@@ -92,7 +91,7 @@ public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
           control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).setValue(null);
           control.getGeburtsdatumvon().setValue(null);
           control.getGeburtsdatumbis().setValue(null);
-          control.getGeschlecht().setValue(null);
+          control.getSuchGeschlecht().setValue(null);
           if (Einstellungen.getEinstellung().hasZusatzfelder())
           {
             control.resetZusatzfelderAuswahl();

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -86,11 +86,19 @@ public class MitgliedAuswertungPDF implements IAuswertung
     if (control.isMitgliedStatusAktiv())
     {
       params.put("Status", (String) control.getMitgliedStatus().getValue());
+    }
+    if (control.isEigenschaftenAuswahlAktiv())
+    {
       String eig = control.getEigenschaftenAuswahl().getText();
       if (eig.length() > 0)
       {
         params.put("Eigenschaften", eig);
       }
+    }
+    if (control.isSuchExterneMitgliedsnummerActive() && control.getSuchExterneMitgliedsnummer() != null)
+    {
+      String val = control.getSuchExterneMitgliedsnummer().getValue().toString();
+      params.put("Externe Mitgliedsnummer ", val);
     }
     if (control.isGeburtsdatumvonAktiv() && control.getGeburtsdatumvon().getValue() != null)
     {
@@ -156,16 +164,17 @@ public class MitgliedAuswertungPDF implements IAuswertung
       Date d = (Date) control.getStichtag(false).getValue();
       params.put("Stichtag", new JVDateFormatTTMMJJJJ().format(d));
     }
-
-    for (int i = 1; i < control.getSettings().getInt(zusatzfelder + "counter",
-        0) + 1; i++)
+    if (control.isZusatzfelderAuswahlAktiv())
     {
-      if (!control.getSettings().getString(zusatzfeld + i + ".value", "")
-          .equals(""))
+      int counter = control.getSettings().getInt(zusatzfelder + "counter", 0);
+      for (int i = 1; i <= counter; i++)
       {
-        params.put(
-            control.getSettings().getString(zusatzfeld + i + ".name", ""),
-            control.getSettings().getString(zusatzfeld + i + ".value", ""));
+        String value = control.getSettings().getString(zusatzfeld + i + ".value", "");
+        if (!value.equals("") && !value.equals("false"))
+        {
+          params.put(
+            control.getSettings().getString(zusatzfeld + i + ".name", ""), value);
+        }
       }
     }
     String ueberschrift = (String) control.getAuswertungUeberschrift()

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -98,7 +98,9 @@ public class MitgliedAuswertungPDF implements IAuswertung
     if (control.isSuchExterneMitgliedsnummerActive() && control.getSuchExterneMitgliedsnummer() != null)
     {
       String val = control.getSuchExterneMitgliedsnummer().getValue().toString();
-      params.put("Externe Mitgliedsnummer ", val);
+      if (val.length() > 0) {
+        params.put("Externe Mitgliedsnummer ", val);
+      }
     }
     if (control.isGeburtsdatumvonAktiv() && control.getGeburtsdatumvon().getValue() != null)
     {
@@ -149,15 +151,15 @@ public class MitgliedAuswertungPDF implements IAuswertung
     if (control.isMailauswahlAktiv())
     {
       int ma = (Integer) control.getMailauswahl().getValue();
-      if (ma == MailAuswertungInput.ALLE)
+      if (ma != MailAuswertungInput.ALLE)
       {
         params.put("Mail", control.getMailauswahl().getText());
       }
     }
-    if (control.isGeschlechtAktiv() && control.getGeschlecht().getText() != null
-        && !control.getGeschlecht().getText().equals("Bitte auswählen"))
+    if (control.isSuchGeschlechtAktiv() && control.getSuchGeschlecht().getText() != null
+        && !control.getSuchGeschlecht().getText().equals("Bitte auswählen"))
     {
-      params.put("Geschlecht", control.getGeschlecht().getText());
+      params.put("Geschlecht", control.getSuchGeschlecht().getText());
     }
     if (control.isStichtagAktiv() && control.getStichtag(false).getValue() != null)
     {

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -157,8 +157,8 @@ public class MitgliedAuswertungPDF implements IAuswertung
       params.put("Stichtag", new JVDateFormatTTMMJJJJ().format(d));
     }
 
-    for (int i = 0; i < control.getSettings().getInt(zusatzfelder + "selected",
-        0); i++)
+    for (int i = 1; i < control.getSettings().getInt(zusatzfelder + "counter",
+        0) + 1; i++)
     {
       if (!control.getSettings().getString(zusatzfeld + i + ".value", "")
           .equals(""))

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -52,6 +52,10 @@ public class MitgliedAuswertungPDF implements IAuswertung
   private String subtitle = "";
 
   private TreeMap<String, String> params;
+  
+  String zusatzfeld = null;
+  
+  String zusatzfelder = null;
 
   public MitgliedAuswertungPDF(MitgliedControl control)
   {
@@ -62,16 +66,24 @@ public class MitgliedAuswertungPDF implements IAuswertung
   public void beforeGo() throws RemoteException
   {
     params = new TreeMap<>();
-    this.adresstyp = (Adresstyp) control.getAdresstyp().getValue();
-    if (adresstyp == null)
+    
+    if (control.isAdresstypActive())
+    {
+      adresstyp = (Adresstyp) control.getAdresstyp().getValue();
+      zusatzfeld = "nichtzusatzfeld.";
+      zusatzfelder = "nichtzusatzfelder.";
+    }
+    else
     {
       DBIterator<Adresstyp> it = Einstellungen.getDBService()
           .createList(Adresstyp.class);
       it.addFilter("jvereinid=1");
       adresstyp = (Adresstyp) it.next();
+      zusatzfeld = "zusatzfeld.";
+      zusatzfelder = "zusatzfelder.";
     }
 
-    if (adresstyp.getJVereinid() == 1)
+    if (control.isMitgliedStatusAktiv())
     {
       params.put("Status", (String) control.getMitgliedStatus().getValue());
       String eig = control.getEigenschaftenAuswahl().getText();
@@ -79,74 +91,81 @@ public class MitgliedAuswertungPDF implements IAuswertung
       {
         params.put("Eigenschaften", eig);
       }
-      if (control.getGeburtsdatumvon().getValue() != null)
-      {
-        Date d = (Date) control.getGeburtsdatumvon().getValue();
-        params.put("Geburtsdatum von ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getGeburtsdatumbis().getValue() != null)
-      {
-        Date d = (Date) control.getGeburtsdatumbis().getValue();
-        params.put("Geburtsdatum bis ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getEintrittvon().getValue() != null)
-      {
-        Date d = (Date) control.getEintrittvon().getValue();
-        params.put("Eintritt von ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getEintrittbis().getValue() != null)
-      {
-        Date d = (Date) control.getEintrittbis().getValue();
-        params.put("Eintritt bis ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getAustrittvon().getValue() != null)
-      {
-        Date d = (Date) control.getAustrittvon().getValue();
-        params.put("Austritt von ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getAustrittbis().getValue() != null)
-      {
-        Date d = (Date) control.getAustrittbis().getValue();
-        params.put("Austritt bis ", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getSterbedatumvon().getValue() != null)
-      {
-        Date d = (Date) control.getSterbedatumvon().getValue();
-        params.put("Sterbetag von", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getSterbedatumbis().getValue() != null)
-      {
-        Date d = (Date) control.getSterbedatumbis().getValue();
-        params.put("Sterbedatum bis", new JVDateFormatTTMMJJJJ().format(d));
-      }
-      if (control.getBeitragsgruppeAusw().getValue() != null)
-      {
-        Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
-            .getValue();
-        params.put("Beitragsgruppe", bg.getBezeichnung());
-      }
+    }
+    if (control.isGeburtsdatumvonAktiv() && control.getGeburtsdatumvon().getValue() != null)
+    {
+      Date d = (Date) control.getGeburtsdatumvon().getValue();
+      params.put("Geburtsdatum von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isGeburtsdatumbisAktiv() && control.getGeburtsdatumbis().getValue() != null)
+    {
+      Date d = (Date) control.getGeburtsdatumbis().getValue();
+      params.put("Geburtsdatum bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isEintrittvonAktiv() && control.getEintrittvon().getValue() != null)
+    {
+      Date d = (Date) control.getEintrittvon().getValue();
+      params.put("Eintritt von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isEintrittbisAktiv() && control.getEintrittbis().getValue() != null)
+    {
+      Date d = (Date) control.getEintrittbis().getValue();
+      params.put("Eintritt bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isAustrittvonAktiv() && control.getAustrittvon().getValue() != null)
+    {
+      Date d = (Date) control.getAustrittvon().getValue();
+      params.put("Austritt von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isAustrittbisAktiv() && control.getAustrittbis().getValue() != null)
+    {
+      Date d = (Date) control.getAustrittbis().getValue();
+      params.put("Austritt bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isSterbedatumvonAktiv() && control.getSterbedatumvon().getValue() != null)
+    {
+      Date d = (Date) control.getSterbedatumvon().getValue();
+      params.put("Sterbetag von", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isSterbedatumbisAktiv() && control.getSterbedatumbis().getValue() != null)
+    {
+      Date d = (Date) control.getSterbedatumbis().getValue();
+      params.put("Sterbedatum bis", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isBeitragsgruppeAuswAktiv() && control.getBeitragsgruppeAusw().getValue() != null)
+    {
+      Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
+          .getValue();
+      params.put("Beitragsgruppe", bg.getBezeichnung());
+    }
+    if (control.isMailauswahlAktiv())
+    {
       int ma = (Integer) control.getMailauswahl().getValue();
       if (ma == MailAuswertungInput.ALLE)
       {
         params.put("Mail", control.getMailauswahl().getText());
       }
-      if (control.getGeschlecht().getText() != null
-          && !control.getGeschlecht().getText().equals("Bitte auswählen"))
-      {
-        params.put("Geschlecht", control.getGeschlecht().getText());
-      }
+    }
+    if (control.isGeschlechtAktiv() && control.getGeschlecht().getText() != null
+        && !control.getGeschlecht().getText().equals("Bitte auswählen"))
+    {
+      params.put("Geschlecht", control.getGeschlecht().getText());
+    }
+    if (control.isStichtagAktiv() && control.getStichtag(false).getValue() != null)
+    {
       Date d = (Date) control.getStichtag(false).getValue();
       params.put("Stichtag", new JVDateFormatTTMMJJJJ().format(d));
     }
-    for (int i = 0; i < control.getSettings().getInt("zusatzfelder.selected",
+
+    for (int i = 0; i < control.getSettings().getInt(zusatzfelder + "selected",
         0); i++)
     {
-      if (!control.getSettings().getString("zusatzfeld." + i + ".value", "")
+      if (!control.getSettings().getString(zusatzfeld + i + ".value", "")
           .equals(""))
       {
         params.put(
-            control.getSettings().getString("zusatzfeld." + i + ".name", ""),
-            control.getSettings().getString("zusatzfeld." + i + ".value", ""));
+            control.getSettings().getString(zusatzfeld + i + ".name", ""),
+            control.getSettings().getString(zusatzfeld + i + ".value", ""));
       }
     }
     String ueberschrift = (String) control.getAuswertungUeberschrift()


### PR DESCRIPTION
Das Query hat im NichtMitgliedSucheView unsichtbare Eingabefelder erzeugt wegen dem Aufruf der get Methoden.
Habe die adresstyp Abfrage vorangestellt, dann wird die get Methode nicht mehr aufgerufen.

Ich glaube hier liegt ein großes Missverständnis vor. Die Abfrage auf ! = null ist sinnlos da die get Methode immer etwas zurück liefert. Und wenn das Objekt nicht existiert wird es in der Methode erzeugt und auch evtl. mit Werten aus den Settings initialisiert. 
Damit das wie vom Entwickler gedacht funktioniert bräuchte man getrennte Methoden für das erzeugen und löschen. 

Vermutlich gibt es an anderen Stellen ähnliche Probleme da oft der gleiche Control für unterschiedliche Views verwendet wird. 
Das muss ich mir mal genauer anschauen. 

Ich habe etwas gefunden, es gibt die Methoden is...active(). Das prüft ob das Objekt existiert. Das ist aber nicht durchgängig implementiert. 

