### PR TITLE
Feature Unterschrift in Standard Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -1193,8 +1193,18 @@ public class SpendenbescheinigungPrintAction implements Action
             + new JVDateFormatTTMMJJJJ().format(spb.getBescheinigungsdatum()),
         9);
 
+    if (Einstellungen.getEinstellung().getUnterschriftdrucken())
+    {
+      rpt.add("\n", 8);
+      rpt.add(Einstellungen.getEinstellung().getUnterschrift(), 400, 75, 0);
+    }
+    else
+    {
+      rpt.add("\n\n\n\n", 8);
+    }
+    
     rpt.add(
-        "\n\n\n\n.................................................................................\nUnterschrift des Zuwendungsempfängers",
+        ".................................................................................\nUnterschrift des Zuwendungsempfängers",
         8);
 
     rpt.add("\nHinweis:", 8);

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -52,6 +52,7 @@ import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.DirectoryInput;
+import de.willuhn.jameica.gui.input.ImageInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.PasswordInput;
@@ -293,6 +294,10 @@ public class EinstellungControl extends AbstractControl
   private CheckboxInput abrlabschliessen;
 
   private CheckboxInput optiert;
+  
+  private CheckboxInput unterschriftdrucken;
+  
+  private ImageInput unterschrift;
 
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
@@ -1794,6 +1799,26 @@ public class EinstellungControl extends AbstractControl
     abrlabschliessen.setName("Funktion einschalten");
     return abrlabschliessen;
   }
+  
+  public CheckboxInput getUnterschriftdrucken() throws RemoteException 
+  {
+    if (unterschriftdrucken != null) 
+    {
+      return unterschriftdrucken;
+    }
+    unterschriftdrucken = new CheckboxInput(Einstellungen.getEinstellung().getUnterschriftdrucken());
+    return unterschriftdrucken;
+  }
+
+  public ImageInput getUnterschrift() throws RemoteException
+  {
+    if (unterschrift != null)
+    {
+      return unterschrift;
+    }
+    unterschrift = new ImageInput(Einstellungen.getEinstellung().getUnterschrift(), 400, 75);
+    return unterschrift;
+  }
 
   public void handleStoreAllgemein()
   {
@@ -1961,6 +1986,8 @@ public class EinstellungControl extends AbstractControl
           .getValue());
       e.setSpendenbescheinigungPrintBuchungsart((Boolean) spendenbescheinigungprintbuchungsart
           .getValue());
+      e.setUnterschriftdrucken((Boolean) unterschriftdrucken.getValue());
+      e.setUnterschrift((byte[]) unterschrift.getValue());
       e.store();
       Einstellungen.setEinstellung(e);
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -52,6 +52,9 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
         control.getSpendenbescheinigungverzeichnis());
     cont.addLabelPair("Buchungsart drucken",
         control.getSpendenbescheinigungPrintBuchungsart());
+    cont.addLabelPair("Unterschrift drucken",
+        control.getUnterschriftdrucken());
+    cont.addLabelPair("Unterschrift", control.getUnterschrift());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -256,6 +256,27 @@ public class Reporter
     cell.setHorizontalAlignment(horizontalalignment);
     table.addCell(cell);
   }
+  
+  public void add(byte[] image, int width, int height,
+      int horizontalalignment)
+      throws BadElementException, MalformedURLException, IOException, DocumentException
+  {
+    Image i = Image.getInstance(image);
+    float w = i.getWidth() / width;
+    float h = i.getHeight() / height;
+    if (w > h)
+    {
+      h = i.getHeight() / w;
+      w = width;
+    }
+    else
+    {
+      w = i.getHeight() / h;
+      h = height;
+    }
+    i.scaleToFit(w, h);
+    rpt.add(i);
+  }
 
   /**
    * Fuegt eine neue Zelle zur Tabelle hinzu.

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -544,4 +544,11 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public SepaVersion getCt1SepaVersion() throws RemoteException;
 
+  public Boolean getUnterschriftdrucken() throws RemoteException;
+
+  public void setUnterschriftdrucken(Boolean unterschriftdrucken) throws RemoteException;
+  
+  public byte[] getUnterschrift() throws RemoteException;
+
+  public void setUnterschrift(byte[] unterschrift) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0435.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0435.java
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0435 extends AbstractDDLUpdate
+{
+  public Update0435(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("unterschriftdrucken",
+        COLTYPE.BOOLEAN, 0, null, false, false)));
+    execute(addColumn("einstellung", new Column("unterschrift",
+        COLTYPE.LONGBLOB, 0, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -1817,4 +1817,27 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     }
   }
 
+  @Override
+  public Boolean getUnterschriftdrucken() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("unterschriftdrucken"));
+  }
+
+  @Override
+  public void setUnterschriftdrucken(Boolean unterschriftdrucken) throws RemoteException
+  {
+    setAttribute("unterschriftdrucken", unterschriftdrucken);
+  }
+  
+  @Override
+  public byte[] getUnterschrift() throws RemoteException
+  {
+    return (byte[]) getAttribute("unterschrift");
+  }
+
+  @Override
+  public void setUnterschrift(byte[] unterschrift) throws RemoteException
+  {
+    setAttribute("unterschrift", unterschrift);
+  }
 }


### PR DESCRIPTION
Das Feature erlaubt es in den Einstellungen der Spendenbescheinigung ein Bild einer Unterschrift zu laden. Dieses Bild wird dann in der automatisch generierten Spendenbescheinigung in das PDF aufgenommen.
Das Feature lässt sich über einen Schalter in den Einstellungen aktivieren.

PS: Die Migration benutzt die Nummer 0435. Es sollte also vorher entweder #204 oder #205 übernommen werden.