### PR TITLE
Feature Lastschrift View

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/LastschriftDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/LastschriftDeleteAction.java
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.rmi.Lastschrift;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Loeschen einer Lastschrift.
+ */
+public class LastschriftDeleteAction implements Action
+{
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (context == null
+        || (!(context instanceof Lastschrift) && !(context instanceof Lastschrift[])))
+    {
+      throw new ApplicationException("Keine Lastschrift ausgewählt");
+    }
+    try
+    {
+      Lastschrift[] la = null;
+      if (context instanceof Lastschrift)
+      {
+        la = new Lastschrift[1];
+        la[0] = (Lastschrift) context;
+      }
+      else if (context instanceof Lastschrift[])
+      {
+        la = (Lastschrift[]) context;
+      }
+      if (la == null)
+      {
+        return;
+      }
+      if (la.length == 0)
+      {
+        return;
+      }
+      if (la[0].isNewObject())
+      {
+        return;
+      }
+      YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+      d.setTitle("Lastschrift" + (la.length > 1 ? "en" : "") + " löschen");
+      d.setText("Wollen Sie diese Lastschrift" + (la.length > 1 ? "en" : "")
+          + " wirklich löschen?");
+      try
+      {
+        Boolean choice = (Boolean) d.open();
+        if (!choice.booleanValue())
+        {
+          return;
+        }
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Löschen der Lastschrift", e);
+        return;
+      }
+      int count = 0;
+      for (Lastschrift l : la)
+      {
+        l.delete();
+        count++;
+      }
+      if (count > 0)
+      {
+        GUI.getStatusBar().setSuccessText(String.format(
+            "%d Lastschrift" + (count != 1 ? "en" : "") + " gelöscht.", count));
+      }
+      else
+      {
+        GUI.getStatusBar().setErrorText("Keine Lastschrift gelöscht");
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler beim Löschen der Lastschrift.";
+      GUI.getStatusBar().setErrorText(fehler);
+      Logger.error(fehler, e);
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/action/LastschriftListAction.java
+++ b/src/de/jost_net/JVerein/gui/action/LastschriftListAction.java
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.LastschriftListeView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+
+public class LastschriftListAction implements Action
+{
+  @Override
+  public void handleAction(Object context)
+  {
+    GUI.startView(LastschriftListeView.class.getName(), null);
+  }
+}

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -135,6 +135,7 @@ public class FilterControl extends AbstractControl
 
   protected DateInput abbuchungsdatumbis = null;
 
+  protected TextInput suchtext = null;
   
   public enum Mitgliedstyp {
     MITGLIED,
@@ -845,6 +846,23 @@ public class FilterControl extends AbstractControl
     return abbuchungsdatumbis != null;
   }
   
+  public TextInput getSuchtext()
+  {
+    if (suchtext != null)
+    {
+      return suchtext;
+    }
+    this.suchtext = new TextInput(settings.getString(settingsprefix + "suchtext", ""),
+          50);
+    suchtext.setName("Text");
+    return suchtext;
+  }
+  
+  public boolean isSuchtextAktiv()
+  {
+    return suchtext != null;
+  }
+  
   /**
    * Buttons
    */
@@ -955,6 +973,8 @@ public class FilterControl extends AbstractControl
           abbuchungsdatumvon.setValue(null);
         if (abbuchungsdatumbis != null)
           abbuchungsdatumbis.setValue(null);
+        if (suchtext != null)
+          suchtext.setValue("");
         refresh();
       }
     }, null, false, "eraser.png");
@@ -1311,6 +1331,19 @@ public class FilterControl extends AbstractControl
     if (abbuchungsdatumbis != null)
     {
       saveDate( (Date) abbuchungsdatumbis.getValue(), "abbuchungsdatum.bis");
+    }
+    
+    if (suchtext != null)
+    {
+      String tmp = (String) suchtext.getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute(settingsprefix + "suchtext", tmp);
+      }
+      else
+      {
+        settings.setAttribute(settingsprefix + "suchtext", "");
+      }
     }
     
   }

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -82,6 +82,8 @@ public class FilterControl extends AbstractControl
   protected SelectInput suchadresstyp = null;
 
   protected SelectInput status = null;
+  
+  protected SelectInput art = null;
 
   protected TextInput suchexternemitgliedsnummer = null;
 
