### PR TITLE
Feature Sterbedatum in Mitgliedertabelle

### DIFF
--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -100,9 +100,19 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     add("Kündigung", "kuendigung", false,
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
         false);
-    add("Sterbedatum", "sterbetag", false,
-        new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
-        false);
+    try
+    {
+      if (Einstellungen.getEinstellung().getSterbedatum())
+      {
+        add("Sterbedatum", "sterbetag", false,
+            new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
+            false);
+      }
+    }
+    catch (RemoteException re)
+    {
+      //
+    }
     add("Eingabedatum", "eingabedatum", false,
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO, true);
     add("Letzte Änderung", "letzteaenderung", false,

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -43,7 +43,7 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     {
       if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
       {
-        add("externe Mitgliedsnummer", "externemitgliedsnummer", false, false);
+        add("Externe Mitgliedsnummer", "externemitgliedsnummer", false, false);
       }
     }
     catch (RemoteException re)
@@ -98,6 +98,9 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
         false);
     add("Kündigung", "kuendigung", false,
+        new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
+        false);
+    add("Sterbedatum", "sterbetag", false,
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
         false);
     add("Eingabedatum", "eingabedatum", false,


### PR DESCRIPTION
Das Feature erlaubt es das Sterbedatum in der Tabelle der Mitglieder im "Mitglieder Suchen" View anzuzeigen.
Die Auswahl der Spalte passiert wie üblich in den Einstellungen.
Sterbedatum muss in den Einstellungen->Anzeige ausgewählt sein.
Externe Mitgliedsnummer auf Großschrift geändert.