### PR TITLE
Sollbuchungen Menu Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoSollbuchungEditAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoSollbuchungEditAction.java
@@ -49,6 +49,10 @@ public class MitgliedskontoSollbuchungEditAction implements Action
             "Fehler beim Editieren einer Sollbuchung");
       }
     }
+    else if (context != null && (context instanceof Mitgliedskonto))
+    {
+      mk = (Mitgliedskonto) context;
+    }
     else
     {
       try

--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoSollbuchungLoeschenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoSollbuchungLoeschenAction.java
@@ -36,7 +36,8 @@ public class MitgliedskontoSollbuchungLoeschenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context == null || !((context instanceof MitgliedskontoNode)
+        || context instanceof Mitgliedskonto))
     {
       throw new ApplicationException("Keine Sollbuchung ausgewählt");
     }
@@ -60,25 +61,28 @@ public class MitgliedskontoSollbuchungLoeschenAction implements Action
     }
     MitgliedskontoNode mkn = null;
     Mitgliedskonto mk = null;
-
-    if (context != null && (context instanceof MitgliedskontoNode))
+    try
     {
-      mkn = (MitgliedskontoNode) context;
-      try
+      if (context instanceof MitgliedskontoNode)
       {
+        mkn = (MitgliedskontoNode) context;
         mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
             Mitgliedskonto.class, mkn.getID());
-        Mitglied mitglied = mk.getMitglied();
-        mk.delete();
-        GUI.getStatusBar().setSuccessText("Sollbuchung gelöscht.");
-        Application.getMessagingFactory().sendMessage(
-            new MitgliedskontoMessage(mitglied));
       }
-      catch (RemoteException e)
+      else
       {
-        throw new ApplicationException(
-            "Fehler beim Löschen einer Sollbuchung");
+        mk = (Mitgliedskonto) context;
       }
+      Mitglied mitglied = mk.getMitglied();
+      mk.delete();
+      GUI.getStatusBar().setSuccessText("Sollbuchung gelöscht.");
+      Application.getMessagingFactory().sendMessage(
+          new MitgliedskontoMessage(mitglied));
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException(
+          "Fehler beim Löschen einer Sollbuchung");
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/Mitgliedskonto2Menu.java
+++ b/src/de/jost_net/JVerein/gui/menu/Mitgliedskonto2Menu.java
@@ -52,7 +52,7 @@ public class Mitgliedskonto2Menu extends ContextMenu
     addItem(new CheckedSingleContextMenuItem("Sollbuchung bearbeiten",
         new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
-        new MitgliedskontoSollbuchungLoeschenAction(), "list-remove.png"));
+        new MitgliedskontoSollbuchungLoeschenAction(), "user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedContextMenuItem("Rechnung...",
         new MitgliedskontoRechnungAction(), "file-invoice.png"));

--- a/src/de/jost_net/JVerein/gui/menu/Mitgliedskonto2Menu.java
+++ b/src/de/jost_net/JVerein/gui/menu/Mitgliedskonto2Menu.java
@@ -17,10 +17,23 @@
 
 package de.jost_net.JVerein.gui.menu;
 
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoMahnungAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoRechnungAction;
+import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungEditAction;
+import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungLoeschenAction;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
+import de.willuhn.jameica.gui.parts.ContextMenuItem;
+import de.willuhn.logging.Logger;
 
 /**
  * Kontext-Menu zu den Mitgliedskonten.
@@ -33,9 +46,51 @@ public class Mitgliedskonto2Menu extends ContextMenu
    */
   public Mitgliedskonto2Menu()
   {
+    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
+        new MitgliedDetailAction(), "text-x-generic.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedSingleContextMenuItem("Sollbuchung bearbeiten",
+        new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));
+    addItem(new SollOhneIstItem("Sollbuchung löschen",
+        new MitgliedskontoSollbuchungLoeschenAction(), "list-remove.png"));
+    addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedContextMenuItem("Rechnung...",
         new MitgliedskontoRechnungAction(), "file-invoice.png"));
     addItem(new CheckedContextMenuItem("Mahnung...",
         new MitgliedskontoMahnungAction(), "file-invoice.png"));
+  }
+
+  private static class SollOhneIstItem extends CheckedContextMenuItem
+  {
+
+    private SollOhneIstItem(String text, Action action, String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      if (o instanceof Mitgliedskonto)
+      {
+        Mitgliedskonto mk = (Mitgliedskonto) o;
+        DBIterator<Buchung> it;
+        try
+        {
+          it = Einstellungen.getDBService().createList(Buchung.class);
+          it.addFilter("mitgliedskonto = ?", new Object[] { mk.getID() });
+          if (it.size() == 0)
+          {
+            return true;
+          }
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+        return false;
+      }
+      return false;
+    }
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -51,7 +51,7 @@ public class MitgliedskontoMenu extends ContextMenu
     addItem(new SollItem("Sollbuchung bearbeiten",
         new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
-        new MitgliedskontoSollbuchungLoeschenAction(), "list-remove.png"));
+        new MitgliedskontoSollbuchungLoeschenAction(), "user-trash-full.png"));
     addItem(new SollMitIstItem("Istbuchung von Sollbuchung lösen",
         new MitgliedskontoIstbuchungLoesenAction(), "unlocked.png"));
     addItem(ContextMenuItem.SEPARATOR);


### PR DESCRIPTION
Im Sollbuchungen View habe ich das Context Menu erweitert. Bei einem doppel Klick auf eine Sollbuchung hätte ich erwartet, dass man die Sollbuchung editieren kann. Statt dessen wird aber das Mitglied geöffnet.
Ich habe jetzt die doppel Klick Action auch auf das Context Menü gelegt und zusätzlich die Möglichkeit die Sollbuchung zu editieren oder zu löschen. Man muss dann nicht immer erst in das Mitgliedkonto des Mitglieds gehen.
Der Check für Löschen ist wie im Mitgliedskonto des Mitglieds.

Menü alt:
![Bildschirmfoto_20240703_153042](https://github.com/openjverein/jverein/assets/126261667/f47eae99-9166-4f3b-89c7-27517e6fdc8e)

Menü neu:
![Bildschirmfoto_20240703_153549](https://github.com/openjverein/jverein/assets/126261667/09b8a10e-ebb0-4049-adc8-b872c23f4dbd)

PS: Das Löschen Icon habe ich auch im Context Menü im Mitgliedskonto geändert damit die Menüs gleich aussehen.
![Bildschirmfoto_20240703_154122](https://github.com/openjverein/jverein/assets/126261667/67e96b11-bb5b-4e60-ae54-5a2f9816b997)



