### PR TITLE
Feature adressfenster manuell

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -232,8 +232,23 @@ public class SpendenbescheinigungPrintAction implements Action
               .createObject(Formular.class, spb.getFormular().getID());
           Map<String, Object> map = spb.getMap(null);
           map = new AllgemeineMap().getMap(map);
+          String email = null;
+          if (spb.getMitglied() != null)
+          {
+              email = spb.getMitglied().getEmail();
+          }
           FormularAufbereitung fa = new FormularAufbereitung(file);
           fa.writeForm(fo, map);
+          // Brieffenster drucken bei Spendenbescheinigung
+          if ( (mailversand == false && Einstellungen.getEinstellung().getSpendenbescheinigungadresse())
+              || (mailversand == true && Einstellungen.getEinstellung().getSpendenbescheinigungadresse() 
+                  && (email == null || email.isEmpty()))
+              || (mailversand == true && Einstellungen.getEinstellung().getSpendenbescheinigungadressem() 
+                   && email != null && !email.isEmpty()))
+          {
+            fa.printAdressfenster(getAussteller(), 
+                (String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()));
+          }
           fa.closeFormular();
         }
       }

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -43,9 +43,9 @@ public class SpendenbescheinigungMenu extends ContextMenu
         new SpendenbescheinigungPrintAction(true, false), "file-pdf.png"));
     addItem(new CheckedContextMenuItem("Drucken (Standard, Mailversand)",
         new SpendenbescheinigungPrintAction(true, true), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("Drucken (individuell, Briefversand)",
+    addItem(new CheckedContextMenuItem("Drucken (Individuell, Briefversand)",
         new SpendenbescheinigungPrintAction(false, false), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("Drucken (individuell, Mailversand)",
+    addItem(new CheckedContextMenuItem("Drucken (Individuell, Mailversand)",
         new SpendenbescheinigungPrintAction(false, true), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -43,8 +43,10 @@ public class SpendenbescheinigungMenu extends ContextMenu
         new SpendenbescheinigungPrintAction(true, false), "file-pdf.png"));
     addItem(new CheckedContextMenuItem("Drucken (Standard, Mailversand)",
         new SpendenbescheinigungPrintAction(true, true), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("Drucken (individuell)",
+    addItem(new CheckedContextMenuItem("Drucken (individuell, Briefversand)",
         new SpendenbescheinigungPrintAction(false, false), "file-pdf.png"));
+    addItem(new CheckedContextMenuItem("Drucken (individuell, Mailversand)",
+        new SpendenbescheinigungPrintAction(false, true), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -36,6 +36,7 @@ import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Paragraph;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfImportedPage;
@@ -507,4 +508,27 @@ public class FormularAufbereitung
     }
     return stringVal.toString();
   }
+  
+  public void printAdressfenster(String aussteller, String empfaenger)
+      throws RemoteException
+  {
+    // Neue Seite mit Anschrift für Fenster in querem Brief
+    try
+    {
+      doc.newPage();
+      doc.add(new Paragraph(" ", Reporter.getFreeSans(12)));
+      doc.add(new Paragraph("\n\n\n\n\n\n", Reporter.getFreeSans(12)));
+      Paragraph paragraph = new Paragraph(aussteller, Reporter.getFreeSansUnderline(8));
+      paragraph.setIndentationLeft(40);
+      doc.add(paragraph);
+      paragraph = new Paragraph(empfaenger, Reporter.getFreeSans(9));
+      paragraph.setIndentationLeft(40);
+      doc.add(paragraph);
+    }
+    catch (DocumentException e)
+    {
+      throw new RemoteException("Fehler", e);
+    }
+  }
+  
 }


### PR DESCRIPTION
Mit diesem Feature wird jetzt das Drucken des Adressfensters bei Spendenbescheinigungen auch für individuelles drucken unterstützt.
![Bildschirmfoto_20240703_134011](https://github.com/openjverein/jverein/assets/126261667/806ff2cf-938e-416c-b81c-e1042fb2cb77)
