### PR TITLE
Add support for EPC payment QR Code

### DIFF
--- a/src/de/jost_net/JVerein/Variable/MitgliedskontoMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedskontoMap.java
@@ -110,6 +110,8 @@ public class MitgliedskontoMap
     map.put(MitgliedskontoVar.DIFFERENZ.getName(), differenz.toArray());
     map.put(MitgliedskontoVar.STAND.getName(), Double.valueOf(-1 * saldo));
     map.put(MitgliedskontoVar.SUMME_OFFEN.getName(), Double.valueOf(saldo));
+    map.put(MitgliedskontoVar.QRCODE_INTRO.getName(),
+        Einstellungen.getEinstellung().getQRCodeIntro());
     return map;
   }
 

--- a/src/de/jost_net/JVerein/Variable/MitgliedskontoVar.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedskontoVar.java
@@ -29,7 +29,9 @@ public enum MitgliedskontoVar
   IST("mitgliedskonto_ist"), //
   DIFFERENZ("mitgliedskonto_differenz"), //
   STAND("mitgliedskonto_stand"), //
-  SUMME_OFFEN("mitgliedskonto_summe_offen");
+  SUMME_OFFEN("mitgliedskonto_summe_offen"), //
+  QRCODE("qrcode"), //
+  QRCODE_INTRO("qrcode_intro");
 
   private String name;
 

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -290,9 +290,31 @@ public class EinstellungControl extends AbstractControl
 
   private SelectInput buchungsartsort;
 
+  private IntegerInput qrcodesize;
+
   private CheckboxInput abrlabschliessen;
 
   private CheckboxInput optiert;
+
+  private CheckboxInput qrcodeptext;
+
+  private CheckboxInput qrcodepdate;
+
+  private CheckboxInput qrcodeprenum;
+
+  private CheckboxInput qrcodepmnum;
+
+  private TextInput qrcodetext;
+
+  private CheckboxInput qrcodesngl;
+
+  private CheckboxInput qrcodeext;
+
+  private TextInput qrcodeinfom;
+
+  private TextInput qrcodeintro;
+
+  private CheckboxInput qrcodekuerzen;
 
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
@@ -1608,6 +1630,116 @@ public class EinstellungControl extends AbstractControl
     return buchungsartsort;
   }
 
+  public IntegerInput getQRCodeSizeInMm() throws RemoteException
+  {
+    if (null == qrcodesize)
+    {
+      qrcodesize = new IntegerInput(
+          Einstellungen.getEinstellung().getQRCodeSizeInMm());
+    }
+    return qrcodesize;
+  }
+
+  public TextInput getQRCodeVerwendungszweck() throws RemoteException
+  {
+    if (null == qrcodetext)
+    {
+      qrcodetext = new TextInput(
+          Einstellungen.getEinstellung().getQRCodeText());
+    }
+    return qrcodetext;
+  }
+
+  public CheckboxInput getQRCodePrintVerwendungszweck() throws RemoteException
+  {
+    if (null == qrcodeptext)
+    {
+      qrcodeptext = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeFesterText());
+    }
+    return qrcodeptext;
+  }
+
+  public CheckboxInput getQRCodeSingle() throws RemoteException
+  {
+    if (null == qrcodesngl)
+    {
+      qrcodesngl = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeSnglLine());
+    }
+    return qrcodesngl;
+  }
+
+  public CheckboxInput getQRCodeReDa() throws RemoteException
+  {
+    if (null == qrcodepdate)
+    {
+      qrcodepdate = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeDatum());
+    }
+    return qrcodepdate;
+  }
+
+  public CheckboxInput getQRCodeReNr() throws RemoteException
+  {
+    if (null == qrcodeprenum)
+    {
+      qrcodeprenum = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeReNu());
+    }
+    return qrcodeprenum;
+  }
+
+  public CheckboxInput getQRCodeMemberNr() throws RemoteException
+  {
+    if (null == qrcodepmnum)
+    {
+      qrcodepmnum = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeMember());
+    }
+    return qrcodepmnum;
+  }
+
+  public CheckboxInput getQRCodeExt() throws RemoteException
+  {
+    if (null == qrcodeext)
+    {
+      qrcodeext = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeExtNr());
+    }
+    return qrcodeext;
+  }
+
+  public TextInput getQRCodeInfoToMember() throws RemoteException
+  {
+    if (null == qrcodeinfom)
+    {
+      qrcodeinfom = new TextInput(
+          Einstellungen.getEinstellung().getQRCodeInfoM());
+    }
+    return qrcodeinfom;
+  }
+
+  public CheckboxInput getQRCodeKuerzen() throws RemoteException
+  {
+    if (null == qrcodekuerzen)
+    {
+      qrcodekuerzen = new CheckboxInput(
+          Einstellungen.getEinstellung().getQRCodeKuerzen());
+    }
+    return qrcodekuerzen;
+  }
+
+  public TextInput getQRCodeIntro() throws RemoteException
+  {
+    if (null == qrcodeintro)
+    {
+      qrcodeintro = new TextInput(
+          Einstellungen.getEinstellung().getQRCodeIntro());
+    }
+    return qrcodeintro;
+  }
+
   // // public void handleStore()
   // {
   // try