@@ -253,6 +255,26 @@ public class FilterControl extends AbstractControl
   public boolean isMitgliedStatusAktiv()
   {
     return status != null;
+  }
+  
+  public Input getMitgliedArt()
+  {
+    if (art != null)
+    {
+      return art;
+    }
+    art = new SelectInput(
+        new String[] { "Mitglied", "Nicht-Mitglied", "Kursteilnehmer" },
+        settings.getString(settingsprefix + "status.art", ""));
+    art.setName("Mitgliedsart");
+    art.setPleaseChoose("Bitte auswählen");
+    art.addListener(new FilterListener());
+    return art;
+  }
+
+  public boolean isMitgliedArtAktiv()
+  {
+    return art != null;
   }
   
   public TextInput getSuchExterneMitgliedsnummer()
@@ -914,6 +936,8 @@ public class FilterControl extends AbstractControl
           suchadresstyp.setValue(null);
         if (status != null)
           status.setValue("Angemeldet");
+        if (art != null)
+          art.setValue(null);
         if (suchexternemitgliedsnummer != null)
           suchexternemitgliedsnummer.setValue("");
         if (eigenschaftenabfrage != null)
@@ -1151,6 +1175,19 @@ public class FilterControl extends AbstractControl
       else
       {
         settings.setAttribute(settingsprefix + "status.mitglied", "");
+      }
+    }
+    
+    if (art != null)
+    {
+      String tmp = (String) art.getValue();
+      if (tmp != null && !tmp.equals("Bitte auswählen"))
+      {
+        settings.setAttribute(settingsprefix + "status.art", tmp);
+      }
+      else
+      {
+        settings.setAttribute(settingsprefix + "status.art", "");
       }
     }
     

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -264,8 +264,21 @@ public class FilterControl extends AbstractControl
       return art;
     }
     art = new SelectInput(
-        new String[] { "Mitglied", "Nicht-Mitglied", "Kursteilnehmer" },
+        new String[] { "Mitglied", "Nicht-Mitglied" },
         settings.getString(settingsprefix + "status.art", ""));
