### PR TITLE
Fix Eigenschaften in Mitglied Query

### DIFF
--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -257,20 +257,21 @@ public class MitgliedQuery
         {
           StringBuilder condEigenschaft = new StringBuilder(
               "(select count(*) from eigenschaften where ");
-          boolean first = true;
           condEigenschaft.append("eigenschaften.mitglied = mitglied.id AND (");
+          int count = 0;
           for (Eigenschaft ei : eiu.get(eg))
           {
-            if (!first)
+            if (count != 0)
             {
               condEigenschaft.append("OR ");
             }
-            first = false;
+            count++;
             condEigenschaft.append("eigenschaft = ? ");
             bedingungen.add(ei.getID());
           }
-          condEigenschaft.append(")) > 0 ");
+          condEigenschaft.append(")) = ? ");
           addCondition(condEigenschaft.toString());
+          bedingungen.add(Integer.toString(count));
         }
       }
       else


### PR DESCRIPTION
Das Query der Mitglieder hat nicht funktioniert für die Verknüpfung "und" bei den Eigenschaften. 
Die Implementierung für "oder" iteriert über alle Eigenschaften und schaut ob es mindestens einen Match gibt. Das passt. 
Die Implementierung für "und" iteriert über alle Gruppen und schaut ob es in jeder Gruppe einen Match gibt. Das funktioniert aber nicht wenn eine Gruppe mehrere Eigenschaften hat weil es dem Code reicht wenn es für eine davon einen Match gibt. Es muss aber für alle sein. Also muss man statt >0 auf Gleichheit mit der Anzahl der Eigenschaften prüfen. 
Man könnte sich auch die Schleife über die Gruppen sparen und wie bei "oder" direkt über die Eigenschaften iterieren.
Ich habe den Query Code korrigiert damit er auch "und" korrekt ausführt.