@@ -2019,6 +2151,17 @@ public class EinstellungControl extends AbstractControl
       e.setRechnungTextBar((String) rechnungtextbar.getValue());
       Integer length = (Integer) zaehlerlaenge.getValue();
       e.setZaehlerLaenge(length);
+      e.setQRCodeSizeInMm((Integer) qrcodesize.getValue());
+      e.setQRCodeDatum((Boolean) qrcodepdate.getValue());
+      e.setQRCodeExtNr((Boolean) qrcodeext.getValue());
+      e.setQRCodeFesterText((Boolean) qrcodeptext.getValue());
+      e.setQRCodeInfoM((String) qrcodeinfom.getValue());
+      e.setQRCodeMember((Boolean) qrcodepmnum.getValue());
+      e.setQRCodeReNu((Boolean) qrcodeprenum.getValue());
+      e.setQRCodeSnglLine((Boolean) qrcodesngl.getValue());
+      e.setQRCodeText((String) qrcodetext.getValue());
+      e.setQRCodeIntro((String) qrcodeintro.getValue());
+      e.setQRCodeKuerzen((Boolean) qrcodekuerzen.getValue());
 
       e.store();
       Einstellungen.setEinstellung(e);
@@ -2242,5 +2385,5 @@ public class EinstellungControl extends AbstractControl
       }
     }
   }
-
+  
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -41,6 +41,23 @@ public class EinstellungenRechnungenView extends AbstractView
         control.getRechnungTextUeberweisung());
     cont.addLabelPair("Text Bar", control.getRechnungTextBar());
     cont.addLabelPair("Zählerlänge", control.getZaehlerLaenge());
+    cont.addLabelPair("Kantenlänge QR-Code", control.getQRCodeSizeInMm());
+    cont.addLabelPair("Verwendungszweck", control.getQRCodeVerwendungszweck());
+    cont.addLabelPair("Verwendungszweck hinzufügen",
+        control.getQRCodePrintVerwendungszweck());
+    cont.addLabelPair("Bei einzelner Position Verwendungszweck ersetzen",
+        control.getQRCodeSingle());
+    cont.addLabelPair("Rechnungsdatum in QR-Code", control.getQRCodeReDa());
+    cont.addLabelPair("Rechnungsnummer in QR-Code", control.getQRCodeReNr());
+    cont.addLabelPair("Mitgliedsnummer in QR-Code",
+        control.getQRCodeMemberNr());
+    cont.addLabelPair("externe Mitgliedsnummer verwenden",
+        control.getQRCodeExt());
+    cont.addLabelPair("Information an Mitglied in QR-Code",
+        control.getQRCodeInfoToMember());
+    cont.addLabelPair("Texte in QR-Code kürzen", control.getQRCodeKuerzen());
+    cont.addLabelPair("Beschreibungstext für QR-Code",
+        control.getQRCodeIntro());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -16,13 +16,24 @@
  **********************************************************************/
 package de.jost_net.JVerein.io;
 
