### PR TITLE
Fix Loeschen von Buchungen mit Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
@@ -67,7 +67,7 @@ public class AbrechnungslaufDeleteAction implements Action
             "Abgeschlossene Abrechnungsläufe können nicht gelöscht werden!");
       }
       
-      // Check ob einer der Buchungen der Splittbuchung
+      // Check ob einer der Buchungen des Abrechnungslaufs
       // eine Spendenbescheinigung zugeordnet ist
       final DBService service = Einstellungen.getDBService();
       String sql = "SELECT DISTINCT buchung.id from buchung "

--- a/src/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
@@ -17,6 +17,8 @@
 package de.jost_net.JVerein.gui.action;
 
 import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
@@ -29,6 +31,8 @@ import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.rmi.ZusatzbetragAbrechnungslauf;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.YesNoDialog;
@@ -62,10 +66,43 @@ public class AbrechnungslaufDeleteAction implements Action
         throw new ApplicationException(
             "Abgeschlossene Abrechnungsläufe können nicht gelöscht werden!");
       }
+      
+      // Check ob einer der Buchungen der Splittbuchung
+      // eine Spendenbescheinigung zugeordnet ist
+      final DBService service = Einstellungen.getDBService();
+      String sql = "SELECT DISTINCT buchung.id from buchung "
+          + "WHERE (abrechnungslauf = ? and spendenbescheinigung IS NOT NULL) ";
+      boolean spendenbescheinigung = (boolean) service.execute(sql,
+          new Object[] { abrl.getID() }, new ResultSetExtractor()
+      {
+        @Override
+        public Object extract(ResultSet rs)
+            throws RemoteException, SQLException
+        {
+          if (rs.next())
+          {
+            return true;
+          }
+          return false;
+        }
+      });
+
+      String text = "";
+      if (!spendenbescheinigung)
+      {
+        text = "Wollen Sie diesen Abrechnungslauf wirklich löschen?";
+      }
+      else
+      {
+        text = "Der Abrechnungslauf enthält Buchungen denen eine "
+            + "Spendenbescheinigung zugeordnet ist.\n"
+            + "Sie können nur zusammen gelöscht werden.\n"
+            + "Abrechnungslauf und Spendenbescheinigungen löschen?";
+      }
 
       YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
       d.setTitle(String.format("Abrechnungslauf %s löschen", abrl.getID()));
-      d.setText("Wollen Sie diesen Abrechnungslauf wirklich löschen?");
+      d.setText(text);
 
       try
       {
@@ -80,6 +117,7 @@ public class AbrechnungslaufDeleteAction implements Action
         Logger.error("Fehler beim Löschen eines Abrechnungslaufes", e);
         return;
       }
+      
       DBIterator<Buchung> it = Einstellungen.getDBService()
           .createList(Buchung.class);
       it.addFilter("abrechnungslauf = ?", new Object[] { abrl.getID() });
@@ -99,6 +137,8 @@ public class AbrechnungslaufDeleteAction implements Action
         }
         b.setMitgliedskontoID(null);
         b.store();
+        if (b.getSpendenbescheinigung() != null)
+          b.getSpendenbescheinigung().delete();
         b.delete();
       }
       it = Einstellungen.getDBService().createList(Mitgliedskonto.class);

--- a/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
@@ -74,10 +74,44 @@ public class BuchungDeleteAction implements Action
       {
         return;
       }
+      
+      // Check ob einer der Buchungen
+      // eine Spendenbescheinigung zugeordnet ist
+      boolean spendenbescheinigung = false;
+      for (Buchung bu : b)
+      {
+        if (bu.getSpendenbescheinigung() != null)
+        {
+          spendenbescheinigung = true;
+          break;
+        }
+      }
+      
+      String text = "";
+      if (!spendenbescheinigung)
+      {
+        text = "Wollen Sie diese Buchung" + (b.length > 1 ? "en" : "")
+            + " wirklich löschen?";
+      }
+      else
+      {
+        if (b.length == 1)
+        {
+         text = "Die Buchung gehört zu einer Spendenbescheinigung.\n"
+              + "Sie können nur zusammen gelöscht werden.\n"
+              + "Beide löschen?";
+        }
+        else
+        {
+          text = "Mindestens eine Buchung gehört zu einer Spendenbescheinigung.\n"
+              + "Sie können nur zusammen gelöscht werden.\n"
+              + "Jeweils auch die Spendenbescheinigungen löschen?";
+        }
+      }
+      
       YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
       d.setTitle("Buchung" + (b.length > 1 ? "en" : "") + " löschen");
-      d.setText("Wollen Sie diese Buchung" + (b.length > 1 ? "en" : "")
-          + " wirklich löschen?");
+      d.setText(text);
       try
       {
         Boolean choice = (Boolean) d.open();
@@ -91,40 +125,7 @@ public class BuchungDeleteAction implements Action
         Logger.error("Fehler beim Löschen der Buchung", e);
         return;
       }
