### PR TITLE
Feature Familienmitglieder View Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
+++ b/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
@@ -65,7 +65,7 @@ public class FamilienbeitragNode implements GenericObjectNode
       DBIterator<Mitglied> it2 = Einstellungen.getDBService()
           .createList(Mitglied.class);
       it2.addFilter("beitragsgruppe = ?", new Object[] { bg.getID() });
-      it2.addFilter("austritt is null");
+      //it2.addFilter("austritt is null");
       it2.setOrder("ORDER BY name, vorname");
       while (it2.hasNext())
       {
@@ -87,7 +87,7 @@ public class FamilienbeitragNode implements GenericObjectNode
     DBIterator<Mitglied> it = Einstellungen.getDBService()
         .createList(Mitglied.class);
     it.addFilter("zahlerid = ?", new Object[] { m.getID() });
-    it.addFilter("austritt is null");
+    //it.addFilter("austritt is null");
     while (it.hasNext())
     {
       FamilienbeitragNode fbn = new FamilienbeitragNode(this, it.next(), 1);

--- a/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
+++ b/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
@@ -30,6 +30,7 @@ import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.GenericObjectNode;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.logging.Logger;
 
 public class FamilienbeitragNode implements GenericObjectNode
@@ -49,9 +50,12 @@ public class FamilienbeitragNode implements GenericObjectNode
   private FamilienbeitragNode parent = null;
 
   private ArrayList<FamilienbeitragNode> children;
+  
+  private Input status;
 
-  public FamilienbeitragNode() throws RemoteException
+  public FamilienbeitragNode(Input status) throws RemoteException
   {
+    this.status = status;
     this.parent = null;
     this.type = ROOT;
     this.children = new ArrayList<>();
@@ -65,7 +69,10 @@ public class FamilienbeitragNode implements GenericObjectNode
       DBIterator<Mitglied> it2 = Einstellungen.getDBService()
           .createList(Mitglied.class);
       it2.addFilter("beitragsgruppe = ?", new Object[] { bg.getID() });
-      //it2.addFilter("austritt is null");
+      if (status.getValue().equals("Angemeldet"))
+        it2.addFilter("austritt is null");
+      if (status.getValue().equals("Abgemeldet"))
+        it2.addFilter("austritt is not null");
       it2.setOrder("ORDER BY name, vorname");
       while (it2.hasNext())
       {
@@ -79,6 +86,7 @@ public class FamilienbeitragNode implements GenericObjectNode
   public FamilienbeitragNode(FamilienbeitragNode parent, Mitglied m)
       throws RemoteException
   {
+    this.status = parent.status;
     this.parent = parent;
     this.mitglied = m;
     this.id = mitglied.getID();
@@ -87,7 +95,10 @@ public class FamilienbeitragNode implements GenericObjectNode
     DBIterator<Mitglied> it = Einstellungen.getDBService()
         .createList(Mitglied.class);
     it.addFilter("zahlerid = ?", new Object[] { m.getID() });
-    //it.addFilter("austritt is null");
+    if (status.getValue().equals("Angemeldet"))
+      it.addFilter("austritt is null");
+    if (status.getValue().equals("Abgemeldet"))
+      it.addFilter("austritt is not null");
     while (it.hasNext())
     {
       FamilienbeitragNode fbn = new FamilienbeitragNode(this, it.next(), 1);

--- a/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
+++ b/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
@@ -159,10 +160,15 @@ public class FamilienbeitragNode implements GenericObjectNode
       {
         return "Familienbeiträge";
       }
+      Date d = getMitglied().getGeburtsdatum();
+      if (d.equals(Einstellungen.NODATE))
+      {
+        d = null;
+      }
       JVDateFormatTTMMJJJJ jvttmmjjjj = new JVDateFormatTTMMJJJJ();
       return Adressaufbereitung.getNameVorname(mitglied)
-          + (mitglied.getGeburtsdatum() != null
-              ? ", " + jvttmmjjjj.format(mitglied.getGeburtsdatum())
+          + (d != null
+              ? ", " + jvttmmjjjj.format(d)
               : "")
           + (mitglied.getIban().length() > 0
               ? ", " + mitglied.getBic() + ", " + mitglied.getIban()

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -129,6 +129,7 @@ import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SWTUtil;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.system.Application;
@@ -2486,6 +2487,35 @@ public class MitgliedControl extends FilterControl
     familienbeitragtree.setRememberOrder(true);
     this.fbc = new FamilienbeitragMessageConsumer();
     Application.getMessagingFactory().registerMessageConsumer(this.fbc);
+    familienbeitragtree.setFormatter(new TreeFormatter()
+    {
+      @Override
+      public void format(TreeItem item)
+      {
+        FamilienbeitragNode fbn = (FamilienbeitragNode) item.getData();
+        try
+        {
+         if (fbn.getType() == FamilienbeitragNode.ROOT)
+           item.setImage(SWTUtil.getImage("file-invoice.png"));
+         if (fbn.getType() == FamilienbeitragNode.ZAHLER
+             && fbn.getMitglied().getAustritt() == null)
+           item.setImage(SWTUtil.getImage("user-friends.png"));
+         if (fbn.getType() == FamilienbeitragNode.ZAHLER
+             && fbn.getMitglied().getAustritt() != null)
+           item.setImage(SWTUtil.getImage("eraser.png"));
+         if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
+             && fbn.getMitglied().getAustritt() == null)
+           item.setImage(SWTUtil.getImage("user.png"));
+         if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
+             && fbn.getMitglied().getAustritt() != null)
+           item.setImage(SWTUtil.getImage("eraser.png"));
+        }
+        catch (Exception e)
+        {
+          Logger.error("Fehler beim TreeFormatter", e);
+        }
+      }
+    });
     return familienbeitragtree;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2479,7 +2479,7 @@ public class MitgliedControl extends FilterControl
 
   public TreePart getFamilienbeitraegeTree() throws RemoteException
   {
-    familienbeitragtree = new TreePart(new FamilienbeitragNode(),
+    familienbeitragtree = new TreePart(new FamilienbeitragNode(getMitgliedStatus()),
         new MitgliedDetailAction());
     familienbeitragtree.addColumn("Name", "name");
     familienbeitragtree.setContextMenu(new FamilienbeitragMenu());
@@ -2496,7 +2496,7 @@ public class MitgliedControl extends FilterControl
         try
         {
          if (fbn.getType() == FamilienbeitragNode.ROOT)
-           item.setImage(SWTUtil.getImage("file-invoice.png"));
+           item.setImage(SWTUtil.getImage("users.png"));
          if (fbn.getType() == FamilienbeitragNode.ZAHLER
              && fbn.getMitglied().getAustritt() == null)
            item.setImage(SWTUtil.getImage("user-friends.png"));
@@ -2834,7 +2834,7 @@ public class MitgliedControl extends FilterControl
                   FamilienbeitragMessageConsumer.this);
               return;
             }
-            familienbeitragtree.setRootObject(new FamilienbeitragNode());
+            familienbeitragtree.setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
           }
           catch (Exception e)
           {
@@ -2905,6 +2905,19 @@ public class MitgliedControl extends FilterControl
         {
           refreshMitgliedTable(0);
         }
+      }
+      catch (RemoteException e1)
+      {
+        Logger.error("Fehler", e1);
+      }
+    }
+    
+    if (familienbeitragtree != null)
+    {
+      try
+      {
+        familienbeitragtree.removeAll();
+        familienbeitragtree.setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
       }
       catch (RemoteException e1)
       {

--- a/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
+++ b/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
 
 public class FamilienbeitragView extends AbstractView
 {
@@ -31,6 +32,10 @@ public class FamilienbeitragView extends AbstractView
     GUI.getView().setTitle("Familienbeitrag");
 
     final MitgliedControl control = new MitgliedControl(this);
+    control.init("familie.", null, null);
+    
+    LabelGroup group = new LabelGroup(getParent(), "Filter");
+    group.addInput(control.getMitgliedStatus());
 
     control.getFamilienbeitraegeTree().paint(this.getParent());
 


### PR DESCRIPTION
Mit diesem Feature erweitere ich den Familienbeitrag View.
- Schönere passendere Icons
- Filter für Mitgliedstatus

Mit dem Feature kann man sich jetzt auch die Familien Einträge von ausgetretenen Mitgliedern anschauen. Das ist nützlich wenn man z.B. den Familienzahler löschen will. Das geht erst wenn alle Familienmitglieder gelöscht sind. Mit der Anzeige hier kann man leicht sehen welche Familienmitglieder da sind und leicht zu ihnen wechseln um sie zu löschen.
Natürlich könnte man das auch im jeweiligen Mitglied View unter dem Tab Familienverband sehen, aber dann nicht so leicht die Familienmitglieder löschen.

Ich habe auch noch einen Bug behoben. Wenn kein Geburtsdatum beim Mitglied gesetzt war hat der View das Datum 01.01.1900 an den Namen anghängt. Jetzt zeigt er keines an wenn kein Geburtsdatum konfiguriert ist.

Der Radiergummi kennzeichnet abgemeldete Mitglieder.

![Bildschirmfoto_20240704_181828](https://github.com/openjverein/jverein/assets/126261667/1b236708-6f2a-4dc4-9732-ff6e6f9136ec)


