### PR TITLE
Filter für Spendenbescheinigungen View

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -662,7 +662,7 @@ public class SpendenbescheinigungControl extends FilterControl
     spbList.setRememberColWidths(true);
     spbList.setContextMenu(new SpendenbescheinigungMenu());
     spbList.setRememberOrder(true);
-    spbList.removeFeature(FeatureSummary.class);
+    spbList.addFeature(new FeatureSummary());
     spbList.setMulti(true);
     return spbList;
   }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -694,7 +694,7 @@ public class SpendenbescheinigungControl extends FilterControl
     and = false;
     
     sql = "select spendenbescheinigung.*  from spendenbescheinigung ";
-    sql +=  "join mitglied on (spendenbescheinigung.mitglied = mitglied.id) ";
+    sql +=  "left join mitglied on (spendenbescheinigung.mitglied = mitglied.id) ";
     
     if (isSuchnameAktiv() && getSuchname().getValue() != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -19,6 +19,9 @@ package de.jost_net.JVerein.gui.control;
 import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
 
@@ -34,6 +37,7 @@ import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.MitgliedskontoFormatter;
 import de.jost_net.JVerein.gui.input.FormularInput;
+import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.menu.SpendenbescheinigungMenu;
 import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
 import de.jost_net.JVerein.io.FileViewer;
@@ -47,9 +51,8 @@ import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.Dateiname;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
-import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -68,10 +71,8 @@ import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class SpendenbescheinigungControl extends AbstractControl
+public class SpendenbescheinigungControl extends FilterControl
 {
-
-  private de.willuhn.jameica.system.Settings settings;
 
   private TablePart spbList;
 
@@ -110,6 +111,10 @@ public class SpendenbescheinigungControl extends AbstractControl
   private TablePart buchungsList;
 
   private Spendenbescheinigung spendenbescheinigung;
+  
+  private boolean and = false;
+
+  private String sql = "";
 
   public SpendenbescheinigungControl(AbstractView view)
   {
@@ -634,12 +639,11 @@ public class SpendenbescheinigungControl extends AbstractControl
 
   public Part getSpendenbescheinigungList() throws RemoteException
   {
-    DBService service = Einstellungen.getDBService();
-    DBIterator<Spendenbescheinigung> spendenbescheinigungen = service
-        .createList(Spendenbescheinigung.class);
-    spendenbescheinigungen.setOrder("ORDER BY bescheinigungsdatum desc");
-
-    spbList = new TablePart(spendenbescheinigungen,
+    if (spbList != null)
+    {
+      return spbList;
+    }
+    spbList = new TablePart(getSpendenbescheinigungen(),
         new SpendenbescheinigungAction(Spendenart.SACHSPENDE));
     spbList.addColumn("Bescheinigungsdatum", "bescheinigungsdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
@@ -663,16 +667,112 @@ public class SpendenbescheinigungControl extends AbstractControl
     return spbList;
   }
 
-  public void refreshTable() throws RemoteException
+  public void TabRefresh()
   {
-    spbList.removeAll();
-    DBIterator<Spendenbescheinigung> spendenbescheinigungen = Einstellungen
-        .getDBService().createList(Spendenbescheinigung.class);
-    spendenbescheinigungen.setOrder("ORDER BY bescheinigungsdatum desc");
-    while (spendenbescheinigungen.hasNext())
+    if (spbList != null)
     {
-      spbList.addItem(spendenbescheinigungen.next());
+      try
+      {
+        spbList.removeAll();
+        for (Spendenbescheinigung spb : getSpendenbescheinigungen())
+        {
+          spbList.addItem(spb);
+        }
+      }
+      catch (RemoteException e1)
+      {
+        Logger.error("Fehler", e1);
+      }
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private ArrayList<Spendenbescheinigung> getSpendenbescheinigungen() throws RemoteException
+  {
+    final DBService service = Einstellungen.getDBService();
+    ArrayList<Object> bedingungen = new ArrayList<>();
+    and = false;
+    
+    sql = "select spendenbescheinigung.*  from spendenbescheinigung ";
+    sql +=  "join mitglied on (spendenbescheinigung.mitglied = mitglied.id) ";
+    
+    if (isSuchnameAktiv() && getSuchname().getValue() != null)
+    {
+      String tmpSuchname = (String) getSuchname().getValue();
+      if (tmpSuchname.length() > 0)
+      {
+        addCondition("(lower(zeile2) like ?)");
+        bedingungen.add("%" + tmpSuchname.toLowerCase() + "%");
+      }
+    }
+    if (isMailauswahlAktiv())
+    {
+      int mailauswahl = (Integer) getMailauswahl().getValue();
+      if (mailauswahl == MailAuswertungInput.OHNE)
+      {
+        addCondition("(email is null or length(email) = 0)");
+      }
+      if (mailauswahl == MailAuswertungInput.MIT)
+      {
+        addCondition("(email is  not null and length(email) > 0)");
+      }
+    }
+    if (isDatumvonAktiv() && getDatumvon().getValue() != null)
+    {
+      addCondition("bescheinigungsdatum >= ?");
+      Date d = (Date) getDatumvon().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    if (isDatumbisAktiv() && getDatumbis().getValue() != null)
+    {
+      addCondition("bescheinigungsdatum <= ?");
+      Date d = (Date) getDatumbis().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    if (isEingabedatumvonAktiv() && getEingabedatumvon().getValue() != null)
+    {
+      addCondition("spendedatum >= ?");
+      Date d = (Date) getEingabedatumvon().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    if (isEingabedatumbisAktiv() && getEingabedatumbis().getValue() != null)
+    {
+      addCondition("spendedatum <= ?");
+      Date d = (Date) getEingabedatumbis().getValue();
+      bedingungen.add(new java.sql.Date(d.getTime()));
+    }
+    sql += " ORDER BY bescheinigungsdatum desc ";
+    
+    ResultSetExtractor rs = new ResultSetExtractor()
+    {
+      @Override
+      public Object extract(ResultSet rs) throws RemoteException, SQLException
+      {
+        ArrayList<Spendenbescheinigung> list = new ArrayList<>();
+        while (rs.next())
+        {
+          list.add(
+              (Spendenbescheinigung) service.createObject(Spendenbescheinigung.class, rs.getString(1)));
+        }
+        return list;
+      }
+    };
+
+    return (ArrayList<Spendenbescheinigung>) service.execute(sql, bedingungen.toArray(),
+        rs);
+  }
+  
+  private void addCondition(String condition)
+  {
+    if (and)
+    {
+      sql += " AND ";
+    }
+    else
+    {
+      sql += "where ";
+    }
+    and = true;
+    sql += condition;
+  }
 }

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -52,14 +52,13 @@ public class SpendenbescheinigungListeView extends AbstractView
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addLabelPair("Spendedatum von", control.getEingabedatumvon());
     right.addLabelPair("Spendedatum bis", control.getEingabedatumbis());
-
-
-    control.getSpendenbescheinigungList().paint(this.getParent());
     
     ButtonArea fbuttons = new ButtonArea();
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+
+    control.getSpendenbescheinigungList().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -24,6 +24,9 @@ import de.jost_net.JVerein.keys.Spendenart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class SpendenbescheinigungListeView extends AbstractView
 {
@@ -34,8 +37,29 @@ public class SpendenbescheinigungListeView extends AbstractView
     GUI.getView().setTitle("Spendenbescheinigungen");
 
     SpendenbescheinigungControl control = new SpendenbescheinigungControl(this);
+    
+    LabelGroup group = new LabelGroup(getParent(), "Filter");
+    ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
+
+    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    left.addInput(control.getSuchname());
+    left.addInput(control.getMailauswahl());
+
+    SimpleContainer middle = new SimpleContainer(cl.getComposite());
+    middle.addLabelPair("Bescheinigungsdatum von", control.getDatumvon());
+    middle.addLabelPair("Bescheinigungsdatum bis", control.getDatumbis());
+    
+    SimpleContainer right = new SimpleContainer(cl.getComposite());
+    right.addLabelPair("Spendedatum von", control.getEingabedatumvon());
+    right.addLabelPair("Spendedatum bis", control.getEingabedatumbis());
+
 
     control.getSpendenbescheinigungList().paint(this.getParent());
+    
+    ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getResetButton());
+    fbuttons.addButton(control.getSuchenButton());
+    group.addButtonArea(fbuttons);
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),


### PR DESCRIPTION
Dieses Feature fügt einen Filterbereich im Spendenbescheinigungen View hinzu.
Das ist nützlich um z.B. herauszufinden für welche Spendenbescheinigungen kein Mitglied mit Mailadresse vorhanden ist. Diese Spendenbescheinigungen müssen per Post verschickt werden, die anderen können per Mail verschickt werden.
Der Filter sieht so aus:
![Screenshot_20240603_102810](https://github.com/openjverein/jverein/assets/126261667/adb4e6ed-5f56-42b9-9bb1-cc3e046f5ee3)
