### PR TITLE
Fix crash SpendenbescheinigungEmailAction

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
@@ -58,18 +58,19 @@ public class SpendenbescheinigungEmailAction implements Action
     try
     {
       Mitglied member = spb.getMitglied();
-      if (member == null || member.getEmail() == null
-          || member.getEmail().length() == 0)
+      if (member == null)
       {
         String fehler = "Kein Mitglied zugewiesen";
         GUI.getStatusBar().setErrorText(fehler);
         Logger.error(fehler);
+        return;
       }
       if (member.getEmail() == null || member.getEmail().length() == 0)
       {
         String fehler = "Mitglied hat keine E-Mail Adresse";
         GUI.getStatusBar().setErrorText(fehler);
         Logger.error(fehler);
+        return;
       }
       MitgliedMailSendenAction mailSendenAction = new MitgliedMailSendenAction();
       mailSendenAction.handleAction(member);


### PR DESCRIPTION
Beim Spendenbescheinigung Kontextmenü "E-Mail an Spender" kommt es zu einer Exception mit Main Loop Crash wenn der Spendenbescheinigung kein Mitglied zugeordnet ist.
Das liegt daran, dass nach dem ersten Check nicht beendet wird sondern weiter gemacht wird. Dann kommt es anschließend zur Exception weil member null ist.
Mit return im ersten if würde man nie die zweite Ausgabe machen weil diese schon im ersten if mit geprüft wird. Darum habe ich auch das erste if abgeändert.