### PR TITLE
Gesamtsumme in Sollbuchungen View

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -39,6 +39,7 @@ import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
+import de.jost_net.JVerein.gui.parts.SollbuchungListTablePart;
 import de.jost_net.JVerein.io.Kontoauszug;
 import de.jost_net.JVerein.io.Mahnungsausgabe;
 import de.jost_net.JVerein.io.Rechnungsausgabe;
@@ -680,7 +681,7 @@ public class MitgliedskontoControl extends AbstractControl
     settings.setAttribute(datumverwendung + "differenz", getDifferenz().getValue().toString());
     if (mitgliedskontoList == null)
     {
-      mitgliedskontoList = new TablePart(mitgliedskonten, action);
+      mitgliedskontoList = new SollbuchungListTablePart(mitgliedskonten, action);
       mitgliedskontoList.addColumn("Datum", "datum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       mitgliedskontoList.addColumn("Abrechnungslauf", "abrechnungslauf");

--- a/src/de/jost_net/JVerein/gui/parts/SollbuchungListTablePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/SollbuchungListTablePart.java
@@ -21,26 +21,28 @@ import java.rmi.RemoteException;
 import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.willuhn.datasource.GenericIterator;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.Feature;
-import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 import de.willuhn.jameica.gui.parts.table.Feature.Context;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 
-public class BuchungListTablePart extends TablePart
+public class SollbuchungListTablePart extends TablePart
 {
 
-  public BuchungListTablePart(Action action)
+  public SollbuchungListTablePart(Action action)
   {
     super(action);
   }
 
-  public BuchungListTablePart(List<Buchung> list, Action action)
+  @SuppressWarnings("rawtypes")
+  public SollbuchungListTablePart(GenericIterator mitgliedskonten, Action action)
   {
-    super(list, action);
+    super(mitgliedskonten, action);
   }
-  
+
   /**
    * Belegt den Context mit dem anzuzeigenden Text.
    * Ersetzt getSummary() welches deprecated ist.
@@ -61,7 +63,7 @@ public class BuchungListTablePart extends TablePart
         summary = new String(l.size() + " Datensätze");
         for (int i = 0; i < l.size(); i++)
         {
-          Buchung b = (Buchung) l.get(i);
+          Mitgliedskonto b = (Mitgliedskonto) l.get(i);
           sumBetrag += b.getBetrag();
         }
         summary += " / " + "Gesamtbetrag:" + " "


### PR DESCRIPTION
Mit diesem Feature wird auch im View der Sollbuchungen im Tabellen Summary der Gesamtbetrag über die Einträge angezeigt so wie beim Buchungen View.
Ich habe dabei nicht das deprecated getSummary() verwendet sondern die empfohlene Lösung. Dazu habe ich dann auch für den Buchungen View das deprecated getSummary() analog ersetzt.