### PR TITLE
Mahnung und Rechnung View Update

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -778,6 +778,7 @@ public class FilterControl extends AbstractControl
       return ohneabbucher;
     }
     ohneabbucher = new CheckboxInput(settings.getBoolean(settingsprefix + "ohneabbucher", false));
+    ohneabbucher.addListener(new FilterListener());
     return ohneabbucher;
   }
   

--- a/src/de/jost_net/JVerein/gui/menu/SollbuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SollbuchungMenu.java
@@ -38,13 +38,13 @@ import de.willuhn.logging.Logger;
 /**
  * Kontext-Menu zu den Mitgliedskonten.
  */
-public class Mitgliedskonto2Menu extends ContextMenu
+public class SollbuchungMenu extends ContextMenu
 {
 
   /**
    * Erzeugt ein Kontext-Menu fuer Mitgliedskonten.
    */
-  public Mitgliedskonto2Menu()
+  public SollbuchungMenu()
   {
     addItem(new CheckedSingleContextMenuItem("Sollbuchung bearbeiten",
         new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoMahnungView.java
@@ -21,12 +21,12 @@ import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction.EXPORT_TYP;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
-import de.jost_net.JVerein.gui.control.MitgliedskontoControl.DIFFERENZ;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
@@ -44,15 +44,29 @@ public class MitgliedskontoMahnungView extends AbstractView
     if (this.getCurrentObject() == null)
     {
       LabelGroup group = new LabelGroup(getParent(), "Filter");
-      group.addInput(control.getDatumvon());
-      group.addInput(control.getDatumbis());
+      ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+      
+      SimpleContainer left = new SimpleContainer(cl.getComposite());
+      left.addInput(control.getSuchname());
+      left.addInput(control.getDifferenz());
+      left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
+      
+      SimpleContainer right = new SimpleContainer(cl.getComposite());
+      right.addInput(control.getDatumvon());
+      right.addInput(control.getDatumbis());
+      right.addInput(control.getMailauswahl());
       
       ButtonArea filterbuttons = new ButtonArea();
       filterbuttons.addButton(control.getResetButton());
       filterbuttons.addButton(control.getSpeichernButton());
       group.addButtonArea(filterbuttons);
     }
-    control.getDifferenz(DIFFERENZ.FEHLBETRAG);
+    else
+    {
+      SimpleContainer cont1 = new SimpleContainer(getParent(), false);
+      cont1.addHeadline("Info");
+      cont1.addInput(control.getInfo());
+    }
 
     SimpleContainer cont = new SimpleContainer(getParent(), true);
     cont.addHeadline("Parameter");

--- a/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedskontoRechnungView.java
@@ -26,6 +26,7 @@ import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
@@ -43,14 +44,28 @@ public class MitgliedskontoRechnungView extends AbstractView
     if (this.getCurrentObject() == null)
     {
       LabelGroup group = new LabelGroup(getParent(), "Filter");
-      group.addInput(control.getDatumvon());
-      group.addInput(control.getDatumbis());
-      group.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
+      ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+      
+      SimpleContainer left = new SimpleContainer(cl.getComposite());
+      left.addInput(control.getSuchname());
+      left.addInput(control.getDifferenz());
+      left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
+      
+      SimpleContainer right = new SimpleContainer(cl.getComposite());
+      right.addInput(control.getDatumvon());
+      right.addInput(control.getDatumbis());
+      right.addInput(control.getMailauswahl());
       
       ButtonArea filterbuttons = new ButtonArea();
       filterbuttons.addButton(control.getResetButton());
       filterbuttons.addButton(control.getSpeichernButton());
       group.addButtonArea(filterbuttons);
+    }
+    else
+    {
+      SimpleContainer cont1 = new SimpleContainer(getParent(), false);
+      cont1.addHeadline("Info");
+      cont1.addInput(control.getInfo());
     }
         
     SimpleContainer cont = new SimpleContainer(getParent(), true);

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -21,7 +21,7 @@ import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungEditAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoExportAction.EXPORT_TYP;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
-import de.jost_net.JVerein.gui.menu.Mitgliedskonto2Menu;
+import de.jost_net.JVerein.gui.menu.SollbuchungMenu;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -47,10 +47,12 @@ public class SollbuchungListeView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
     left.addInput(control.getDifferenz());
+    left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
     
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addInput(control.getDatumvon());
     right.addInput(control.getDatumbis());
+    right.addInput(control.getMailauswahl());
     
     ButtonArea fbuttons = new ButtonArea();
     fbuttons.addButton(control.getResetButton());
@@ -58,7 +60,7 @@ public class SollbuchungListeView extends AbstractView
     group.addButtonArea(fbuttons);
 
     control.getMitgliedskontoList(new MitgliedskontoSollbuchungEditAction(),
-        new Mitgliedskonto2Menu(), false).paint(this.getParent());
+        new SollbuchungMenu(), false).paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -18,15 +18,13 @@ package de.jost_net.JVerein.io;
 
 import java.io.IOException;
 import java.rmi.RemoteException;
-import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.keys.FormularArt;
-import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
-import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.GenericIterator;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.logging.Logger;
 
@@ -54,30 +52,8 @@ public class Rechnungsausgabe extends AbstractMitgliedskontoDokument
     else
     {
       // Nein: Sammeldruck aus der MitgliedskontoRechnungView
-      DBIterator<Mitgliedskonto> it = Einstellungen.getDBService()
-          .createList(Mitgliedskonto.class);
-      Date d = null;
-      if (control.isDatumvonAktiv() && control.getDatumvon().getValue() != null)
-      {
-        d = (Date) control.getDatumvon().getValue();
-        if (d != null)
-        {
-          it.addFilter("datum >= ?", d);
-        }
-      }
-      if (control.isDatumbisAktiv() && control.getDatumbis().getValue() != null)
-      {
-        d = (Date) control.getDatumbis().getValue();
-        if (d != null)
-        {
-          it.addFilter("datum <= ?", d);
-        }
-      }
-      if (control.isOhneAbbucherAktiv() && (Boolean) control.getOhneAbbucher().getValue())
-      {
-        it.addFilter("zahlungsweg <> ?", Zahlungsweg.BASISLASTSCHRIFT);
-      }
-
+      @SuppressWarnings("rawtypes")
+      GenericIterator it = control.getMitgliedskontoIterator(false);
       Mitgliedskonto[] mk = new Mitgliedskonto[it.size()];
       int i = 0;
       while (it.hasNext())


### PR DESCRIPTION
Jetzt gibt es ein Update für den Sollbuchungen, Mahnung und Rechnung View  wie versprochen.

Ich habe jetzt bei all diesen drei den gleichen Filter eingebaut.
![Bildschirmfoto_20240727_201612](https://github.com/user-attachments/assets/c8ada6c2-0401-4ddd-909b-e0ab16c74696)

Das hat jetzt folgende Vorteile.
- Im Sollbuchung View kann man jetzt auch nach Mail und Abbucher filtern. So kann man jetzt z.B. Mail setzen, alle selektieren und auf Rechnung/Mahnung erzeugen gehen und per Mail verschicken. Oder man wählt Ohne Mail, selektiert alle und macht dann ein Drucken. Im Mahnung und Rechnung View wird dann auch das Info Feld angezeigt. Da ist dann alles so wie es auch beim Kontoauszug View ist.
- Ruft man die Mahnung oder Rechnung aus dem linken Auswahlbaum auf wird kein Info Feld angezeigt. Jetzt hat man da aber die gleichen Filter wie im Sollbuchung View. Damit ist es dann noch einfacher. Hier kann man direkt Mail auswählen und dann per Mail verschicken. Anschliesend Ohne Mail auswählen und dann einfach Drucken. Ein Info Feld braucht es darum nicht