### PR TITLE
Fix Versand - Korrigiert #187

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -556,7 +556,6 @@ public class MailControl extends AbstractControl
       for (MailEmpfaenger me : getMail().getEmpfaenger())
       {
         me.setMail(m);
-        me.setVersand(m.getVersand());
         me.store();
       }
       DBIterator<MailEmpfaenger> it = Einstellungen.getDBService()


### PR DESCRIPTION
In #187 hat sich ein Fehler eingeschlichen. In Zeile 559 wird Versand gesetzt. Das passiert zu früh. Im run Thread wird dann festgestellt, dass die Mail schon versendet wurde und sie wird übersprungen. 
Darum kann man keine Mails mehr versenden. Die Zeile muss wieder raus.