### PR TITLE
Fix Target Date in SEPA File

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -680,7 +680,7 @@ public class AbrechnungSEPA
     ls_properties.setProperty("sepaid", epochtime_string);
     ls_properties.setProperty("pmtinfid", epochtime_string);
     ls_properties.setProperty("sequencetype", "RCUR");
-    ls_properties.setProperty("targetdate", param.stichtag != null ? ISO_DATE.format(param.stichtag) : SepaUtil.DATE_UNDEFINED);
+    ls_properties.setProperty("targetdate", param.faelligkeit != null ? ISO_DATE.format(param.faelligkeit) : SepaUtil.DATE_UNDEFINED);
     ls_properties.setProperty("type", "CORE");
     ls_properties.setProperty("batchbook", "");
     int counter = 0;


### PR DESCRIPTION
Im generierten SEPA File für die Lastschriften wird als TargetDate das Attribut Stichtag verwendet. Es sollte aber das Fälligkeitsdatum sein, so wie es auch bei der Übergabe an Hibiscus ist.

Der Fix ändert das TargetDate für die Abbuchung auf das Attribut Fälligkeit.