-      for (Buchung bu : b)
-      {
-        if (bu.getSpendenbescheinigung() != null)
-        {
-          YesNoDialog dl = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-          dl.setTitle("Buchung" + (b.length > 1 ? "en" : "") + 
-              " und Spendenbescheinigungen löschen");
-          if (b.length == 1)
-          {
-            dl.setText("Die Buchung gehört zu einer Spendenbescheinigung.\n"
-                + "Sie können nur zusammen gelöscht werden.\n"
-                + "Beide löschen?");
-          }
-          else
-          {
-            dl.setText("Mindestens eine Buchung gehört zu einer Spendenbescheinigung.\n"
-                + "Sie können nur zusammen gelöscht werden.\n"
-                + "Jeweils auch die Spendenbescheinigungen löschen?");
-          }
-          try
-          {
-            Boolean choice = (Boolean) dl.open();
-            if (!choice.booleanValue())
-            {
-              return;
-            }
-          }
-          catch (Exception e)
-          {
-            Logger.error("Fehler beim Löschen der Buchung", e);
-            return;
-          }
-        }
-      }
+      
       int count = 0;
       for (Buchung bu : b)
       {

--- a/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
@@ -91,6 +91,40 @@ public class BuchungDeleteAction implements Action
         Logger.error("Fehler beim Löschen der Buchung", e);
         return;
       }
+      for (Buchung bu : b)
+      {
+        if (bu.getSpendenbescheinigung() != null)
+        {
+          YesNoDialog dl = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+          dl.setTitle("Buchung" + (b.length > 1 ? "en" : "") + 
+              " und Spendenbescheinigungen löschen");
+          if (b.length == 1)
+          {
+            dl.setText("Die Buchung gehört zu einer Spendenbescheinigung.\n"
+                + "Sie können nur zusammen gelöscht werden.\n"
+                + "Beide löschen?");
+          }
+          else
+          {
+            dl.setText("Mindestens eine Buchung gehört zu einer Spendenbescheinigung.\n"
+                + "Sie können nur zusammen gelöscht werden.\n"
+                + "Jeweils auch die Spendenbescheinigungen löschen?");
+          }
+          try
+          {
+            Boolean choice = (Boolean) dl.open();
+            if (!choice.booleanValue())
+            {
+              return;
+            }
+          }
+          catch (Exception e)
+          {
+            Logger.error("Fehler beim Löschen der Buchung", e);
+            return;
+          }
+        }
+      }
       int count = 0;
       for (Buchung bu : b)
       {
@@ -103,6 +137,8 @@ public class BuchungDeleteAction implements Action
         }
         if (bu.getSplitId() == null)
         {
+          if (bu.getSpendenbescheinigung() != null)
+            bu.getSpendenbescheinigung().delete();
           bu.delete();
           count++;
         }

--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
@@ -17,13 +17,18 @@
 package de.jost_net.JVerein.gui.action;
 
 import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.YesNoDialog;
@@ -68,10 +73,60 @@ public class SplitbuchungBulkAufloesenAction implements Action
       {
         return;
       }
+      
+      boolean spendenbescheinigung = false;
+      for (Buchung splitbu : b)
+      {
+        // Check ob einer der Buchungen der Splittbuchung
+        // eine Spendenbescheinigung zugeordnet ist
+        final DBService service = Einstellungen.getDBService();
+        String sql = "SELECT DISTINCT buchung.id from buchung "
+            + "WHERE (splitid = ? and spendenbescheinigung IS NOT NULL) ";
+        spendenbescheinigung = (boolean) service.execute(sql,
+            new Object[] { splitbu.getSplitId() }, new ResultSetExtractor()
+        {
+          @Override
+          public Object extract(ResultSet rs)
+              throws RemoteException, SQLException
+          {
+            if (rs.next())
+            {
+              return true;
+            }
+            return false;
+          }
+        });
+        if (spendenbescheinigung)
+          break;
+      }
+      
+      String text = "";
+      if (!spendenbescheinigung)
+      {
+        text = "Wollen Sie diese Splituchung" + (b.length > 1 ? "en" : "")
+            + " wirklich auflösen?";
+      }
+      else
+      {
+        if (b.length == 1)
+        {
+          text = "Die Splitbuchung enthält Buchungen denen eine "
+              + "Spendenbescheinigung zugeordnet ist.\n"
+              + "Sie können nur zusammen gelöscht werden.\n"
+              + "Splitbuchung auflösen und Spendenbescheinigungen löschen?";
+        }
+        else
+        {
+          text = "Mindestens eine Splitbuchung enthält Buchungen denen "
+              + "eine Spendenbescheinigung zugeordnet ist.\n"
+              + "Sie können nur zusammen gelöscht werden.\n"
+              + "Splitbuchungen auflösen und Spendenbescheinigungen löschen?";
+        }
+      }
+      
       YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
       d.setTitle("Splitbuchung" + (b.length > 1 ? "en" : "") + " auflösen");
