### PR TITLE
Spendenbescheinigung per Mail versenden, implementiert #191

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -1297,7 +1297,11 @@ public class SpendenbescheinigungPrintAction implements Action
       rpt.closeTable();      
     }
     
-    String email = spb.getMitglied().getEmail();
+    String email = null;
+    if (spb.getMitglied() != null)
+    {
+        spb.getMitglied().getEmail();
+    }
     if ( (mailversand == false && Einstellungen.getEinstellung().getSpendenbescheinigungadresse())
         || (mailversand == true && Einstellungen.getEinstellung().getSpendenbescheinigungadresse() 
             && (email == null || email.isEmpty()))

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -47,7 +47,6 @@ import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.TablePart;
-import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 /**
@@ -164,9 +163,8 @@ public class SpendenbescheinigungPrintAction implements Action
           Formular spendeformular = spb.getFormular();
           if (spendeformular == null)
           {
-            GUI.getStatusBar().setErrorText(
-                "Nicht alle Spendenbescheinigungen haben ein gültiges Formular!");
-            return;
+            String text = "Nicht alle Spendenbescheinigungen haben ein gültiges Formular!";
+            throw new ApplicationException(text);
           }
         }
       }
@@ -238,8 +236,7 @@ public class SpendenbescheinigungPrintAction implements Action
     {
       String fehler = "Fehler beim Aufbereiten der Spendenbescheinigung ("
           + e.getMessage() + ")";
-      GUI.getStatusBar().setErrorText(fehler);
-      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
     }
   }
 

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungSendAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungSendAction.java
@@ -1,0 +1,109 @@
+/**********************************************************************
+* Copyright (c) by Alexander Dippe
+* This program is free software: you can redistribute it and/or modify it under the terms of the 
+* GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+* even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+* the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with this program.  If not, 
+* see <http://www.gnu.org/licenses/>.
+* 
+* https://openjverein.github.io
+**********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.SpendenbescheinigungMailView;
+
+import de.jost_net.JVerein.gui.dialogs.MailAbfrageDialog;
+import de.jost_net.JVerein.gui.dialogs.MailAbfrageDialog.Auswahl;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * E-Mail senden Formular anhand des zugewiesenen Spenders
+ */
+public class SpendenbescheinigungSendAction implements Action
+{
+  private de.willuhn.jameica.system.Settings settings;
+  
+  public SpendenbescheinigungSendAction()
+  {
+    super();
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+  }
+
+  /**
+   * Versenden einer E-Mail mit der Spendenbescheinigung im Anhang 
+   * für Mitglieder deren Spendenbescheinigung im View ausgewählt ist.
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    Spendenbescheinigung[] spbArr = null;
+    // Prüfung des Contexs, vorhanden, eine oder mehrere
+    if (context instanceof TablePart)
+    {
+      TablePart tp = (TablePart) context;
+      context = tp.getSelection();
+    }
+    if (context == null)
+    {
+      throw new ApplicationException("Keine Spendenbescheinigung ausgewählt");
+    }
+    else if (context instanceof Spendenbescheinigung)
+    {
+      spbArr = new Spendenbescheinigung[] { (Spendenbescheinigung) context };
+    }
+    else if (context instanceof Spendenbescheinigung[])
+    {
+      spbArr = (Spendenbescheinigung[]) context;
+    }
+    else
+    {
+      return;
+    }
+    
+    try
+    {
+      String text = "Für das Versenden werden gedruckte Spendenbescheinigungen benötigt."
+          + "\nWenn sie schon gedruckt wurden brauchen sie nicht neu gedruckt werden.";
+      MailAbfrageDialog d = new MailAbfrageDialog(text, MailAbfrageDialog.POSITION_CENTER);
+      d.setTitle("Spendenbescheinigungen versenden");
+      d.setPanelText("Spendenbescheinigungen drucken?");
+      
+      MailAbfrageDialog.Auswahl choice = (MailAbfrageDialog.Auswahl) d.open();
+      if (choice == null)
+      {
+        return;
+      }
+      else if (choice == Auswahl.DRUCKEN_STANDARD)
+      {
+        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(true);
+        action.handleAction(spbArr);
+      }
+      else if (choice == Auswahl.DRUCKEN_INDIVIDUELL)
+      {
+        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(false);
+        action.handleAction(spbArr);
+      }
+
+      GUI.startView(SpendenbescheinigungMailView.class, spbArr);
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (Exception e)
+    {
+      GUI.getStatusBar().setErrorText(e.getMessage());
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungSendAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungSendAction.java
@@ -86,12 +86,12 @@ public class SpendenbescheinigungSendAction implements Action
       }
       else if (choice == Auswahl.DRUCKEN_STANDARD)
       {
-        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(true);
+        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(true, true);
         action.handleAction(spbArr);
       }
       else if (choice == Auswahl.DRUCKEN_INDIVIDUELL)
       {
-        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(false);
+        SpendenbescheinigungPrintAction action = new SpendenbescheinigungPrintAction(false, true);
         action.handleAction(spbArr);
       }
 

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -300,6 +300,8 @@ public class EinstellungControl extends AbstractControl
   private CheckboxInput unterschriftdrucken;
   
   private ImageInput unterschrift;
+  
+  private CheckboxInput anhangspeichern;
 
 
   /**
@@ -1832,6 +1834,16 @@ public class EinstellungControl extends AbstractControl
     unterschrift = new ImageInput(Einstellungen.getEinstellung().getUnterschrift(), 400, 75);
     return unterschrift;
   }
+  
+  public CheckboxInput getAnhangSpeichern() throws RemoteException 
+  {
+    if (anhangspeichern != null) 
+    {
+      return anhangspeichern;
+    }
+    anhangspeichern = new CheckboxInput(Einstellungen.getEinstellung().getAnhangSpeichern());
+    return anhangspeichern;
+  }
 
   public void handleStoreAllgemein()
   {
@@ -2002,6 +2014,7 @@ public class EinstellungControl extends AbstractControl
       e.setSpendenbescheinigungadresse((Boolean) getSpendenbescheinigungadresse().getValue());
       e.setUnterschriftdrucken((Boolean) unterschriftdrucken.getValue());
       e.setUnterschrift((byte[]) unterschrift.getValue());
+      e.setAnhangSpeichern((Boolean) anhangspeichern.getValue());
       e.store();
       Einstellungen.setEinstellung(e);
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -524,7 +524,7 @@ public class SpendenbescheinigungControl extends AbstractControl
           GUI.getStatusBar().setSuccessText("Spendenbescheinigung erstellt");
           FileViewer.show(file);
         }
-        catch (RemoteException e)
+        catch (Exception e)
         {
           Logger.error(e.getMessage());
           throw new ApplicationException(

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
@@ -1,0 +1,321 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.StringWriter;
+import java.rmi.RemoteException;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.Map;
+import java.util.TreeSet;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.MitgliedMap;
+import de.jost_net.JVerein.Variable.VarTools;
+import de.jost_net.JVerein.io.MailSender;
+import de.jost_net.JVerein.rmi.Mail;
+import de.jost_net.JVerein.rmi.MailAnhang;
+import de.jost_net.JVerein.rmi.MailEmpfaenger;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.util.Dateiname;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.TextAreaInput;
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
+
+
+public class SpendenbescheinigungMailControl extends AbstractControl
+{
+
+  private de.willuhn.jameica.system.Settings settings;
+
+  private TextInput mailbetreff;
+
+  private TextAreaInput mailtext;
+  
+  private TextAreaInput info;
+  
+  private Spendenbescheinigung[] spbArr;
+
+  public SpendenbescheinigungMailControl(AbstractView view)
+  {
+    super(view);
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+  }
+
+  public void init(Object spbArray)
+  {
+    spbArr = (Spendenbescheinigung[]) spbArray;
+    info.setValue((String) info.getValue() + "Es wurden " + spbArr.length + 
+        " Spendenbescheinigungen ausgewählt"
+        + "\nFolgende Mitglieder haben keine Mailadresse:");
+    try
+    {
+      for (Spendenbescheinigung spb: spbArr)
+      {
+        Mitglied m = spb.getMitglied();
+        if (m != null && ( m.getEmail() == null || m.getEmail().isEmpty()))
+        {
+          info.setValue((String) info.getValue() + "\n - " + m.getName()
+              + ", " + m.getVorname());
+        }
+      }
+      info.setValue((String) info.getValue() 
+          + "\nFür folgende Spendenbescheinigungen existiert kein Mitglied und keine Mailadresse:");
+      for (Spendenbescheinigung spb: spbArr)
+      {
+        if (spb.getMitglied() == null)
+        {
+          info.setValue((String) info.getValue() + "\n - " + spb.getZeile1()
+              + ", " + spb.getZeile2() + ", " + spb.getZeile3());
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      GUI.getStatusBar().setErrorText("Fehler beim Ermitteln der Mitglieder aus den Spendenbescheinigungen");
+    }
+  }
+
+  public TextInput getBetreff() throws RemoteException
+  {
+    if (mailbetreff != null)
+    {
+      return mailbetreff;
+    }
+    mailbetreff = new TextInput(settings.getString("spendenbescheinigungmail.subject", ""), 100);
+    mailbetreff.setName("Betreff");
+    return mailbetreff;
+  }
+
+  public TextAreaInput getTxt() throws RemoteException
+  {
+    if (mailtext != null)
+    {
+      return mailtext;
+    }
+    mailtext = new TextAreaInput(settings.getString("spendenbescheinigungmail.body", ""), 10000);
+    mailtext.setName("Text");
+    return mailtext;
+  }
+  
+  public TextAreaInput getInfo() throws RemoteException
+  {
+    if (info != null)
+    {
+      return info;
+    }
+    info = new TextAreaInput("", 5000);
+    info.setName("Info");
+    info.setEnabled(false);
+    return info;
+  }
+  
+  public Button getStartButton(final Object currentObject)
+  {
+    Button button = new Button("Starten", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        try
+        {
+          settings.setAttribute("spendenbescheinigungmail.subject",
+              (String) mailbetreff.getValue());
+          settings.setAttribute("spendenbescheinigungmail.body", 
+              (String) mailtext.getValue());
+          String betr = (String) mailbetreff.getValue();
+          String text = (String) mailtext.getValue();
+         sendeMail(betr, text);
+        }
+        catch (Exception e)
+        {
+          Logger.error("Fehler", e);
+          GUI.getStatusBar().setErrorText(e.getMessage());
+        }
+      }
+    }, null, true, "walking.png");
+    return button;
+  }
+
+  private void sendeMail(final String betr, final String txt) throws RemoteException
+  {
+
+    BackgroundTask t = new BackgroundTask()
+    {
+
+      @Override
+      public void run(ProgressMonitor monitor)
+      {
+        try
+        {
+          MailSender sender = new MailSender(
+              Einstellungen.getEinstellung().getSmtpServer(),
+              Einstellungen.getEinstellung().getSmtpPort(),
+              Einstellungen.getEinstellung().getSmtpAuthUser(),
+              Einstellungen.getEinstellung().getSmtpAuthPwd(),
+              Einstellungen.getEinstellung().getSmtpFromAddress(),
+              Einstellungen.getEinstellung().getSmtpFromAnzeigename(),
+              Einstellungen.getEinstellung().getMailAlwaysBcc(),
+              Einstellungen.getEinstellung().getMailAlwaysCc(),
+              Einstellungen.getEinstellung().getSmtpSsl(),
+              Einstellungen.getEinstellung().getSmtpStarttls(),
+              Einstellungen.getEinstellung().getMailVerzoegerung(),
+              Einstellungen.getImapCopyData());
+
+          Velocity.init();
+          Logger.debug("preparing velocity context");
+          monitor.setStatus(ProgressMonitor.STATUS_RUNNING);
+          monitor.setPercentComplete(0);
+
+          int sentCount = 0;
+          int size = spbArr.length;
+          for (int i=0; i < size; i++)
+          {
+            Mitglied m = spbArr[i].getMitglied();
+            if (m == null || m.getEmail() == null || m.getEmail().isEmpty())
+            {
+              continue;
+            }
+            VelocityContext context = new VelocityContext();
+            context.put("dateformat", new JVDateFormatTTMMJJJJ());
+            context.put("decimalformat", Einstellungen.DECIMALFORMAT);
+            context.put("email", m.getEmail());
+
+            Map<String, Object> map = new MitgliedMap().getMap(m, null);
+            map = new AllgemeineMap().getMap(map);
+            VarTools.add(context, map);
+
+            StringWriter wtext1 = new StringWriter();
+            Velocity.evaluate(context, wtext1, "LOG", betr);
+
+            StringWriter wtext2 = new StringWriter();
+            Velocity.evaluate(context, wtext2, "LOG", txt);
+
+            try
+            {
+              String path = Einstellungen.getEinstellung()
+                  .getSpendenbescheinigungverzeichnis();
+              if (path == null || path.length() == 0)
+              {
+                path = settings.getString("lastdir", System.getProperty("user.home"));
+              }
+
+              settings.setAttribute("lastdir", path);
+              path = path.endsWith(File.separator) ? path : path + File.separator;
+              TreeSet<MailAnhang> anhang = new TreeSet<MailAnhang>();
+              MailAnhang anh = (MailAnhang) Einstellungen.getDBService()
+                  .createObject(MailAnhang.class, null);
+              String fileName = new Dateiname(m,
+                  spbArr[i].getBescheinigungsdatum(), "Spendenbescheinigung",
+                  Einstellungen.getEinstellung().getDateinamenmusterSpende(),
+                  "pdf").get();
+              anh.setDateiname(fileName);
+              fileName = path + fileName;
+              File file = new File(fileName);
+              FileInputStream fis = new FileInputStream(file);
+              byte[] buffer = new byte[(int) file.length()];
+              fis.read(buffer);
+              anh.setAnhang(buffer);
+              anhang.add(anh);
+              fis.close();
+
+              sender.sendMail(m.getEmail(), wtext1.getBuffer().toString(),
+                  wtext2.getBuffer().toString(), anhang);
+              sentCount++;
+
+              // Mail in die Datenbank schreiben
+              Mail mail = (Mail) Einstellungen.getDBService()
+                  .createObject(Mail.class, null);
+              Timestamp ts = new Timestamp(new Date().getTime());
+              mail.setBearbeitung(ts);
+              mail.setBetreff(wtext1.getBuffer().toString());
+              mail.setTxt(wtext2.getBuffer().toString());
+              mail.setVersand(ts);
+              mail.store();
+              MailEmpfaenger empf = (MailEmpfaenger) Einstellungen
+                  .getDBService().createObject(MailEmpfaenger.class, null);
+              empf.setMail(mail);
+              empf.setMitglied(m);
+              empf.setVersand(ts);
+              empf.store();
+              anh.setMail(mail);
+              anh.store();
+
+              monitor.log(m.getEmail() + " - versendet");
+            }
+            catch (Exception e)
+            {
+              Logger.error("Fehler beim Mailversand", e);
+              monitor.log(m.getEmail() + " - " + e.getMessage());
+            }
+          }
+          monitor.setPercentComplete(100);
+          monitor.setStatus(ProgressMonitor.STATUS_DONE);
+          monitor.setStatusText(
+              String.format("Anzahl verschickter Mails: %d", sentCount));
+          GUI.getStatusBar().setSuccessText(
+              "Mail" + (sentCount > 1 ? "s" : "") + " verschickt");
+          GUI.getCurrentView().reload();
+        }
+        catch (ApplicationException ae)
+        {
+          Logger.error("", ae);
+          monitor.log(ae.getMessage());
+        }
+        catch (Exception re)
+        {
+          Logger.error("", re);
+          monitor.log(re.getMessage());
+        }
+      }
+
+      @Override
+      public void interrupt()
+      {
+        //
+      }
+
+      @Override
+      public boolean isInterrupted()
+      {
+        return false;
+      }
+    };
+    Application.getController().start(t);
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
@@ -273,7 +273,10 @@ public class SpendenbescheinigungMailControl extends AbstractControl
               empf.setVersand(ts);
               empf.store();
               anh.setMail(mail);
-              anh.store();
+              if (Einstellungen.getEinstellung().getAnhangSpeichern())
+              {
+                anh.store();
+              }
 
               monitor.log(m.getEmail() + " - versendet");
             }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
@@ -202,6 +202,7 @@ public class SpendenbescheinigungMailControl extends AbstractControl
           monitor.setPercentComplete(0);
 
           int sentCount = 0;
+          int zae = 0;
           int size = spbArr.length;
           for (int i=0; i < size; i++)
           {
@@ -285,6 +286,10 @@ public class SpendenbescheinigungMailControl extends AbstractControl
               Logger.error("Fehler beim Mailversand", e);
               monitor.log(m.getEmail() + " - " + e.getMessage());
             }
+            zae++;
+            double proz = (double) zae
+                / (double) size * 100d;
+            monitor.setPercentComplete((int) proz);
           }
           monitor.setPercentComplete(100);
           monitor.setStatus(ProgressMonitor.STATUS_DONE);

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungMailControl.java
@@ -202,10 +202,11 @@ public class SpendenbescheinigungMailControl extends AbstractControl
           monitor.setPercentComplete(0);
 
           int sentCount = 0;
-          int zae = 0;
           int size = spbArr.length;
           for (int i=0; i < size; i++)
           {
+            double proz = (double) i / (double) size * 100d;
+            monitor.setPercentComplete((int) proz);
             Mitglied m = spbArr[i].getMitglied();
             if (m == null || m.getEmail() == null || m.getEmail().isEmpty())
             {
@@ -286,10 +287,6 @@ public class SpendenbescheinigungMailControl extends AbstractControl
               Logger.error("Fehler beim Mailversand", e);
               monitor.log(m.getEmail() + " - " + e.getMessage());
             }
-            zae++;
-            double proz = (double) zae
-                / (double) size * 100d;
-            monitor.setPercentComplete((int) proz);
           }
           monitor.setPercentComplete(100);
           monitor.setStatus(ProgressMonitor.STATUS_DONE);

--- a/src/de/jost_net/JVerein/gui/dialogs/MailAbfrageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailAbfrageDialog.java
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.input.TextAreaInput;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Ein Dialog, um auszuwählen ob Spendenbescheinigungen 
+ * vor dem Versenden noch gedruckt werden müssen.
+ */
+public class MailAbfrageDialog extends AbstractDialog<MailAbfrageDialog.Auswahl>
+{
+
+  private Auswahl retval = null;
+  
+  private String text;
+  
+  public enum Auswahl {
+    OHNE_DRUCKEN,
+    DRUCKEN_STANDARD,
+    DRUCKEN_INDIVIDUELL
+  }
+
+  public MailAbfrageDialog(String text, int position)
+  {
+    super(position);
+    this.text = text;
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    TextAreaInput  textfeld = new TextAreaInput(text, 100);
+    textfeld.disable();
+    textfeld.paint(parent);
+    
+    ButtonArea b = new ButtonArea();
+    
+    b.addButton("Ohne Drucken", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        retval = Auswahl.OHNE_DRUCKEN;
+        close();
+      }
+    }, null, true, "go-next.png");
+    
+    b.addButton("Mit Drucken (Standard)", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        retval = Auswahl.DRUCKEN_STANDARD;
+        close();
+      }
+    }, null, false, "go-next.png");
+    
+    b.addButton("Mit Drucken (Individuell)", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        retval = Auswahl.DRUCKEN_INDIVIDUELL;
+        close();
+      }
+    }, null, false, "go-next.png");
+    
+    b.addButton("Abbrechen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        retval = null;
+        close();
+      }
+    }, null, false, "process-stop.png");
+    b.paint(parent);
+  }
+
+  @Override
+  protected Auswahl getData() throws Exception
+  {
+    return retval;
+  }
+}

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.menu;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungDeleteAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungDuplizierenAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungEmailAction;
+import de.jost_net.JVerein.gui.action.SpendenbescheinigungSendAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.jameica.gui.Action;
@@ -40,11 +41,13 @@ public class SpendenbescheinigungMenu extends ContextMenu
   {
     addItem(new CheckedContextMenuItem("Drucken (Standard)",
         new SpendenbescheinigungPrintAction(true), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("Drucken (individuell)",
+    addItem(new CheckedContextMenuItem("Drucken (Individuell)",
         new SpendenbescheinigungPrintAction(false), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));
+    addItem(new CheckedContextMenuItem("Spendenbescheinigungen versenden",
+        new SpendenbescheinigungSendAction(), "envelope-open.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new DuplicateMenuItem("Als Vorlage für neue Spende",
         new SpendenbescheinigungDuplizierenAction(), "edit-copy.png"));

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -57,6 +57,7 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
     cont.addLabelPair("Unterschrift drucken",
         control.getUnterschriftdrucken());
     cont.addLabelPair("Unterschrift", control.getUnterschrift());
+    cont.addLabelPair("Anhang bei E-Mail Versand in DB speichern", control.getAnhangSpeichern());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.SpendenbescheinigungMailControl;
+import de.jost_net.JVerein.gui.util.JameicaUtil;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+
+public class SpendenbescheinigungMailView extends AbstractView
+{
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Spendenbescheinigung-Mail");
+
+    final SpendenbescheinigungMailControl control = new SpendenbescheinigungMailControl(this);
+
+    Composite comp = new Composite(this.getParent(), SWT.NONE);
+    comp.setLayoutData(new GridData(GridData.FILL_BOTH));
+
+    GridLayout layout = new GridLayout(2, false);
+    comp.setLayout(layout);
+
+    JameicaUtil.addLabel("Betreff", comp, GridData.VERTICAL_ALIGN_CENTER);
+    control.getBetreff().paint(comp);
+    JameicaUtil.addLabel("Text", comp, GridData.VERTICAL_ALIGN_BEGINNING);
+    control.getTxt().paint(comp);
+    JameicaUtil.addLabel("Info", comp, GridData.VERTICAL_ALIGN_BEGINNING);
+    control.getInfo().paint(comp);
+    
+    control.init(this.getCurrentObject());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+    buttons.addButton(control.getStartButton(this.getCurrentObject()));
+    buttons.paint(this.getParent());
+  }
+}

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -555,4 +555,8 @@ public interface Einstellung extends DBObject, IBankverbindung
   public byte[] getUnterschrift() throws RemoteException;
 
   public void setUnterschrift(byte[] unterschrift) throws RemoteException;
+
+  public Boolean getAnhangSpeichern() throws RemoteException;
+
+  public void setAnhangSpeichern(Boolean anhangspeichern) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0437.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0437.java
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0437 extends AbstractDDLUpdate
+{
+  public Update0437(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("anhangspeichern",
+        COLTYPE.BOOLEAN, 0, "TRUE", false, false)));
+    execute(alterColumn("mailanhang",
+        new Column("dateiname", COLTYPE.VARCHAR, 100, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0438.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0438.java
@@ -20,9 +20,9 @@ import de.willuhn.util.ProgressMonitor;
 
 import java.sql.Connection;
 
-public class Update0437 extends AbstractDDLUpdate
+public class Update0438 extends AbstractDDLUpdate
 {
-  public Update0437(String driver, ProgressMonitor monitor, Connection conn)
+  public Update0438(String driver, ProgressMonitor monitor, Connection conn)
   {
     super(driver, monitor, conn);
   }

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -1852,4 +1852,16 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   {
     setAttribute("unterschrift", unterschrift);
   }
+  
+  @Override
+  public Boolean getAnhangSpeichern() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("anhangspeichern"));
+  }
+
+  @Override
+  public void setAnhangSpeichern(Boolean anhangspeichern) throws RemoteException
+  {
+    setAttribute("anhangspeichern", anhangspeichern);
+  }
 }

--- a/src/de/jost_net/JVerein/server/MailAnhangImpl.java
+++ b/src/de/jost_net/JVerein/server/MailAnhangImpl.java
@@ -72,7 +72,7 @@ public class MailAnhangImpl extends AbstractDBObject implements MailAnhang,
   private void dateinameCheck(String dateiname) throws ApplicationException
   {
     // Länge des Dateinamens auf 100 Zeichen begrenzt:
-    // JVereinUpdateProvider: update0437(Mailanhang speichern)
+    // JVereinUpdateProvider: update0438(Mailanhang speichern)
     if (dateiname.length() > 100)
       throw new ApplicationException(
           String.format(

--- a/src/de/jost_net/JVerein/server/MailAnhangImpl.java
+++ b/src/de/jost_net/JVerein/server/MailAnhangImpl.java
@@ -71,13 +71,13 @@ public class MailAnhangImpl extends AbstractDBObject implements MailAnhang,
 
   private void dateinameCheck(String dateiname) throws ApplicationException
   {
-    // Länge des Dateinamens auf 50 Zeichen begrenzt:
-    // JVereinUpdateProvider: update0093(Connection)
-    if (dateiname.length() > 50)
+    // Länge des Dateinamens auf 100 Zeichen begrenzt:
+    // JVereinUpdateProvider: update0437(Mailanhang speichern)
+    if (dateiname.length() > 100)
       throw new ApplicationException(
           String.format(
-              "Maximale Länge (50) des Dateinamens von Mail-Anhang überschritten. (%d, %s...)",
-              dateiname.length(), dateiname.substring(0, 50)));
+              "Maximale Länge (100) des Dateinamens von Mail-Anhang überschritten. (%d, %s...)",
+              dateiname.length(), dateiname.substring(0, 100)));
   }
 
   @Override


### PR DESCRIPTION
Der Request implementiert das Feature #191
Es gibt einen neuen Menüpunkt "Spendenbescheinigungen versenden" bei Spendenbescheinigungen, multi Selection ist aktiv:
![Screenshot_20240426_090846](https://github.com/openjverein/jverein/assets/126261667/e9bf3a12-aaee-4f20-a56d-13b0e60a1c6d)
Dann kommt ein Dialog wo man entscheiden kann ob die Spendenbescheinigungen gedruckt werden sollen. Sind sie schon gedruckt kann man ohne neues drucken weiter gehen.
![Screenshot_20240418_180941](https://github.com/openjverein/jverein/assets/126261667/4e22cb9e-ad78-4478-8feb-2090008f5241)
Der View zum senden schaut dann so aus. Im Info Feld liste ich Mitglieder auf die keine Mailadresse haben. Auch wird aufgelistet ob für eine Spendenbescheinigung kein Mitglied existiert. Das ist der Fall wenn man die Spendenbescheinigung im Spendenbescheinigung Liste View manuell erzeugt. Für die muss man dann halt die Bescheinigungen per Brief versenden.

![Screenshot_20240426_091226](https://github.com/openjverein/jverein/assets/126261667/2bff043c-34de-478f-ae83-d15719a90434)

Über einen Schalter in den Einstellungen lässt sich auswählen ob der Mailanhang (Spendenbescheinigung) mit der Mail in der Datenbank gespeichert werden soll.

![Screenshot_20240426_091830](https://github.com/openjverein/jverein/assets/126261667/792f1d69-38d8-4854-b033-2616588a6bcb)

