### PR TITLE
Texte erweitert, Filter-standartauswahl Zusatzbeitraege geaendert

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -243,7 +243,8 @@ public class SpendenbescheinigungPrintAction implements Action
           fa.closeFormular();
         }
       }
-      String erfolg = (spbArr.length > 1) ? "Die Spendenbescheinigungen wurden erstellt." : "Die Spendenbescheinigung wurde erstellt.";
+      String erfolg = (spbArr.length > 1) ? "Die Spendenbescheinigungen wurden erstellt und unter " + path + " gespeichert."
+                                          : "Die Spendenbescheinigung wurde erstellt und unter " + path + " gespeichert.";
       GUI.getStatusBar().setSuccessText(erfolg);
     }
     catch (Exception e)

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -159,7 +159,7 @@ public class ZusatzbetragControl extends AbstractControl
     };
     service.execute(sql, new Object[] {}, rs);
 
-    ausfuehrungSuch = new SelectInput(werte, werte.elementAt(0));
+    ausfuehrungSuch = new SelectInput(werte, werte.elementAt(1));
     ausfuehrungSuch.addListener(new Listener()
     {
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
@@ -97,7 +97,7 @@ public class MitgliedZusatzbetragZuordnungDialog extends AbstractDialog<String>
             zb.store();
             count++;
           }
-          message = String.format("%d Arbeitseinsätze gespeichert.", count);
+          message = String.format("%d Zusatzbeiträge gespeichert.", count);
         }
         catch (RemoteException e)
         {

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
@@ -43,13 +43,17 @@ public class SpendenbescheinigungAutoNeuView extends AbstractView
     if (betrag == 0)
     {
       info.setText("Es wurden nur Mitglieder berücksichtigt, bei denen Strasse, "
-          + "PLZ und Ort eingetragen sind.");
+          + "PLZ und Ort eingetragen sind.\n\n"
+    	  + "Um eine neue Spende zu erstellen muss die Buchung einer Buchungsart mit Spende zugeordnet sein.\n"
+          + "Außerdem muss sie einem (Nicht-)Mitglied zugeordnet sein. (ggfs. bei Nicht-Mitglieder Spender anlegen).");
     }
     else
     {
     info.setText(String.format("Es wurden nur Mitglieder berücksichtigt, bei denen Strasse, "
         + "PLZ und Ort eingetragen sind."+'\n'+"Auch wurden nur Spendenbescheinigungen "
-        + "generiert deren Betrag größer oder gleich %s Euro ist.", betrag));
+        + "generiert deren Betrag größer oder gleich %s Euro ist.\n\n"
+        + "Um eine neue Spende zu erstellen muss die Buchung einer Buchungsart mit Spende zugeordnet sein.\n"
+        + "Außerdem muss sie einem (Nicht-)Mitglied zugeordnet sein. (ggfs. bei Nicht-Mitglieder Spender anlegen).", betrag));
     info.setComment("Siehe Administration->Einstellungen->Spendenbescheinigungen->Mindestbetrag");
     }
     info.paint(getParent());


### PR DESCRIPTION
Hier habe ich einige Texte korrigiert bzw. erweitert:
-Bei Erstellen der Spendenbescheinigungen aus dem Context-Menue den Pfad mit ausgeben damit man die Dokumente leichter finden kann
-Beim Speichern eines Zusatzbetrags wurde falsch "Arbeitseinsätze gespeichert" angezeigt
-Beim Automatischen erstellen von Spendenbescheinigungen habe ich den Text in der Info Box erweitert da ich es nicht intuitiv finde wie man eine neue Spende erstellen kann.
-Außerdem habe ich im ZusatzbeitragControl den vorausgewählten Filter auf "Aktive" geändert. Sonst hat das laden bei vielen Zusatzbeiträgen manchmal sehr lange gedauert, und ich denke, dass man meistens nur die Aktiven Zusatzbeiträge sehen will.