### PR TITLE
Fix Familienzahler

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -94,7 +94,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     }
     catch (RemoteException e)
     {
-      String fehler = "Mitglied kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Mitglied kann nicht gelöscht werden. Siehe system log";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }


### PR DESCRIPTION
Bei der Implementierung der Funktion für Familienbeitrag gab es einige Fehler.
- Ändert man die Beitragsgruppe eines Familienzahlers wurde nicht geprüft ob dieser aktuell für andere zahlt.
- Löscht man einen Familienzahler wurde nicht geprüft ob er für andere zahlt. In diesem Fall zeigen bei denen die Zahler IDs auf ein nicht existierendes Mitglied. Beim Öffnen des Mitgliedsdialogs kommt es dann zu einem Fehler der Anzeige.

Ich habe jetzt den Plausi Check von MitgliedImpl geändert. Falls die Beitragsart nicht FAMILIE_ZAHLER ist wird jetzt neu geprüft ob das Mitglied gerade für andere zahlt. Die Beitragsart könnte ja gerade geändert worden sein.

Beim deleteCheck() prüfe ich auch ob das Mitglied noch für andere zahlt. In diesem Fall kann man nicht löschen.