### PR TITLE
Fix Abrechnung Eintrittsdatum

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -45,7 +45,7 @@ public class AbrechnungSEPAView extends AbstractView
       group.addLabelPair("Abrechnungsmonat", control.getAbrechnungsmonat());
     }
     group.addLabelPair("Stichtag", control.getStichtag());
-    group.addLabelPair("Von Eingabedatum", control.getVondatum());
+    group.addLabelPair("Von Eintrittsdatum", control.getVondatum());
     group.addLabelPair("Bis Austrittsdatum", control.getBisdatum());
     group.addLabelPair("Zahlungsgrund für Beiträge",
         control.getZahlungsgrund());

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -291,7 +291,7 @@ public class AbrechnungSEPA
       // berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
       if (param.vondatum != null)
       {
-        list.addFilter("eingabedatum >= ?",
+        list.addFilter("eintritt >= ?",
             new Object[] { new java.sql.Date(param.vondatum.getTime()) });
       }
       if (Einstellungen.getEinstellung()


### PR DESCRIPTION
Ich bin mir nicht ganz sicher aber ich glaube die bisherige Implementierung für eingetretene Mitglieder im View Abrechnung ist falsch.
Alt, es wird das Eingabedatum des Mitglieds im View abgefragt und auch im Query benutzt. Der Kommentar im Code sagt aber dass auf das Eintrittsdatum geprüft wird, was aber so nicht stimmt.
Kommentar im Code:
// Bei Abbuchungen im Laufe des Jahres werden nur die Mitglieder
// berücksichtigt, die ab einem bestimmten Zeitpunkt eingetreten sind.
![Bildschirmfoto_20240613_153705](https://github.com/openjverein/jverein/assets/126261667/b253e0e6-d887-46ea-be7c-50b8e2514247)

Neu, ich denke es sollte so sein, dass hier das Eintrittsdatum gemeint ist und auch so im Query geprüft werden sollte.
![Bildschirmfoto_20240613_153600](https://github.com/openjverein/jverein/assets/126261667/74d234d8-2897-4cfe-b30a-286a803fde71)

Wenn ihr das auch so seht könnt ihr das ja akzeptieren.
