### PR TITLE
SollbuchungsView Differenz falsch gelese

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -459,7 +459,7 @@ public class MitgliedskontoControl extends AbstractControl
       return differenz;
     }
     DIFFERENZ defaultwert = DIFFERENZ
-        .fromString(settings.getString("differenz", DIFFERENZ.EGAL.toString()));
+        .fromString(settings.getString(datumverwendung + "differenz", DIFFERENZ.EGAL.toString()));
     return getDifferenz(defaultwert);
   }
 


### PR DESCRIPTION
Beim SollbuchungsView würden die Settings falsch gelesen, und so immer EGAL statt dem gesspeichertem wert vom letzten mal verwendet.