### PR TITLE
Einstellbear machen ob ZIP Mail Anhänge in DB gespeichert werden

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2004,6 +2004,7 @@ public class EinstellungControl extends AbstractControl
       e.setLehrgaenge((Boolean) lehrgaenge.getValue());
       e.setJuristischePersonen((Boolean) juristischepersonen.getValue());
       e.setMitgliedfoto((Boolean) mitgliedfoto.getValue());
+      e.setAnhangSpeichern((Boolean) anhangspeichern.getValue());
       // TODO deaktiviert für Versionsbau
       // e.setInventar((Boolean) inventar.getValue());
       e.setUseLesefelder((Boolean) uselesefelder.getValue());
@@ -2121,7 +2122,6 @@ public class EinstellungControl extends AbstractControl
           .getValue());
       e.setUnterschriftdrucken((Boolean) unterschriftdrucken.getValue());
       e.setUnterschrift((byte[]) unterschrift.getValue());
-      e.setAnhangSpeichern((Boolean) anhangspeichern.getValue());
       e.store();
       Einstellungen.setEinstellung(e);
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -67,6 +67,7 @@ public class EinstellungenAnzeigeView extends AbstractView
     left.addLabelPair("Juristische Personen erlaubt",
         control.getJuristischePersonen());
     left.addLabelPair("Mitgliedsfoto *", control.getMitgliedfoto());
+    left.addLabelPair("Bei Mail Versand von Formularen Anhang in DB speichern", control.getAnhangSpeichern());
     // TODO Für Versionsbau deaktiviert
     // left.addLabelPair("Inventarverwaltung *", control.getInventar());
     SimpleContainer right = new SimpleContainer(cols1.getComposite());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -55,7 +55,6 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
     cont.addLabelPair("Unterschrift drucken",
         control.getUnterschriftdrucken());
     cont.addLabelPair("Unterschrift", control.getUnterschrift());
-    cont.addLabelPair("Spendenbescheinigung Anhang bei Mail Versand in DB speichern", control.getAnhangSpeichern());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/de/jost_net/JVerein/io/ZipMailer.java
@@ -154,9 +154,11 @@ public class ZipMailer
                 me.setMail(ml);
                 me.setVersand(new Timestamp(new Date().getTime()));
                 me.store();
-                
-                ma.setMail(ml);
-                ma.store();
+                if (Einstellungen.getEinstellung().getAnhangSpeichern())
+                {
+                  ma.setMail(ml);
+                  ma.store();
+                }
               }
               catch (SendFailedException e1)
               {


### PR DESCRIPTION
Hier habe ich die Einstellung ob Mailanhänge in der DB gespeichert werden von Einstellungen/Spendenbescheinigung in Einstellungen/Anzeige verschoben und den text geändert. Die Einstellung gilt jetzt auch für per ZIP Mail verschicke Mails