### PR TITLE
Fix Nullpointer Exception beim Speichern von Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -358,10 +358,13 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
   {
     super.store();
     Long id = Long.valueOf(getID());
-    for (Buchung b : buchungen)
+    if (buchungen != null)
     {
-      b.setSpendenbescheinigungId(id);
-      b.store();
+      for (Buchung b : buchungen)
+      {
+        b.setSpendenbescheinigungId(id);
+        b.store();
+      }
     }
   }
 


### PR DESCRIPTION
Beim Speichern von Spendenbescheinigungen ohne Buchung ist "buchungen" null und es kommt zu einer  Nullpointer Exception in der for Schleife.