-      d.setText("Wollen Sie diese Splituchung" + (b.length > 1 ? "en" : "")
-          + " wirklich auflösen?");
+      d.setText(text);
       try
       {
         Boolean choice = (Boolean) d.open();
@@ -85,6 +140,7 @@ public class SplitbuchungBulkAufloesenAction implements Action
         Logger.error("Fehler beim Auflösen der Splituchung", e);
         return;
       }
+      
       for (Buchung bu : b)
       {
         Jahresabschluss ja = bu.getJahresabschluss();

--- a/src/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
@@ -366,10 +366,11 @@ public class DbBereinigenControl extends AbstractControl
       // Check ob im Bereich Splittbuchungen mit Spendenbescheinigungen liegen
       final DBService service = Einstellungen.getDBService();
       String sql = "SELECT DISTINCT buchung.splitid from buchung "
-          + "WHERE splitid IS NOT NULL and spendenbescheinigung IS NOT NULL ";
+          + "WHERE splitid IS NOT NULL and spendenbescheinigung IS NOT NULL "
+          + "and datum < ? ";
       @SuppressWarnings("unchecked")
       ArrayList<Long> splitmitspende = (ArrayList<Long>) service.execute(sql,
-          new Object[] { }, new ResultSetExtractor()
+          new Object[] { date }, new ResultSetExtractor()
       {
         @Override
         public Object extract(ResultSet rs)

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -53,6 +53,7 @@ public class LastschriftControl extends FilterControl
       return lastschriftList;
     }
     lastschriftList = new TablePart(getLastschriften(), null);
+    lastschriftList.addColumn("Nr", "id");
     lastschriftList.addColumn("Name", "name");
     lastschriftList.addColumn("Vorname", "vorname");
     lastschriftList.addColumn("Zweck", "verwendungszweck");

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -617,6 +617,7 @@ public class MailControl extends FilterControl
       return mailsList;
     }
     mailsList = new TablePart(getMails(), new MailDetailAction());
+    mailsList.addColumn("Nr", "id");
     mailsList.addColumn("Betreff", "betreff");
     mailsList.addColumn("Bearbeitung", "bearbeitung",
         new DateFormatter(new JVDateFormatDATETIME()));

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -698,6 +698,7 @@ public class SpendenbescheinigungControl extends FilterControl
     }
     spbList = new TablePart(getSpendenbescheinigungen(),
         new SpendenbescheinigungAction(Spendenart.SACHSPENDE));
+    spbList.addColumn("Nr", "id");
     spbList.addColumn("Bescheinigungsdatum", "bescheinigungsdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     spbList.addColumn("Spendedatum", "spendedatum",

--- a/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
+++ b/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
@@ -35,6 +35,13 @@ public class DbBereinigenView extends AbstractView
 
     final DbBereinigenControl control = new DbBereinigenControl(this);
 
+    LabelGroup groupspendenbescheinigungen = new LabelGroup(getParent(), "Spendenbescheinigungen");
+    ColumnLayout scl = new ColumnLayout(groupspendenbescheinigungen.getComposite(), 2);
+    SimpleContainer sleft = new SimpleContainer(scl.getComposite());
+    sleft.addLabelPair("Löschen", control.getSpendenbescheinigungenLoeschen());
+    SimpleContainer sright = new SimpleContainer(scl.getComposite());
+    sright.addLabelPair("Spendedatum älter als", control.getDatumAuswahlSpendenbescheinigungen());
+    
     LabelGroup groupbuchungen = new LabelGroup(getParent(), "Buchungen");
     ColumnLayout bcl = new ColumnLayout(groupbuchungen.getComposite(), 2);
     SimpleContainer bleft = new SimpleContainer(bcl.getComposite());

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -236,6 +236,8 @@ public class SplitbuchungsContainer
     {
       if (b.isToDelete())
       {
+        if (b.getSpendenbescheinigung() != null)
+          b.getSpendenbescheinigung().delete();
         b.delete();
       }
       else

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -163,6 +163,8 @@ public class SplitbuchungsContainer
       }
       else
       {
+        if (b.getSpendenbescheinigung() != null)
+          b.getSpendenbescheinigung().delete();
         b.delete();
       }
     }

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -36,8 +36,8 @@ import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.db.AbstractDBObject;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.ObjectNotFoundException;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -37,6 +37,7 @@ import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.ObjectNotFoundException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -69,9 +70,29 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   protected void deleteCheck() throws ApplicationException
   {
-    //insertCheck();
+    try
+    {
+      if (this.getSpendenbescheinigung() != null)
+      {
+        throw new ApplicationException(
+            "Buchung kann nicht gelöscht werden weil sie zu eine "
+                + "Spendenbescheinigung gehört");
+      }
+    }
+    catch (ObjectNotFoundException e)
+    {
+      // Alles ok, es gibt keine Spendenbescheinigung
+      // Das passiert wenn sie kurz vorher gelöscht wurde aber 
+      // die ID noch im Cache gespeichert ist
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      throw new ApplicationException(
+          "Buchung kann nicht gelöscht werden. Siehe system log");
+    }
   }
