### PR TITLE
Reset Filter für Buchungen View

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -73,6 +73,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.rmi.Projekt;
 import de.jost_net.JVerein.util.Dateiname;
+import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -2004,5 +2005,37 @@ public class BuchungsControl extends AbstractControl
       return 0;
     }
 
+  }
+  
+  public void resetFilter()
+  {
+    try
+    {
+      suchbuchungsart.setValue(suchbuchungsart.getList().get(0));
+      suchprojekt.setValue(null);
+      suchbetrag.setValue("");
+      hasmitglied.setValue(hasmitglied.getList().get(2));
+      Calendar calendar = Calendar.getInstance();
+      Integer year = calendar.get(Calendar.YEAR);
+      Date startGJ = Datum.toDate(Einstellungen.getEinstellung()
+          .getBeginnGeschaeftsjahr() + year);
+      if (calendar.getTime().before(startGJ))
+      {
+        year = year -1;
+        startGJ = Datum.toDate(Einstellungen.getEinstellung()
+            .getBeginnGeschaeftsjahr() + year);
+      }
+      vondatum.setValue(startGJ);
+      calendar.setTime(startGJ);
+      calendar.add(Calendar.YEAR, 1);
+      calendar.add(Calendar.DAY_OF_MONTH, -1);
+      bisdatum.setValue(calendar.getTime());
+      suchtext.setValue("");
+      refreshBuchungsList();
+    }
+    catch (Exception ex)
+    {
+      Logger.error("Error filter reset", ex);
+    }
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -71,6 +71,16 @@ public class BuchungslisteView extends AbstractView
     right.addLabelPair("Enthaltener Text", control.getSuchtext());
     
     ButtonArea buttons1 = new ButtonArea();
+    Button reset = new Button("Filter-Reset", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        control.resetFilter();
+      }
+    }, null, false, "eraser.png");
+    buttons1.addButton(reset);
+    
     Button suchen = new Button("Suchen", new Action()
     {
       @Override


### PR DESCRIPTION
Dieses Feature fügt den "Filter-Reset" Button beim Buchungen Liste View hinzu.
Zusammen mit den anderen noch anstehenden Pull Requests erhält man dann ein einheitliches Erscheinungsbild aller Filter.
![Bildschirmfoto_20240627_135044](https://github.com/openjverein/jverein/assets/126261667/dc53997c-ff97-461b-a040-8d256adf6e21)


PS: Den Datumsbereich lösche ich nicht sondern setze ihn auf das Start- und Endedatum des aktuellen Geschäftsjahres.