### PR TITLE
Fix ZusatzbeitraegeAction und Icon Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/ZusatzbetraegeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/ZusatzbetraegeAction.java
@@ -41,16 +41,17 @@ public class ZusatzbetraegeAction implements Action
   public void handleAction(Object context) throws ApplicationException
   {
     Zusatzbetrag z = null;
-    if (m == null)
-    {
-      return;
-    }
+
     if (context != null && (context instanceof Zusatzbetrag))
     {
       z = (Zusatzbetrag) context;
     }
     else
     {
+      if (m == null)
+      {
+        return;
+      }
       try
       {
         z = (Zusatzbetrag) Einstellungen.getDBService().createObject(

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
@@ -333,7 +333,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
         settings.setAttribute(zusatzfelder + "selected", selcounter);
         close();
       }
-    });
+    }, null, true, "ok.png");
     buttons.paint(parent);
   }
 

--- a/src/de/jost_net/JVerein/gui/view/FelddefinitionDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FelddefinitionDetailView.java
@@ -44,7 +44,7 @@ public class FelddefinitionDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FELDDEFINITIONEN, false, "question-circle.png");
-    buttons.addButton("Übersicht", new FelddefinitionenAction());
+    buttons.addButton("Übersicht", new FelddefinitionenAction(), null, false, "list.png");
     buttons.addButton("Speichern", new Action()
     {
 


### PR DESCRIPTION
Der Pull Request enthält folgendes:
- Ok Icon für Ok Button in Zusatzfelder Auswahl Dialog hinzugefügt. Der Ok Button hatte kein Icon
- Icon für Übersicht Button in Felddefinition View hinzugefügt. Der Button hatte kein Icon
![Bildschirmfoto_20240712_172854](https://github.com/user-attachments/assets/e96bebee-4ebe-4fd1-9301-e55d540a3604)

- Fix Bug in ZusatzbeitraegeAction: Wurde im View Zusatzbeiträge ein doppel Klick auf einen Eintrag gemacht ist nichts passiert. Das lag daran, weil hier als Mitglied null übergeben wird und die Action dann gleich ein return macht. Es muss erst auf context Zusatzbeitrag geprüft werden, der in diesem Fall zutrifft. Die Prüfung auf Mitglied null muss dann in das else für den Fall,  dass ein neuer Zusatzbeitrag erzeugt werden soll. Hier ist der Context kein Zusatzbeitrag.