+import java.awt.Color;
+import java.awt.Image;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.rmi.RemoteException;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.pdf.BaseFont;
@@ -33,6 +44,8 @@ import com.itextpdf.text.pdf.PdfWriter;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineVar;
+import de.jost_net.JVerein.Variable.MitgliedVar;
+import de.jost_net.JVerein.Variable.MitgliedskontoVar;
 import de.jost_net.JVerein.rmi.Einstellung;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
@@ -59,6 +72,18 @@ public class FormularAufbereitung
   private static final int links = 1;
 
   private static final int rechts = 2;
+
+  private static final String EPC_STRING = "BCD";
+
+  private static final String EPC_VERSION = "002";
+
+  private static final String EPC_CHARSET_NR = "2"; // 2 = ISO-8859-1, 1 = UTF-8
+
+  private static final String EPC_CHARSET = "ISO-8859-1"; // must match above
+
+  private static final String EPC_ID = "SCT";
+
+  private static final String EPC_EUR = "EUR";
 
   private int buendig = links;
 
@@ -124,8 +149,11 @@ public class FormularAufbereitung
         {
           Formularfeld f = (Formularfeld) it.next();
           
-          // Increase counter if form field is zaehler
-          if (f.getName().equals(AllgemeineVar.ZAEHLER.getName()) && !increased) 
+          // Increase counter if form field is zaehler or qrcode (counter is
+          // needed in QR code, so it needs to be incremented)
+          if ((f.getName().equals(AllgemeineVar.ZAEHLER.getName())
+              || f.getName().equals(MitgliedskontoVar.QRCODE.getName()))
+              && !increased)
           {
             zaehler++;
             // Prevent multiple increases by next page
@@ -135,10 +163,17 @@ public class FormularAufbereitung
                 zaehler.toString(), zaehlerLaenge, "0"));
           }
           
+          // create QR code if form field is QR code
+          if (f.getName().equals(MitgliedskontoVar.QRCODE.getName()))
+          {
+            map.put(MitgliedskontoVar.QRCODE.getName(), getPaymentQRCode(map));
+            // Update QR code
+          }
+
           goFormularfeld(contentByte, f, map.get(f.getName()));
         }
       }
-      
+         
       // Set counter to form (not yet saved to the DB)
       formular.setZaehler(zaehler);
     }