+    try
+    {
+      if (Einstellungen.getEinstellung().getKursteilnehmer())
+      {
+        art = new SelectInput(
+            new String[] { "Mitglied", "Nicht-Mitglied", "Kursteilnehmer" },
+            settings.getString(settingsprefix + "status.art", ""));
+      }
+    }
+    catch (Exception e)
+    {
+      Logger.error("Fehler beim lesen der Einstellungen");
+    }
     art.setName("Mitgliedsart");
     art.setPleaseChoose("Bitte auswählen");
     art.addListener(new FilterListener());

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -1,0 +1,128 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.menu.LastschriftMenu;
+import de.jost_net.JVerein.rmi.Lastschrift;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+import de.willuhn.logging.Logger;
+
+public class LastschriftControl extends FilterControl
+{
+
+
+  private TablePart lastschriftList;
+
+  public LastschriftControl(AbstractView view)
+  {
+    super(view);
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+  }
+ 
+  public Part getLastschriftList() throws RemoteException
+  {
+    if (lastschriftList != null)
+    {
+      return lastschriftList;
+    }
+    lastschriftList = new TablePart(getLastschriften(), null);
+    lastschriftList.addColumn("Name", "name");
+    lastschriftList.addColumn("Vorname", "vorname");
+    lastschriftList.addColumn("Zweck", "verwendungszweck");
+    lastschriftList.addColumn("Betrag", "betrag",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    lastschriftList.addColumn("Fälligkeit", "faelligkeit",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    lastschriftList.addColumn("IBAN", "iban");
+    lastschriftList.addColumn("Mandat", "mandatid");
+    lastschriftList.addColumn("Mandatdatum", "mandatdatum",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    lastschriftList.setRememberColWidths(true);
+    lastschriftList.setContextMenu(new LastschriftMenu());
+    lastschriftList.setRememberOrder(true);
+    lastschriftList.removeFeature(FeatureSummary.class);
+    lastschriftList.setMulti(true);
+    return lastschriftList;
+  }
+
+  public void TabRefresh()
+  {
+    if (lastschriftList == null)
+    {
+      return;
+    }
+    try
+    {
+      lastschriftList.removeAll();
+      DBIterator<Lastschrift> lastschriften = getLastschriften();
+      while (lastschriften.hasNext())
+      {
+        lastschriftList.addItem(lastschriften.next());
+      }
+    }
+    catch (RemoteException e1)
+    {
+      Logger.error("Fehler", e1);
+    }
+  }
+  
+  private  DBIterator<Lastschrift> getLastschriften() throws RemoteException
+  {
+    DBService service = Einstellungen.getDBService();
+    DBIterator<Lastschrift> lastschriften = service
+        .createList(Lastschrift.class);
+    lastschriften.join("abrechnungslauf");
+    lastschriften.addFilter("abrechnungslauf.id = lastschrift.abrechnungslauf");
+    if (isSuchnameAktiv() && getSuchname().getValue() != null)
+    {
+      String tmpSuchname = (String) getSuchname().getValue();
+      if (tmpSuchname.length() > 0)
+      {
+        lastschriften.addFilter("(lower(name) like ?)",
+            new Object[] { tmpSuchname.toLowerCase() + "%"});
+      }
+    }
+    if (isDatumvonAktiv() && getDatumvon().getValue() != null)
+    {
+      lastschriften.addFilter("faelligkeit >= ?",
+          new Object[] { (Date) getDatumvon().getValue() });
+    }
+    if (isDatumbisAktiv() && getDatumbis().getValue() != null)
+    {
+      lastschriften.addFilter("faelligkeit <= ?",
+          new Object[] { (Date) getDatumbis().getValue() });
+    }
+    
+    lastschriften.setOrder("ORDER BY name");
+
+    return lastschriften;
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -67,7 +67,7 @@ public class LastschriftControl extends FilterControl
     lastschriftList.setRememberColWidths(true);
     lastschriftList.setContextMenu(new LastschriftMenu());
     lastschriftList.setRememberOrder(true);
-    lastschriftList.removeFeature(FeatureSummary.class);
+    lastschriftList.addFeature(new FeatureSummary());
     lastschriftList.setMulti(true);
     return lastschriftList;
   }

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -109,6 +109,15 @@ public class LastschriftControl extends FilterControl
             new Object[] { tmpSuchname.toLowerCase() + "%"});
       }
     }
+    if (isSuchtextAktiv() && getSuchtext().getValue() != null)
+    {
+      String tmpSuchtext = (String) getSuchtext().getValue();
+      if (tmpSuchtext.length() > 0)
+      {
+        lastschriften.addFilter("(lower(verwendungszweck) like ?)",
+            new Object[] { "%" + tmpSuchtext.toLowerCase() + "%"});
+      }
+    }
     if (isDatumvonAktiv() && getDatumvon().getValue() != null)
     {
       lastschriften.addFilter("faelligkeit >= ?",

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -100,12 +100,33 @@ public class LastschriftControl extends FilterControl
         .createList(Lastschrift.class);
     lastschriften.join("abrechnungslauf");
     lastschriften.addFilter("abrechnungslauf.id = lastschrift.abrechnungslauf");
+    if (isMitgliedArtAktiv() && getMitgliedArt().getValue() != null)
+    {
+      String tmpArt = (String) getMitgliedArt().getValue();
+      if (tmpArt.equalsIgnoreCase("Kursteilnehmer"))
+      {
+        lastschriften.addFilter("(lastschrift.kursteilnehmer IS NOT NULL)");
+      }
+      else
+      {
+        lastschriften.join("mitglied");
+        lastschriften.addFilter("mitglied.id = lastschrift.mitglied");
+        if (tmpArt.equalsIgnoreCase("Mitglied"))
+        {
+          lastschriften.addFilter("(adresstyp = 1)");
+        }
+        else if (tmpArt.equalsIgnoreCase("Nicht-Mitglied"))
+        {
+          lastschriften.addFilter("(adresstyp > 1)");
+        }
+      }
+    }
     if (isSuchnameAktiv() && getSuchname().getValue() != null)
     {
       String tmpSuchname = (String) getSuchname().getValue();
       if (tmpSuchname.length() > 0)
       {
-        lastschriften.addFilter("(lower(name) like ?)",
+        lastschriften.addFilter("(lower(lastschrift.name) like ?)",
             new Object[] { tmpSuchname.toLowerCase() + "%"});
       }
     }

--- a/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.menu;
+
+import de.jost_net.JVerein.gui.action.LastschriftDeleteAction;
+import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+
+/**
+ * Kontext-Menu zu den Lastschriften
+ */
+public class LastschriftMenu extends ContextMenu
+{
+
+  /**
+   * Erzeugt ein Kontext-Menu fuer die Liste der Lastschriften.
+   */
+  public LastschriftMenu()
+  {
+    addItem(new CheckedContextMenuItem("Löschen...", new LastschriftDeleteAction(),
+        "user-trash-full.png"));
+  }
+}

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -61,6 +61,7 @@ import de.jost_net.JVerein.gui.action.KontenrahmenExportAction;
 import de.jost_net.JVerein.gui.action.KontenrahmenImportAction;
 import de.jost_net.JVerein.gui.action.KontoListAction;
 import de.jost_net.JVerein.gui.action.KursteilnehmerSucheAction;
+import de.jost_net.JVerein.gui.action.LastschriftListAction;
 import de.jost_net.JVerein.gui.action.LehrgaengeListeAction;
 import de.jost_net.JVerein.gui.action.LehrgangsartListeAction;
 import de.jost_net.JVerein.gui.action.LesefelddefinitionenAction;
@@ -166,6 +167,8 @@ public class MyExtension implements Extension
           new AbrechnungSEPAAction(), "calculator.png"));
       abrechnung.addChild(new MyItem(abrechnung, "Abrechnungslauf",
           new AbrechnunslaufListAction(), "calculator.png"));
+      abrechnung.addChild(new MyItem(abrechnung, "Lastschriften",
+          new LastschriftListAction(), "file-invoice.png"));
       jverein.addChild(abrechnung);
 
       NavigationItem auswertung = null;

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -43,6 +43,8 @@ public class DokumentationUtil
   public static final String ABRECHNUNG = PRE + FUNKTIONEN + ABRECH + "abrechnung";
 
   public static final String ABRECHNUNGSLAUF = PRE + FUNKTIONEN + ABRECH + "abrechnungslauf";
+  
+  public static final String LASTSCHRIFT = PRE + FUNKTIONEN + ABRECH + "lastschrift";
 
   public static final String ADRESSTYPEN = PRE + FUNKTIONEN + ADMIN + "adresstypen";
 

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.LastschriftControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
+
+public class LastschriftListeView extends AbstractView
+{
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Lastschriften");
+
+    LastschriftControl control = new LastschriftControl(this);
+    
+    LabelGroup group = new LabelGroup(getParent(), "Filter");
+    ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+
+    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    left.addInput(control.getSuchname());
+
+    SimpleContainer right = new SimpleContainer(cl.getComposite());
+    right.addLabelPair("Fälligkeit von", control.getDatumvon());
+    right.addLabelPair("Fälligkeit bis", control.getDatumbis());
+    
+    ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getResetButton());
+    fbuttons.addButton(control.getSuchenButton());
+    group.addButtonArea(fbuttons);
+    
+    control.getLastschriftList().paint(this.getParent());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.LASTSCHRIFT, false, "question-circle.png");
+    buttons.paint(this.getParent());
+  }
+}

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -41,6 +41,7 @@ public class LastschriftListeView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
     left.addLabelPair("Zweck", control.getSuchtext());
