### PR TITLE
Fix Update0430 Teil 2

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
@@ -311,6 +311,31 @@ public abstract class AbstractDDLUpdate implements IDDLUpdate
     return "";
 
   }
+  
+  public String createForeignKeyIfNotExistsNocheck(String constraintname, String table,
+      String column, String reftable, String refcolumn, String ondelete,
+      String onupdate)
+  {
+    switch (drv)
+    {
+      case H2:
+      {
+        return "ALTER TABLE " + table + " ADD CONSTRAINT IF NOT EXISTS " + constraintname
+            + " FOREIGN KEY (" + column + ") REFERENCES " + reftable + "("
+            + refcolumn + ") ON DELETE " + ondelete + " ON UPDATE " + onupdate
+            + " NOCHECK;\n";
+      }
+      case MYSQL:
+      {
+        return "ALTER TABLE " + table + " ADD CONSTRAINT IF NOT EXISTS " + " FOREIGN KEY "
+            + constraintname + "(" + column + ") REFERENCES " + reftable + " ("
+            + refcolumn + ") ON DELETE " + ondelete + " ON UPDATE " + onupdate
+            + " NOCHECK;\n";
+      }
+    }
+    return "";
+
+  }
 
   public String dropTable(String table)
   {

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * JVerein - Mitgliederverwaltung und einfache Buchhaltung für Vereine
+ * Copyright (c) by Heiner Jostkleigrewe
+ * Copyright (c) 2015 by Thomas Hooge
+ * Main Project: heiner@jverein.dem  http://www.jverein.de/
+ * Module Author: thomas@hoogi.de, http://www.hoogi.de/
+ *
+ * This file is part of JVerein.
+ *
+ * JVerein is free software: you can redistribute it and/or modify 
+ * it under the terms of the  GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JVerein is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0439 extends AbstractDDLUpdate
+{
+  public Update0439(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    // Diese Migration ist für den Fall, dass die korrigierte Migration
+    // Update0430 nicht ausgefürt wird weil schon mit der alten Version 
+    // migriert wurde z.B. mit einem Nightly Build.
+    // Weil wegen gelöschter Buchungsklassen die Integrität verletzt sein 
+    // muss der Foreign Key mit NOCHECK erzeugt werden
+
+    execute(createForeignKeyIfNotExistsNocheck("fkKonto1", "konto",
+        "buchungsart", "buchungsart", "id", "SET NULL", "NO ACTION"));
+
+  }
+}

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
@@ -43,7 +43,7 @@ public class Update0439 extends AbstractDDLUpdate
     // Update0430 nicht ausgefürt wird weil schon mit der alten Version 
     // migriert wurde z.B. mit einem Nightly Build.
     // Weil wegen gelöschter Buchungsklassen die Integrität verletzt sein 
-    // muss der Foreign Key mit NOCHECK erzeugt werden
+    // könnte, muss der Foreign Key mit NOCHECK erzeugt werden
 
     execute(createForeignKeyIfNotExistsNocheck("fkKonto1", "konto",
         "buchungsart", "buchungsart", "id", "SET NULL", "NO ACTION"));


### PR DESCRIPTION
Diese Migration ist für den Fall, dass die korrigierte Migration Update0430 nicht ausgeführt wird weil schon mit der alten Version  migriert wurde z.B. mit einem Nightly Build.
Weil wegen gelöschter Buchungsklassen die Integrität verletzt sein könnte, muss der Foreign Key mit NOCHECK erzeugt werden.

Der Foreign Key wird nur erzeugt wenn er noch nicht existiert.

Sollte jemand schon bei einem Konto eine Buchungsart gesetzt haben und diese dann gelöscht haben, bleibt die ID bei der Migration in der Kontotabelle erhalten. Dies führt aber zu keinem Fehlverhalten der Software. Beim nächsten setzen eine Buchungsart wird die ID überschrieben.

Die Übergabe muss nach #218 erfolgen wegen der Update Nummer.