@@ -149,6 +184,155 @@ public class FormularAufbereitung
     catch (DocumentException e)
     {
       throw new RemoteException("Fehler", e);
+    }
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private Image getPaymentQRCode(Map fieldsMap) throws RemoteException
+  {
+
+    Einstellung e = Einstellungen.getEinstellung();
+
+    boolean festerText = e.getQRCodeFesterText();
+    boolean rechnungDatum = e.getQRCodeDatum();
+    boolean rechnungNummer = e.getQRCodeReNu();
+    boolean mitgliedNummer = e.getQRCodeMember();
+
+    float sz = mm2point(((Integer) e.getQRCodeSizeInMm()).floatValue());
+
+    StringBuilder sb = new StringBuilder();
+    String verwendungszweck;
+    String infoToMitglied;
+
+    if (true == festerText)
+    {
+      String zahlungsgruende_raw = getString(
+          fieldsMap.get(MitgliedskontoVar.ZAHLUNGSGRUND.getName()));
+      String[] zahlungsgruende = zahlungsgruende_raw.split("\n");
+      if (zahlungsgruende.length == 1 && e.getQRCodeSnglLine())
+      {
+        sb.append(zahlungsgruende[0]);
+      }
+      else
+      {
+        sb.append(e.getQRCodeText());
+      }
+      if (rechnungDatum || rechnungNummer || mitgliedNummer)
+      {
+        sb.append(", ");
+      }
+    }
+
+    if (rechnungDatum || rechnungNummer)
+    {
+      if (e.getQRCodeKuerzen())
+      {
+        sb.append("Re. ");
+      }
+      else
+      {
+        sb.append("Rechnung ");
+      }
+      if (true == rechnungNummer)
+      {
+        sb.append(fieldsMap.get(AllgemeineVar.ZAEHLER.getName()));
+        if (true == rechnungDatum)
+        {
+          sb.append(" ");
+        }
+      }
+      if (true == rechnungDatum)
+      {
+        if (e.getQRCodeKuerzen())
+        {
+          sb.append("v. ");
+        }
+        else
+        {
+          sb.append("vom ");
+        }
+        sb.append(fieldsMap.get(AllgemeineVar.TAGESDATUM.getName()));
+      }
+      if (true == mitgliedNummer)
+      {
+        sb.append(", ");
+      }
+    }
+
+    if (true == mitgliedNummer)
+    {
+      if (true == e.getQRCodeKuerzen())
+      {
+        sb.append("Mitgl. ");
+      }
+      else
+      {
+        sb.append("Mitglied ");
+      }
+
+      if (true == e.getQRCodeExtNr())
+      {
+        sb.append(getString(
+            fieldsMap.get(MitgliedVar.EXTERNE_MITGLIEDSNUMMER.getName())));
+      }
+      else
+      {
+        sb.append(getString(fieldsMap.get(MitgliedVar.ID.getName())));
+      }
+    }
+
+    verwendungszweck = sb.toString();
+
+    infoToMitglied = e.getQRCodeInfoM();
+    if (null == infoToMitglied)
+    {
+      infoToMitglied = "";
+    }
+
+    StringBuilder sbEpc = new StringBuilder();
+    sbEpc.append(EPC_STRING).append("\n");
+    sbEpc.append(EPC_VERSION).append("\n");
+    sbEpc.append(EPC_CHARSET_NR).append("\n");
+    sbEpc.append(EPC_ID).append("\n");
+    sbEpc.append(e.getBic()).append("\n");
+    sbEpc.append(e.getName()).append("\n");
+    sbEpc.append(e.getIban()).append("\n");
+    sbEpc.append(EPC_EUR);
+    sbEpc
+        .append(
+            getString(fieldsMap.get(MitgliedskontoVar.SUMME_OFFEN.getName())))
+        .append("\n");
+    sbEpc.append("\n"); // currently purpose code not used here
+    sbEpc.append("\n"); // Reference not used, unstructured text used instead
+    sbEpc.append(
+        verwendungszweck.substring(0, Math.min(verwendungszweck.length(), 140)))
+        .append("\n"); // trim to 140 chars max.
+    sbEpc.append(
+        infoToMitglied.substring(0, Math.min(infoToMitglied.length(), 70))); // trim
+                                                                             // to
+                                                                             // 70
+                                                                             // chars
+                                                                             // max.
+    String charset = EPC_CHARSET;
+    Map hintMap = new HashMap();
+    hintMap.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.M);
+    try
+    {
+
+      BitMatrix matrix = new MultiFormatWriter().encode(
+          new String(sbEpc.toString().getBytes(charset), charset),
+          BarcodeFormat.QR_CODE, (int) sz, (int) sz, hintMap);
+
+      return MatrixToImageWriter.toBufferedImage(matrix);
+
+    }
+    catch (UnsupportedEncodingException e1)
+    {
+      throw new RemoteException("Fehler", e1);
+    }
+    catch (WriterException e1)
+    {
+      throw new RemoteException("Fehler", e1);
     }
   }
 
@@ -219,24 +403,37 @@ public class FormularAufbereitung
     {
       return;
     }
