### PR TITLE
Mit Zip Mailer versendete Mails in DB Speichern

### DIFF
--- a/src/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/de/jost_net/JVerein/io/ZipMailer.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.TreeSet;
@@ -37,7 +39,9 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.VarTools;
+import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
+import de.jost_net.JVerein.rmi.MailEmpfaenger;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.GUI;
@@ -132,6 +136,24 @@ public class ZipMailer
               monitor.log("Versende an " + mail);
               try
               {
+                Mail ml = (Mail) Einstellungen.getDBService()
+                        .createObject(Mail.class, null);
+                ml.setBetreff(betreff);
+                ml.setTxt(text);
+                ml.setBearbeitung(new Timestamp(new Date().getTime()));
+                ml.setVersand(new Timestamp(new Date().getTime()));
+                ml.store();
+                
+                MailEmpfaenger me = (MailEmpfaenger) Einstellungen.getDBService()
+                        .createObject(MailEmpfaenger.class, null);
+                me.setMitglied(m);
+                me.setMail(ml);
+                me.setVersand(new Timestamp(new Date().getTime()));
+                me.store();
+                
+                ma.setMail(ml);
+                ma.store();
+                
                 sender.sendMail(mail, wtext1.getBuffer().toString(),
                     wtext2.getBuffer().toString(), anhang);
                 sentCount++;


### PR DESCRIPTION
Hiermit werden auch mit dem Zip Mailer versendete Mails in der DB gespeichert (Rechungen, Mahnungen, Kontoauszüge...)
Hier habe ich es so gemacht, dass jedes Mail einzeln gespeicher wird, da es ja auch einen anderen Anhang hat. Dadurch können jedoch sehr viele Einträge in der MailView entstehen. Ansonsten könnte man auch ohne Anhang speichert, ob das dann aber noch seinen Zweck erfüllt ist fragwürdig.