+    left.addInput(control.getMitgliedArt());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addLabelPair("Fälligkeit von", control.getDatumvon());

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -40,6 +40,7 @@ public class LastschriftListeView extends AbstractView
 
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
+    left.addLabelPair("Zweck", control.getSuchtext());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addLabelPair("Fälligkeit von", control.getDatumvon());

--- a/src/de/jost_net/JVerein/server/LastschriftImpl.java
+++ b/src/de/jost_net/JVerein/server/LastschriftImpl.java
@@ -370,7 +370,14 @@ public class LastschriftImpl extends AbstractDBObject implements Lastschrift
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
-    return super.getAttribute(fieldName);
+    if (fieldName.equals("faelligkeit"))
+    {
+      return (Date) getAbrechnungslauf().getFaelligkeit();
+    }
+    else
+    {
+      return super.getAttribute(fieldName);
+    }
   }
 
 }


### PR DESCRIPTION
Beim Bearbeiten der Datenbank habe ich festgestellt, dass es eine Tabelle Lastschrift gibt. Lastschriften Einträge werden während des Abrechnungslaufs generiert. Sie werden bei der Pre-Notification verwendet. 
Ich habe jetzt einen View erzeugt der die gespeicherten Lastschriften anzeigt. Per Kontextmenü kann mann sie auch löschen.
Der Menueintrag ist hier:
![Bildschirmfoto_20240609_125307](https://github.com/openjverein/jverein/assets/126261667/a836e009-913e-4bad-9e8b-2a99a9413874)

Der View schaut dann so aus:
![Bildschirmfoto_20240616_184443](https://github.com/openjverein/jverein/assets/126261667/bb0fd6a2-8eba-4a5c-bea4-e6909f81fb19)


Die FilterControl Erweiterung ist die gleiche wie in #235. Den Eintrag in der Online Help gibt es noch nicht, den würde ich erzeugen wenn das Feature übernommen wird.

Natürlich könnte man den View um weitere Funktionen ergänzen, z.B. die Lastschriften nochmals an Hibiscus übergeben oder ein Sepa XML erzeugen.