-    buendig = links;
-    String stringVal = getString(val);
-    stringVal = stringVal.replace("\\n", "\n");
-    stringVal = stringVal.replaceAll("\r\n", "\n");
-    String[] ss = stringVal.split("\n");
-    for (String s : ss)
+    if (val instanceof String)
     {
-      contentByte.setFontAndSize(bf, feld.getFontsize().floatValue());
-      contentByte.beginText();
-      float offset = 0;
-      if (buendig == rechts)
+      buendig = links;
+      String stringVal = getString(val);
+      stringVal = stringVal.replace("\\n", "\n");
+      stringVal = stringVal.replaceAll("\r\n", "\n");
+      String[] ss = stringVal.split("\n");
+      for (String s : ss)
       {
-        offset = contentByte.getEffectiveStringWidth(s, true);
+        contentByte.setFontAndSize(bf, feld.getFontsize().floatValue());
+        contentByte.beginText();
+        float offset = 0;
+        if (buendig == rechts)
+        {
+          offset = contentByte.getEffectiveStringWidth(s, true);
+        }
+        contentByte.moveText(x - offset, y);
+        contentByte.showText(s);
+        contentByte.endText();
+        y -= feld.getFontsize().floatValue() + 3;
       }
-      contentByte.moveText(x - offset, y);
-      contentByte.showText(s);
-      contentByte.endText();
-      y -= feld.getFontsize().floatValue() + 3;
+    }
+    else
+    {
+      if (val instanceof Image)
+      {
+        com.itextpdf.text.Image i = com.itextpdf.text.Image
+            .getInstance((Image) val, Color.BLACK);
+        float sz = mm2point(Einstellungen.getEinstellung().getQRCodeSizeInMm());
+        contentByte.addImage(i, sz, 0, 0, sz, x, y);
+      }
     }
   }
 

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -544,4 +544,48 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public SepaVersion getCt1SepaVersion() throws RemoteException;
 
