### PR TITLE
Building/update

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -86,6 +86,8 @@ jobs:
       uses: richardsimko/update-tag@v1
       with:
         tag_name: ${{ steps.openjverein.outputs.selected_version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -81,8 +81,15 @@ jobs:
         builddatetime=$(date +'%Y-%m-%d %H:%M')
         echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
 
+    # Update tag
+    - uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ steps.openjverein.outputs.selected_version }}
+        tag_exists_error: false
+        message: Release ${{ steps.openjverein.outputs.selected_version }}
+    
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.openjverein.outputs.selected_version }}
         prerelease: true

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -82,11 +82,10 @@ jobs:
         echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
 
     # Update tag
-    - uses: rickstaa/action-create-tag@v1
+    - name: Tag repo
+      uses: richardsimko/update-tag@v1
       with:
-        tag: ${{ steps.openjverein.outputs.selected_version }}
-        tag_exists_error: false
-        message: Release ${{ steps.openjverein.outputs.selected_version }}
+        tag_name: ${{ steps.openjverein.outputs.selected_version }}
     
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         echo "### Version: $tmp_version | filename: $tmp_filename | build datetime: $builddatetime" >> $GITHUB_STEP_SUMMARY
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.openjverein.outputs.selected_version }}
         prerelease: false


### PR DESCRIPTION
Das Update behebt das Problem, dass ein bestehendes github tag nicht aktualisiert wird. Dies führte zu Fehlern beim nightly build. Beim echten Release taucht der Fall nicht auf, da das Tag nur ein mal genutzt wird (beim Erstellen des final build).
Weiterhin wird die neue Version 2 von action-gh-release benutzt.