### PR TITLE
Fix Mailfilter

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.rmi.RemoteException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeSet;
@@ -684,8 +685,11 @@ public class MailControl extends FilterControl
     }
     if (isEingabedatumbisAktiv() && getEingabedatumbis().getValue() != null)
     {
-      Date d = (Date) getEingabedatumbis().getValue();
-      mails.addFilter("bearbeitung <= ?", new Object[] { new java.sql.Date(d.getTime()) });
+      Calendar cal = Calendar.getInstance();
+      cal.setTime((Date) getEingabedatumbis().getValue());
+      cal.add(Calendar.DAY_OF_MONTH, 1);
+      mails.addFilter("bearbeitung <= ?", 
+          new Object[] { new java.sql.Date(cal.getTimeInMillis()) });
     }
     if (isDatumvonAktiv() && getDatumvon().getValue() != null)
     {
@@ -694,8 +698,11 @@ public class MailControl extends FilterControl
     }
     if (isDatumbisAktiv() && getDatumbis().getValue() != null)
     {
-      Date d = (Date) getDatumbis().getValue();
-      mails.addFilter("mail.versand <= ?", new Object[] { new java.sql.Date(d.getTime()) });
+      Calendar cal = Calendar.getInstance();
+      cal.setTime((Date) getDatumbis().getValue());
+      cal.add(Calendar.DAY_OF_MONTH, 1);
+      mails.addFilter("mail.versand <= ?", 
+          new Object[] { new java.sql.Date(cal.getTimeInMillis()) });
     }
     mails.setOrder("ORDER BY betreff");
 

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -652,18 +652,20 @@ public class MailControl extends FilterControl
   {
     DBService service = Einstellungen.getDBService();
     DBIterator<Mail> mails = service.createList(Mail.class);
-    mails.join("mailempfaenger");
-    mails.addFilter("mailempfaenger.mail = mail.id");
-    mails.join("mitglied");
-    mails.addFilter("mitglied.id = mailempfaenger.mitglied");
+
     
     if (isSuchnameAktiv() && getSuchname().getValue() != null)
     {
       String tmpSuchname = (String) getSuchname().getValue();
       if (tmpSuchname.length() > 0)
       {
-        mails.addFilter("(lower(betreff) like ?)", 
-            new Object[] { "%" + tmpSuchname.toLowerCase() + "%" });
+        mails.join("mailempfaenger");
+        mails.addFilter("mailempfaenger.mail = mail.id");
+        mails.join("mitglied");
+        mails.addFilter("mitglied.id = mailempfaenger.mitglied");
+        mails.addFilter("(lower(name) like ? or lower(vorname) like ?) ", 
+            new Object[] { "%" + tmpSuchname.toLowerCase() + "%",
+                "%" + tmpSuchname.toLowerCase() + "%"});
       }
     }
     if (isSuchtextAktiv() && getSuchtext().getValue() != null)


### PR DESCRIPTION
Ich habe einige Bugs in meinem Filter bei den Mails gefunden.
- Mit dem JOIN werden Mails vervielfacht wenn sie mehrere Mailempfänger haben. Für jeden Empfänger entsteht ein Eintrag. Ich habe jetzt das JOIN so verschoben, dass es nur beim Filtern nach einem Empfänger gemacht wird. Da dann der Empfänger gefiltert wird, wird auch in diesem Fall nichts mehr vervielfacht.
- Bei Mail Empfänger hatte ich auf das Attribut betreff verglichen (copy paste Fehler). Korrekter Weise vergleiche ich jetzt den Namen und Vorname.
- Die Vergleiche nach bis Datum hatten nicht richtig funktioniert. Es wurden die Mails mit dem bis Datum nicht angezeigt obwohl "<=" benutzt wurde. Das liegt hier wohl daran, dass die Mails mit Uhrzeit gespeichert werden und das bis Datum wohl die Uhrzeit 0Uhr hat. Damit sind alle Mails des gesetzten Tages später. Ich addiere jetzt einen Tag auf das bis Datum. Damit ist das Limit am Ende des Tages.