### PR TITLE
Progress Info im ZipMailer

### DIFF
--- a/src/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/de/jost_net/JVerein/io/ZipMailer.java
@@ -80,9 +80,11 @@ public class ZipMailer
           Logger.debug("preparing velocity context");
           monitor.setStatus(ProgressMonitor.STATUS_RUNNING);
           monitor.setPercentComplete(0);
-          // int sentCount = 0;
+          int sentCount = 0;
 
           ZipFile zip = new ZipFile(zipfile);
+          int zae = 0;
+          int size = zip.size();
           for (@SuppressWarnings("rawtypes")
           Enumeration e = zip.entries(); e.hasMoreElements();)
           {
@@ -132,6 +134,7 @@ public class ZipMailer
               {
                 sender.sendMail(mail, wtext1.getBuffer().toString(),
                     wtext2.getBuffer().toString(), anhang);
+                sentCount++;
               }
               catch (SendFailedException e1)
               {
@@ -139,8 +142,18 @@ public class ZipMailer
                 Logger.error("Fehler beim Mailversand: " + e1);
               }
             } // Ende von if
+            zae++;
+            double proz = (double) zae / (double) size * 100d;
+            monitor.setPercentComplete((int) proz);
           } // Ende von for
           zip.close();
+          monitor.setPercentComplete(100);
+          monitor.setStatus(ProgressMonitor.STATUS_DONE);
+          monitor.setStatusText(
+              String.format("Anzahl verschickter Mails: %d", sentCount));
+          GUI.getStatusBar().setSuccessText(
+              "Mail" + (sentCount > 1 ? "s" : "") + " verschickt");
+          GUI.getCurrentView().reload();
         }
         catch (ZipException e)
         {


### PR DESCRIPTION
Mir ist aufgefallen, dass der ZipMailer keine Fortschrittsinformation ausgibt. Ich hatte nicht erkannt wann er fertig ist und darum endlos gewartet.
Ich habe jetzt folgendes eingebaut:
- Der Progressbar wird entsprechend dem  Fortschritt angepasst
- Am Ende gibt es eine Meldung wie viele Mails verschickt wurden. Daran erkennt man, dass er fertig ist.

Ansonsten ist mir noch aufgefallen, dass die verschickten Mails nicht in der Datenbank gespeichert werden. Da hier Mahnungen und Rechnungen verschickt werden für deren Kommunikation eine Aufbewahrungspflicht besteht, denke ich, dass diese Mails gespeichert werden sollten, so wie es auch bei anderen Mails der Fall ist.

Was meint ihr?
Ich könnte das noch mit einbauen.