### PR TITLE
Fix Kursteilnehmer Abbuchungsdatum

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -635,7 +635,7 @@ public class AbrechnungSEPA
         zahler.setName(kt.getName());
         zahler.setVerwendungszweck(kt.getVZweck1());
         lastschrift.add(zahler);
-        kt.setAbbudatum();
+        kt.setAbbudatum(param.faelligkeit);
         kt.store();
       }
       catch (Exception e)

--- a/src/de/jost_net/JVerein/rmi/Kursteilnehmer.java
+++ b/src/de/jost_net/JVerein/rmi/Kursteilnehmer.java
@@ -78,7 +78,7 @@ public interface Kursteilnehmer extends DBObject, ILastschrift
 
   public Date getEingabedatum() throws RemoteException;
 
-  public void setAbbudatum() throws RemoteException;
+  public void setAbbudatum(Date abbudatum) throws RemoteException;
 
   public void resetAbbudatum() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/KursteilnehmerImpl.java
+++ b/src/de/jost_net/JVerein/server/KursteilnehmerImpl.java
@@ -421,9 +421,9 @@ public class KursteilnehmerImpl extends AbstractDBObject implements
   }
 
   @Override
-  public void setAbbudatum() throws RemoteException
+  public void setAbbudatum(Date abbudatum) throws RemoteException
   {
-    setAttribute("abbudatum", new Date());
+    setAttribute("abbudatum", abbudatum);
   }
 
   @Override


### PR DESCRIPTION
Bei den Kursteilnehmern wird als Abbuchungsdatum das Datum der Abrechnungslaufes eingetragen. Das ist aber nicht das Abbuchungsdatum der Buchung so wie es auch in der Lastschrift steht.
Ich habe das Datum auf das Datum der Fälligkeit geändert.