### PR TITLE
Feature: Adressausgabe in Spendenbescheinigung konfigurierbar

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -1281,12 +1281,15 @@ public class SpendenbescheinigungPrintAction implements Action
       rpt.closeTable();      
     }
     
-    // Neue Seite mit Anschrift für Fenster in quer Brief
-    rpt.newPage();
-    rpt.add(new Paragraph(" ", Reporter.getFreeSans(12)));
-    rpt.add("\n\n\n\n\n", 12);
-    rpt.addUnderline(getAussteller(),8);
-    rpt.addLight((String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()),9);
+    if (Einstellungen.getEinstellung().getSpendenbescheinigungadresse())
+    {
+      // Neue Seite mit Anschrift für Fenster in querem Brief
+      rpt.newPage();
+      rpt.add(new Paragraph(" ", Reporter.getFreeSans(12)));
+      rpt.add("\n\n\n\n\n", 12);
+      rpt.addUnderline(getAussteller(),8);
+      rpt.addLight((String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()),9);
+    }
 
     rpt.close();
     fos.close();

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -293,6 +293,8 @@ public class EinstellungControl extends AbstractControl
   private CheckboxInput abrlabschliessen;
 
   private CheckboxInput optiert;
+  
+  private CheckboxInput spendenbescheinigungadresse;
 
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
@@ -780,6 +782,16 @@ public class EinstellungControl extends AbstractControl
     optiert = new CheckboxInput(Einstellungen.getEinstellung().getOptiert());
     optiert.setName("Umsatzsteueroption");
     return optiert;
+  }
+  
+  public CheckboxInput getSpendenbescheinigungadresse() throws RemoteException 
+  {
+    if (spendenbescheinigungadresse != null) 
+    {
+      return spendenbescheinigungadresse;
+    }
+    spendenbescheinigungadresse = new CheckboxInput(Einstellungen.getEinstellung().getSpendenbescheinigungadresse());
+    return spendenbescheinigungadresse;
   }
 
   public CheckboxInput getExterneMitgliedsnummer() throws RemoteException
@@ -1961,6 +1973,7 @@ public class EinstellungControl extends AbstractControl
           .getValue());
       e.setSpendenbescheinigungPrintBuchungsart((Boolean) spendenbescheinigungprintbuchungsart
           .getValue());
+      e.setSpendenbescheinigungadresse((Boolean) getSpendenbescheinigungadresse().getValue());
       e.store();
       Einstellungen.setEinstellung(e);
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -52,6 +52,8 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
         control.getSpendenbescheinigungverzeichnis());
     cont.addLabelPair("Buchungsart drucken",
         control.getSpendenbescheinigungPrintBuchungsart());
+    cont.addLabelPair("Adressausgabe für Brieffenster",
+        control.getSpendenbescheinigungadresse());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -543,5 +543,9 @@ public interface Einstellung extends DBObject, IBankverbindung
       throws RemoteException;
 
   public SepaVersion getCt1SepaVersion() throws RemoteException;
+  
+  public Boolean getSpendenbescheinigungadresse() throws RemoteException;
+
+  public void setSpendenbescheinigungadresse(Boolean spendenbescheinigungadresse) throws RemoteException;
 
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0434.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0434.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0434 extends AbstractDDLUpdate
+{
+  public Update0434(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("spendenbescheinigungadresse",
+        COLTYPE.BOOLEAN, 0, "TRUE", false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -1817,4 +1817,15 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     }
   }
 
+  @Override
+  public Boolean getSpendenbescheinigungadresse() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("spendenbescheinigungadresse"));
+  }
+
+  @Override
+  public void setSpendenbescheinigungadresse(Boolean spendenbescheinigungadresse) throws RemoteException
+  {
+    setAttribute("spendenbescheinigungadresse", spendenbescheinigungadresse);
+  }
 }


### PR DESCRIPTION
Mit dem Feature kann man in den Einstellungen festlegen ob die Adresse für das Brief Fenster in der extra Seite der Spendenbescheinigung gedruckt werden soll.
Das dient als Vorbereitung für das Feature um Spendenbescheinigungen per Mail zu verschicken. In diesem Fall braucht man ja keine Adresse in der Bescheinigung.