+  public int getQRCodeSizeInMm() throws RemoteException;
+
+  public void setQRCodeSizeInMm(int size) throws RemoteException;
+
+  public boolean getQRCodeFesterText() throws RemoteException;
+
+  public void setQRCodeFesterText(boolean printText) throws RemoteException;
+
+  public boolean getQRCodeDatum() throws RemoteException;
+
+  public void setQRCodeDatum(boolean printDate) throws RemoteException;
+
+  public boolean getQRCodeReNu() throws RemoteException;
+
+  public void setQRCodeReNu(boolean printNum) throws RemoteException;
+
+  public boolean getQRCodeMember() throws RemoteException;
+
+  public void setQRCodeMember(boolean printMember) throws RemoteException;
+
+  public String getQRCodeText() throws RemoteException;
+
+  public void setQRCodeText(String text) throws RemoteException;
+
+  public boolean getQRCodeSnglLine() throws RemoteException;
+
+  public void setQRCodeSnglLine(boolean single) throws RemoteException;
+
+  public boolean getQRCodeExtNr() throws RemoteException;
+
+  public void setQRCodeExtNr(boolean useExtNr) throws RemoteException;
+
+  public String getQRCodeInfoM() throws RemoteException;
+
+  public void setQRCodeInfoM(String infoMitglied) throws RemoteException;
+
+  public boolean getQRCodeKuerzen() throws RemoteException;
+
+  public void setQRCodeKuerzen(boolean kuerzen) throws RemoteException;
+
+  public String getQRCodeIntro() throws RemoteException;
+
+  public void setQRCodeIntro(String intro) throws RemoteException;
+
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0434.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0434.java
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0434 extends AbstractDDLUpdate
+{
+  public Update0434(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung",
+        new Column("qrcodesizemm", COLTYPE.INTEGER, 1, "30", false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodepdate", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodeext", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodeptext", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodepmnum", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodeprenum", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodesngl", COLTYPE.BOOLEAN, 1, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodetext", COLTYPE.VARCHAR, 140, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodeinfom", COLTYPE.VARCHAR, 70, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodeintro", COLTYPE.VARCHAR, 255, null, false, false)));
+    execute(addColumn("einstellung",
+        new Column("qrcodekuerzen", COLTYPE.BOOLEAN, 1, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -1817,4 +1817,191 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     }
   }
 
+  @Override
+  public int getQRCodeSizeInMm() throws RemoteException
+  {
+    Integer qrsizemm = (Integer) getAttribute("qrcodesizemm");
+    if (null == qrsizemm)
+    {
+      return 20;
+    }
+    return qrsizemm.intValue();
+  }
+
+  @Override
+  public void setQRCodeSizeInMm(int size) throws RemoteException
+  {
+    setAttribute("qrcodesizemm", size);
+  }
+
+  @Override
+  public boolean getQRCodeFesterText() throws RemoteException
+  {
+    Boolean printFesterText = (Boolean) getAttribute("qrcodeptext");
+    if (null == printFesterText)
+    {
+      return true;
+    }
+    return printFesterText.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeFesterText(boolean printText) throws RemoteException
+  {
+    setAttribute("qrcodeptext", printText);
+  }
+
+  @Override
+  public boolean getQRCodeDatum() throws RemoteException
+  {
+    Boolean printDatum = (Boolean) getAttribute("qrcodepdate");
+    if (null == printDatum)
+    {
+      return false;
+    }
+    return printDatum.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeDatum(boolean printDate) throws RemoteException
+  {
+    setAttribute("qrcodepdate", printDate);
+  }
+
+  @Override
+  public boolean getQRCodeReNu() throws RemoteException
+  {
+    Boolean printReNr = (Boolean) getAttribute("qrcodeprenum");
+    if (null == printReNr)
+    {
+      return false;
+    }
+    return printReNr.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeReNu(boolean printReNum) throws RemoteException
+  {
+    setAttribute("qrcodeprenum", printReNum);
+  }
+
+  @Override
+  public boolean getQRCodeMember() throws RemoteException
+  {
+    Boolean printMemberNr = (Boolean) getAttribute("qrcodepmnum");
+    if (null == printMemberNr)
+    {
+      return false;
+    }
+    return printMemberNr.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeMember(boolean printMember) throws RemoteException
+  {
+    setAttribute("qrcodepmnum", printMember);
+  }
+
+  @Override
+  public String getQRCodeText() throws RemoteException
+  {
+    String qrText = (String) getAttribute("qrcodetext");
+    if (null == qrText)
+    {
+      return "Mitgliedsbeitrag";
+    }
+    return qrText;
+  }
+
+  @Override
+  public void setQRCodeText(String text) throws RemoteException
+  {
+    setAttribute("qrcodetext", text);
+  }
+
+  @Override
+  public boolean getQRCodeSnglLine() throws RemoteException
+  {
+    Boolean replaceSnglLine = (Boolean) getAttribute("qrcodesngl");
+    if (null == replaceSnglLine)
+    {
+      return true;
+    }
+    return replaceSnglLine.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeSnglLine(boolean single) throws RemoteException
+  {
+    setAttribute("qrcodesngl", single);
+  }
+
+  @Override
+  public boolean getQRCodeExtNr() throws RemoteException
+  {
+    Boolean useExtNr = (Boolean) getAttribute("qrcodeext");
+    if (null == useExtNr)
+    {
+      return false;
+    }
+    return useExtNr.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeExtNr(boolean useExtNr) throws RemoteException
+  {
+    setAttribute("qrcodeext", useExtNr);
+  }
+
+  @Override
+  public String getQRCodeInfoM() throws RemoteException
+  {
+    String qrInfoToMember = (String) getAttribute("qrcodeinfom");
+    if (null == qrInfoToMember)
+    {
+      return "Vielen Dank für Ihre Spende!";
+    }
+    return qrInfoToMember;
+  }
+
+  @Override
+  public void setQRCodeInfoM(String infoMitglied) throws RemoteException
+  {
+    setAttribute("qrcodeinfom", infoMitglied);
+  }
+
+  @Override
+  public boolean getQRCodeKuerzen() throws RemoteException
+  {
+    Boolean kuerzen = (Boolean) getAttribute("qrcodekuerzen");
+    if (null == kuerzen)
+    {
+      return false;
+    }
+    return kuerzen.booleanValue();
+  }
+
+  @Override
+  public void setQRCodeKuerzen(boolean kuerzen) throws RemoteException
+  {
+    setAttribute("qrcodekuerzen", kuerzen);
+  }
+
+  @Override
+  public String getQRCodeIntro() throws RemoteException
+  {
+    String intro = (String) getAttribute("qrcodeintro");
+    if (null == intro)
+    {
+      return "Bequem bezahlen mit Girocode. Einfach mit der Banking-App auf dem Handy abscannen.";
+    }
+    return intro;
+  }
+
+  @Override
+  public void setQRCodeIntro(String intro) throws RemoteException
+  {
+    setAttribute("qrcodeintro", intro);
+  }
+
 }


### PR DESCRIPTION
- added some settings to configure the QR code's contents
- QR code is available as form element and can be placed on the invoice just like any other form field

Die Rechnungen aus JVerein können mit einem EPC-QR-Code versehen werden ("Zahlen mit Code").
Um den Inhalt dieses QR-Code zu konfigurieren, sind unter JVerein/Administration/Einstellungen/Rechnungen einige Einstellungen verfügbar.

- Kantenlänge QR-Code
Diese Einstellung konfiguriert die Größe des QR-Codes. Der QR-Code ist quadratisch. Eine Einstellung von "20" erzeugt also einen QR-Code der Größe 20 x 20 mm 
- Verwendungszweck
Wenn der QR-Code mit einer mobilen Banking-App gescannt wird, wird im Feld "Verwendungszweck" der Text eingetragen, der in dieser Einstellung konfiguriert wurde, also z. B. "Mitgliedsbeitrag 2024". In dieser Einstellung wird nur der Text konfiguriert. Er wird nur dann in den QR-Code aufgenommen, wenn auch die nächste Option aktiviert ist.
- Verwendungszweck hinzufügen
Wenn diese Checkbox ausgewählt ist, wird der oben konfigurierte Text in den QR-Code aufgenommen.
- Bei einzelner Position Verwendungszweck ersetzen
Besteht die Rechnung nur aus einer einzelnen Rechnungsposition, kann der Verwendungszweck im QR-Code durch den Text dieser Rechnungsposition ersetzt werden. Besteht die Rechnung aus mehr als einer Position wird immer der oben angegebene Verwendungszweck benutzt. Die Gesamtlänge des Verwendungszwecks ist im EPC-Standard auf 140 Zeichen begrenzt. Längere Texte werden auf 140 Zeichen gekürzt.
- Rechnungsdatum in QR-Code
Ist diese Option aktiviert, wird das Rechnungsdatum in den QR-Code mit aufgenommen.
- Rechnungsnummer in QR-Code
Ist diese Option aktiviert, wird die Rechnungsnummer in den QR-Code mit aufgenommen.
- Mitgliedsnummer verwenden
Wenn diese Option aktiviert wird, wird die Mitgliedsnummer in den Verwendungszweck des QR-Codes mit aufgenommen.
- externe Mitgliedsnummer verwenden
Bei Aktivieren dieser Option wird als Mitgliedsnummer nicht die interne Mitgliedsnummer in JVerein verwendet, sondern eine externe Mitgliedsnummer, die für die Mitglieder konfiguriert sein muss.
- Information an Mitglied in QR-Code
Der EPC-Standard bietet die Möglichkeit, den Mitgliedern beim Einscannen des QR-Codes eine Mitteilung anzuzeigen. Wenn die mobile Banking-App dies unterstützt, kann der anzuzeigende Text mit dieser Einstellung gesetzt werden. Die maximale Textlänge ist hier 70 Zeichen. Längere Texte werden abgeschnitten.
- Texte in QR-Code kürzen
Einige Texte (z. B. Rechnung vom) werden gekürzt (Re. v.), um die Anzahl der verwendeten Zeichen zu reduzieren.
- Beschreibungsgext für QR-Code
Um die Mitglieder zu unterstützen und sie über die Bedeutung des QR-Code aufklären zu können, kann hier ein Text angegeben werden, der ebenfalls als Formularfeld verfügbar ist und auf der Rechnung platziert werden kann.

Der QR-Code ist als Formularfeld auswählbar und kann auf das Rechnungsformular gedruckt werden, wie jedes andere Formularfeld auch. Die Formularfelder heißen "qrcode" für den QR-Code und "qrcode_intro" für den Beschreibungstext.

![grafik](https://github.com/openjverein/jverein/assets/54720490/90e73d30-c075-4c72-88d5-1ec81a74e37c)
![grafik](https://github.com/openjverein/jverein/assets/54720490/c4be2964-6399-46af-adf6-6658f64b407c)

