### PR TITLE
Fix Anzeige Konten Saldo

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/KontensaldoList.java
+++ b/src/de/jost_net/JVerein/gui/parts/KontensaldoList.java
@@ -145,6 +145,7 @@ public class KontensaldoList extends TablePart implements Part
     zeile.add(new SaldoZeile(k, null, null, null, null, jahressaldo));
     
     // Leerzeile am Ende wegen Scrollbar
+    k = (Konto) Einstellungen.getDBService().createObject(Konto.class, null);
     k.setBezeichnung("");
     zeile.add(new SaldoZeile(k, null, null, null, null, null));
     return zeile;


### PR DESCRIPTION
Weil keine neue Zeile generiert wurde wurde der Text "Überschuss/Verlust(-)" der vorhergehenden Zeile gelöscht und nicht angezeigt.