### PR TITLE
Fix Buchungskorrektur

### DIFF
--- a/src/com/schlevoigt/JVerein/Queries/BuchungsKorrekturQuery.java
+++ b/src/com/schlevoigt/JVerein/Queries/BuchungsKorrekturQuery.java
@@ -17,10 +17,12 @@
 package com.schlevoigt.JVerein.Queries;
 
 import java.rmi.RemoteException;
+import java.util.Date;
 import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -36,10 +38,24 @@ public class BuchungsKorrekturQuery {
 	public List<Buchung> get() throws RemoteException {
 		final DBService service = Einstellungen.getDBService();
 
-		DBIterator<Buchung> it = service.createList(Buchung.class);
+		DBIterator<Jahresabschluss> it1 = service.createList(Jahresabschluss.class);
+		it1.setOrder("ORDER BY bis DESC");
+		Date bis =  ((Jahresabschluss) it1.next()).getBis();
 		
-		String text1 = "%SVWZ%";
-		it.addFilter("upper(zweck) like ?", text1);
+		DBIterator<Buchung> it = service.createList(Buchung.class);
+		it.addFilter("datum > ?", new java.sql.Date(bis.getTime()));
+		Object[] keys = { "%EREF%", "%KREF%", "%MREF%", "%CRED%",
+		    "%DBET%", "%SVWZ%", "%ABWA%","%IBAN+%","%IBAN:%", "%BIC%"};
+		it.addFilter("(upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ? or "
+		            + "upper(zweck) like ?)", keys);
 		
 		it.setOrder("ORDER BY datum");
 

--- a/src/com/schlevoigt/JVerein/util/Misc.java
+++ b/src/com/schlevoigt/JVerein/util/Misc.java
@@ -1,89 +1,97 @@
 package com.schlevoigt.JVerein.util;
 
-import java.util.ArrayList;
+import java.rmi.RemoteException;
+
+import org.apache.commons.lang.StringUtils;
+
+import de.willuhn.jameica.hbci.rmi.Transfer;
+import de.willuhn.jameica.hbci.server.VerwendungszweckUtil;
+import de.willuhn.jameica.hbci.server.VerwendungszweckUtil.Tag;
 
 public class Misc {
 	
 	public static String getBuchungsZweckKorrektur(String value, boolean withRealLineBreak) {
-		String result = "";
-		if (value == null)
-		{
-		return result;
-		}
-		if (value.length() < 5) 
-		{
-			return value.replace("SVWZ+", "");
-		}
-		value = value.replaceAll("\r\n", "|");
-		value = value.replaceAll("\r", "|");
-		value = value.replaceAll("\n", "|");
-
-		String[] zeilen = value.split("\\|");
-		ArrayList<String> zeilenNeu = new ArrayList<String>();
-
-		String currentKey = "";
-		String currentLine = "";
-
-		for (int i = 0; i < zeilen.length; i++) {
-			String zeile = zeilen[i];
-			if (zeile.length() > 4 && zeile.substring(4, 5).equals("+")) {
-				if (currentLine.trim().length() > 0) {
-					if (currentKey.trim().isEmpty()) {
-						zeilenNeu.add(currentLine);
-					} else {
-						zeilenNeu.add(currentKey + "+" + currentLine);
-					}
-				}
-				currentKey = zeile.substring(0, 4);
-				currentLine = zeile.substring(5);
-			} else {
-				currentLine = currentLine + zeile;
-			}
-			if (currentKey.equals("SVWZ")) {
-				zeilenNeu.add(currentKey + "+" + currentLine);
-				currentLine = "";
-			}
-		}
-		if (!currentLine.trim().isEmpty()) {
-			if (currentKey.trim().isEmpty()) {
-				zeilenNeu.add(currentLine);
-			} else {
-				zeilenNeu.add(currentKey + "+" + currentLine);
-			}
-		}
-
-		String lineBreakAfter = null;
-		String lineBreakBefore = null;
-		for (int i = 0; i < zeilenNeu.size(); i++) {
-			String zeile = zeilenNeu.get(i);
-			if (zeile.startsWith("KREF+") || zeile.startsWith("EREF+") || zeile.startsWith("MREF+") || zeile.startsWith("CRED+")
-					|| zeile.startsWith("PURP+OTHR") || zeile.startsWith("SVWZ+Datum:") || zeile.startsWith("SVWZ+BIC:") || zeile.startsWith("SVWZ+BLZ:")
-					|| zeile.startsWith("SVWZ+IBAN:") || (zeile.contains("UFT ") && zeile.contains("TAN "))
-					|| (zeile.contains("KD ") && zeile.contains("TAN "))) {
-				continue;
-			}
-			if ((i == zeilenNeu.size() - 1) || (zeile.startsWith("SVWZ+"))) {
-				lineBreakAfter = "";
-			} else {
-				lineBreakAfter = "|";
-			}
-			zeile = zeile.replaceAll("PURP\\+RINP ", "").replaceAll("PURP\\+ELEC ", "").replaceAll("SVWZ\\+", "");
-			if (zeile.startsWith("Dauerauftrag:")) {
-				lineBreakBefore = "|";
-			} else {
-				lineBreakBefore = "";
-			}
-			result = result + lineBreakBefore + zeile + lineBreakAfter;
-		}
-
-		if (result.endsWith("|")) {
-			result = result.substring(1, result.length() - 1);
-		}
-		if (withRealLineBreak) {
-			result = result.replaceAll("\\|", "\r\n");
-		}
-
-		return result;
+	  if (value == null) {
+	    return null;
+	  }
+	  try
+	  {
+	    Transfer t = new Verwendungszweck(value);
+	    String s = StringUtils.trimToNull(VerwendungszweckUtil.getTag(t, Tag.SVWZ));
+	    if (!withRealLineBreak)
+	    {
+	      s = s.replaceAll("\r\n", "|");
+        s = s.replaceAll("\r", "|");
+        s = s.replaceAll("\n", "|");
+	    }
+	    return s;
+	  }
+	  catch (RemoteException ex)
+	  {
+	    return null;
+	  }
 	}
+}
+
+// Dummy Klasse um die Methode "VerwendungszweckUtil.getTag(t, Tag.SVWZ)"
+// verwenden zu können
+final class Verwendungszweck implements Transfer
+{
+  String zweck = null;
+
+  public Verwendungszweck(String zweck)
+  {
+    this.zweck = zweck;
+  }
+
+  @Override
+  public String getGegenkontoNummer() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String getGegenkontoBLZ() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String getGegenkontoName() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public double getBetrag() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public String getZweck() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return zweck;
+  }
+
+  @Override
+  public String getZweck2() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String[] getWeitereVerwendungszwecke() throws RemoteException
+  {
+    // TODO Auto-generated method stub
+    return null;
+  }
 
 }
+


### PR DESCRIPTION
Dieser Request korrigiert das Feature Buchungskorrektur wie in #122 diskutiert.
Die Änderungen sind wie folgt:
- Der implementierte Suchalgorithmus wurde durch den Aufruf "VerwendungszweckUtil.getTag(t, Tag.SVWZ)" aus Hibiscus ersetzt. Da die Methode eine Klasse vom Typ Transfer braucht habe ich eine Dummy Klasse erzeugt die das Interface Transfer implementiert, allerdings nur für den Zweck. Damit funktioniert die Ersetzung wie gewünscht.
- Beim Query der Buchungen für den Buchungskorrektur View wurde bisher nur nach SVWZ gesucht. Es gibt aber Buchungen die das nicht enthalten aber einige der anderen Keys. Ich schaue also jetzt ob irgend ein SEPA Tag enthalten ist. Da IBAN bei mir auch manchmal im Zweck vorkommt suche ich hier direkt nach IBAN+ oder IBAN:
- Die Tabelle hat auch Buchungen die schon abgeschlossen waren angezeigt. Beim speichern wurden sie dann ignoriert. Ich zeige jetzt nur noch Buchungen an die noch nicht abgeschlossen sind.