### PR TITLE
Fix Kontonummer in KontensaldoList

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/KontensaldoList.java
+++ b/src/de/jost_net/JVerein/gui/parts/KontensaldoList.java
@@ -146,6 +146,7 @@ public class KontensaldoList extends TablePart implements Part
     
     // Leerzeile am Ende wegen Scrollbar
     k = (Konto) Einstellungen.getDBService().createObject(Konto.class, null);
+    k.setNummer("");
     k.setBezeichnung("");
     zeile.add(new SaldoZeile(k, null, null, null, null, null));
     return zeile;


### PR DESCRIPTION
Bei der Leerzeile in der KontensaldoList wurde die Kontonummer nicht gesetzt.
Das hat dann beim Speichern eines Jahresabschusses zu einer Nullpointer Exception geführt, die allerdings nicht sichtbar war und auch kein Problem gemacht hat weil es die letzte Zeile war.
Die Exception war in JahresabschlussControl der Methode handleStore() bei der Zeile if (ktonr.length() > 0)