-
+  
   @Override
   protected void insertCheck() throws ApplicationException
   {

--- a/src/de/jost_net/JVerein/server/LastschriftImpl.java
+++ b/src/de/jost_net/JVerein/server/LastschriftImpl.java
@@ -24,7 +24,6 @@ import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mitglied;
-import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.datasource.db.AbstractDBObject;
 
 public class LastschriftImpl extends AbstractDBObject implements Lastschrift


### PR DESCRIPTION
Beim Testen der Spendenbescheinigungen habe ich festgestellt, dass es manchmal zu Exceptions beim Drucken gekommen ist. Das liegt daran, dass bei Geldspendenbescheinigungen auf die zugeordneten Buchungen zugegriffen wird. Sind keine da kommt es zur Exception. Da man Geldspendenbescheinigungen nur mit Buchungen generieren kann sollte das nicht passieren. Allerdings kann man momentan auch Buchungen löschen die einer Spendenbescheinigung zugeordnet sind. Löscht man die also, hat die Geldspendenbescheinigung keine Buchungen mehr und es kommt zur Exception.
Man könnte natürlich die Exception abfangen und keine Spendenbescheinigung generieren. Das wäre aber unsauber weil man dann kaputte Spendenbescheinigungen hat. Auch bei Spendenbescheinigungen mit mehreren Buchungen kann das Löschen einzelner Buchungen zu einer Inkonsistenz führen weil dann die Summe der Geldbeträge über die Buchungen nicht mehr mit dem vescheinigten Betrag übereinstimmt.
Ich habe darum versucht es korrkt zu lösen indem ich bei der Buchung einen delete Check eingeführt habe, der das Löschen einer Buchung mit Spendenbescheinigung verhindert. Das hat aber größere Auswirkungen die ich wie folgt gelöst habe:
- Beim Löschen von Buchungen über das Kontextmenü prüfe ich ob eine der selektierten Buchungen eine Spendenbescheinigung hat. Wenn ja, frage ich ob der User beide löschen will oder nicht. Im ja Fall lösche ich dann die Spendenbescheinigung und die Buchung. Bei Nein wird nichts gelöscht, auch die Buchung nicht. Die Spendenbescheinigung wäre sowieso illegal ohne Buchung.
- Beim DBBereinigen habe ich das Error Handling geändert, so dass bei einem Fehler bei einer Buchung eine entsprechende Meldung ausgegeben wird und trotzden dann weiter gemacht wird. Das habe ich auch bei den anderen jetzt so gemacht. Ich gebe jeweils die Id aus für die ein Fehler passiert ist. Dazu musste ich aber dann bei dem Lastschrift-, Spendenbescheinigung- und Mail View die Spalte "Nr" hinzufügen damit man die Einträge auch später finden kann.
- Da man jetzt evetuell beim Bereinigen Buchungen nicht mehr löschen kann habe ich die Möglichkeit hinzugefügt um Spendenbescheinigungen zu löschen. Wenn man beides macht mit gleichen Datum solle alles durchlaufen weil die Spendenbescheinigungen vor den Buchungen gelöscht werden.
- Buchungen einer Splittbuchungen lassen sich per Kontextmenü nur im Splittbuchung View  löschen. Hier erscheint die gleiche Abfrage wenn eine Spendenbescheinigung zugeordnet ist. Es wird dann beim Speichern der Splittbuchung die Spendenbescheinigung gelöscht.
- Beim Auflösen einer Splittbuchung über das Kontextmenü wird jetzt auch geprüft ob die Splittbuchung eine Buchung hat mit Spendenbescheinigung. Bei Ja wird die Splittbuchung aufgelöst und die Spendenbescheinigungen gelöscht.
- Beim Löschen eines Abrechnungslaufes werden die erzeugten Buchungen mit gelöscht. Ich prüfe auch hier auf vorhandene Spendenbescheinigungen. Stimmt der Benutzen zu, werden diese auch automatisch gelöscht.

Es ist dann doch mehr geworden als ich zuerst dachte. Ich glaube aber ich habe alle Fälle erwischt.