### PR TITLE
Fix: Mandatsdatum und Geburtsdatum bei Kursteilnehmern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -308,7 +308,8 @@ public class KursteilnehmerControl extends AbstractControl
     this.mandatdatum.setTitle("Datum des Mandats");
     this.mandatdatum.setName("Datum des Mandats");
     this.mandatdatum.setText("Bitte Datum des Mandats wählen");
-    mandatdatum.setName("Datum des Mandats");
+    this.mandatdatum.setName("Datum des Mandats");
+    this.mandatdatum.setMandatory(true);
     return mandatdatum;
   }
 
@@ -644,7 +645,7 @@ public class KursteilnehmerControl extends AbstractControl
       k.setIban((String) getIBAN().getValue());
       k.setBic((String) getBIC().getValue());
       k.setBetrag((Double) getBetrag().getValue());
-      if (Einstellungen.getEinstellung().getGeburtsdatumPflicht())
+      if (Einstellungen.getEinstellung().getKursteilnehmerGebGesPflicht())
       {
         k.setGeburtsdatum((Date) getGeburtsdatum().getValue());
         k.setGeschlecht((String) getGeschlecht().getValue());


### PR DESCRIPTION
Beim Anlegen von Kursteilnehmern wird eine Fehlermeldung angezeigt, wenn kein Mandatsdatum eingegeben wurde. Dieses Feld ist aber nicht als notwendig gekennzeichnet. Geändert.

Beim Erzeugen des Formulars zum Anlegen neuer Kursteilnehmer wird die Einstellung "kursteilnehmergebgespflicht" verwendet. Bei der Übernahme der Daten aus dem Formular, wird das Geburtsdatum aber nur übernommen, wenn die Einstellung "geburtsdatumpflicht" gesetzt ist. Das kann dazu führen, dass das Geburtsdatum zwar als Pflichtfeld angegeben werden muss, beim Abspeichern aber dann nicht ausgelesen wird (weil die normalen Mitglieder kein Geburtsdatum angeben müssen) und dann eine Fehlermeldung ausgegeben wird. Geändert.