### PR TITLE
Möglicher Fehler bei Familienzahler

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -214,7 +214,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       throw new ApplicationException(
           "Bei verstorbenem Mitglied muss das Austrittsdatum gefüllt sein!");
     }
-    if (getAustritt() != null || getKuendigung() != null)
+    if (getAustritt() != null)
     {
       // Person ist ausgetreten
       // Hat das Mitglied für andere gezahlt?


### PR DESCRIPTION
Ich bin mir nicht sicher ob hier ein Fehler oder Unschönheit vorliegt und bitte um euere Meinung.

Beim Speichern eines Mitglieds wird bei Austritt und Kündigung geprüft ob bei Beitragsart FAMILIE_ZAHLER noch Familienmitglieder existieren die noch nicht ausgetreten sind. Es wird aber nicht geprüft ob Familienmitglieder gekündigt haben.

Das ist inkonsistent. Man kann Austritt nur setzen wenn alle Familienmitglieder auch ausgetreten sind und man kann Kündigung nur setzten wenn alle Familienmitglieder ausgetreten sind. Kündigung der Familienmitglieder reicht nicht.

Allgemein scheint es so zu sein, dass Kuendigung keine Auswirkung auf den Austritt hat. Gekündigte Mitglieder tauchen im Mitglieder View weiter unter dem Filter Angemeldet auf. Auch werden im Abrechnungslauf weiter die Mitgliedsbeiträge eingezogen.

Mit meiner Änderung ergibt sich jetzt folgendes:
- Man kann Austritt nur setzen wenn alle Familienmitglieder auch ausgetreten sind.
- Kündigung kann man unabhängig von den Familienmitgliedern setzen (sie bleiben ja auch weiterhin im Familienbeitrag View angezeigt)

Eine ander Lösung wäre gewesen einen eigenen Check für Kündigung zu erstellen und Kündigung nur erlauben wenn alle Familienmitglieder auch gekündigt haben. Das würde aber bezüglich des Abrechnungslaufes nichts ändern und wäre eine künstliche Einschränkung. 

