### PR TITLE
Doppelklick Action auch im Menu bei Abrechnungslauf

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.AbrechnungslaufAbschliessenAction;
+import de.jost_net.JVerein.gui.action.AbrechnungslaufBuchungenAction;
 import de.jost_net.JVerein.gui.action.AbrechnungslaufDeleteAction;
 import de.jost_net.JVerein.gui.action.AbrechnungslaufDetailAction;
 import de.jost_net.JVerein.gui.action.PreNotificationAction;
@@ -43,6 +44,8 @@ public class AbrechnungslaufMenu extends ContextMenu
   {
     addItem(new ContextMenuItem("Bearbeiten", new AbrechnungslaufDetailAction(),
         "text-x-generic.png"));
+    addItem(new ContextMenuItem("Sollbuchungen", new AbrechnungslaufBuchungenAction(),
+        "calculator.png"));
     addItem(new AbgeschlossenDisabledItem("Pre-Notification",
         new PreNotificationAction(), "document-new.png"));
     addItem(new AbgeschlossenDisabledItem("Löschen...",


### PR DESCRIPTION
Der Menüeintrag "Sollbuchungen" zeigt die generierten Sollbuchungen des Abrechnungslaufs an. Es ist die gleiche Action wie auch bei doppel Klick.
![Bildschirmfoto_20240610_095019](https://github.com/openjverein/jverein/assets/126261667/113341bf-9d15-42b8-901b-6285ca82f5de)

