### PR TITLE
Fix Update 0439

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
@@ -98,6 +98,28 @@ public abstract class AbstractDDLUpdate implements IDDLUpdate
       throw new ApplicationException("Fehler beim Ausführen des Updates", e);
     }
   }
+  
+  public void executeNoCheck(String statement, boolean setVersion)
+      throws ApplicationException
+  {
+    if (statement == null)
+    {
+      throw new ApplicationException("Leeres Statement");
+    }
+    try
+    {
+      Logger.debug(statement);
+      ScriptExecutor.execute(new StringReader(statement), conn, null);
+    }
+    catch (Exception e)
+    {
+      //;
+    }
+    if (setVersion)
+    {
+      setNewVersion(nr);
+    }
+  }
 
   public void setNewVersion(int newVersion) throws ApplicationException
   {
@@ -327,10 +349,10 @@ public abstract class AbstractDDLUpdate implements IDDLUpdate
       }
       case MYSQL:
       {
-        return "ALTER TABLE " + table + " ADD CONSTRAINT IF NOT EXISTS " + " FOREIGN KEY "
+        return "ALTER TABLE " + table + " ADD CONSTRAINT " + " FOREIGN KEY "
             + constraintname + "(" + column + ") REFERENCES " + reftable + " ("
             + refcolumn + ") ON DELETE " + ondelete + " ON UPDATE " + onupdate
-            + " NOCHECK;\n";
+            + ";\n";
       }
     }
     return "";

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0439.java
@@ -45,8 +45,8 @@ public class Update0439 extends AbstractDDLUpdate
     // Weil wegen gelöschter Buchungsklassen die Integrität verletzt sein 
     // könnte, muss der Foreign Key mit NOCHECK erzeugt werden
 
-    execute(createForeignKeyIfNotExistsNocheck("fkKonto1", "konto",
-        "buchungsart", "buchungsart", "id", "SET NULL", "NO ACTION"));
+    executeNoCheck(createForeignKeyIfNotExistsNocheck("fkKonto1", "konto",
+        "buchungsart", "buchungsart", "id", "SET NULL", "NO ACTION"), true);
 
   }
 }


### PR DESCRIPTION
Wie in #223 festgestellt, funktioniert der Code dort nicht mit einer MariaDB.
Da ich bei einer MySQL Datenbank keinen leichten Weg gefunden habe um zu prüfen ob der Foreign Key schon existiert schlage ich eine pragmatische Lösung vor.
Bei MySQL erzeuge ich einfach den Foreign Key auch wenn er schon existiert. In Java fange ich die Exception dann ab und werfe keine Application Exception. Dann läuft die SW einfach weiter ohne Probleme.

Ich habe mir dazu eine MariaDB eingerichtet und damit getestet.