### PR TITLE
Support von Mailvorlagen für Rechnung, Mahnung, Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedMailSendenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedMailSendenAction.java
@@ -94,7 +94,7 @@ public class MitgliedMailSendenAction implements Action
         }
         MailVorlagenAuswahlDialog mvad = new MailVorlagenAuswahlDialog(
             new MailVorlageControl(null),
-            MailVorlagenAuswahlDialog.POSITION_CENTER);
+            MailVorlagenAuswahlDialog.POSITION_CENTER, true);
         Mail mail = (Mail) Einstellungen.getDBService().createObject(Mail.class,
             null);
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -39,11 +39,15 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
   private MailVorlage retval;
   
   private boolean abort = true;
+  
+  private boolean mailsenden = true;
 
-  public MailVorlagenAuswahlDialog(MailVorlageControl control, int position)
+  public MailVorlagenAuswahlDialog(MailVorlageControl control, int position,
+      boolean mailsenden)
   {
     super(position);
     this.control = control;
+    this.mailsenden = mailsenden;
     setTitle("Mail-Vorlage");
     setSize(550, 450);
   }
@@ -75,16 +79,19 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
       }
     }, null, true, "ok.png");
     
-    b.addButton("Ohne Mail-Vorlage", new Action()
+    if (mailsenden)
     {
-
-      @Override
-      public void handleAction(Object context)
+      b.addButton("Ohne Mail-Vorlage", new Action()
       {
-        abort = false;
-        close();
-      }
-    }, null, true, "go-next.png");
+
+        @Override
+        public void handleAction(Object context)
+        {
+          abort = false;
+          close();
+        }
+      }, null, true, "go-next.png");
+    }
     
     b.addButton("Abbrechen", new Action()
     {

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction.EXPORT_TYP;
+import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl.DIFFERENZ;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -60,6 +61,8 @@ public class MitgliedskontoMahnungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MAHNUNG, false, "question-circle.png");
+    buttons.addButton(new Button("Mail-Vorlage", new MailVorlageZuweisenAction(),
+            control, false, "view-refresh.png"));
     buttons.addButton(new Button("Export", new MitgliedskontoExportAction(
         EXPORT_TYP.MAHNUNGEN, getCurrentObject()), control, false, "document-save.png"));
     buttons.addButton(control.getStartMahnungButton(this.getCurrentObject()));

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
@@ -17,6 +17,7 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction.EXPORT_TYP;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
@@ -60,6 +61,8 @@ public class MitgliedskontoRechnungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.RECHNUNG, false, "question-circle.png");
+    buttons.addButton(new Button("Mail-Vorlage", new MailVorlageZuweisenAction(),
+        control, false, "view-refresh.png"));
     buttons.addButton(new Button("Export",
         new MitgliedskontoExportAction(EXPORT_TYP.RECHNUNGEN,
             getCurrentObject()),

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -17,9 +17,11 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungMailControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TextPart;
 import de.willuhn.jameica.gui.util.SimpleContainer;
@@ -47,6 +49,8 @@ public class SpendenbescheinigungMailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+    buttons.addButton(new Button("Mail-Vorlage", new MailVorlageZuweisenAction(),
+        control, false, "view-refresh.png"));
     buttons.addButton(control.getStartButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }


### PR DESCRIPTION
Mit diesem Feature lassen sich in den Views für Rechnung, Mahnung und Spendenbescheinigung senden, Mail Vorlagen auswählen.
Die Auswahl erfolgt über einen neuen Button "Mail-Vorlage".
![Screenshot_20240522_113928](https://github.com/openjverein/jverein/assets/126261667/299ad1b9-f1fc-4918-93ee-973764080212)

Über einen zusätzlichen Übergabewert wird im MailVorlagenAuswahlDialog der Button "Ohne Mail-Vorlage" ausgeblendet weil er in diesem Zusammenhang keinen Sinn macht.

Dieses Feature wurde in #218 während des Reviews besprochen.
