### PR TITLE
Druckmenü Einträge innerhalb Navigation verschoben

### DIFF
--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -134,18 +134,7 @@ public class MyExtension implements Extension
       mitglieder.addChild(new MyItem(mitglieder, "Sollbuchungen",
           new SollbuchungListeAction(), "calculator.png"));
       mitglieder.addChild(new MyItem(mitglieder, "Spendenbescheinigungen",
-          new SpendenbescheinigungListeAction(), "list.png"));      
-      mitglieder.addChild(new MyItem(mitglieder, "Rechnungen",
-          new MitgliedskontoRechnungAction(), "document-print.png"));
-      mitglieder.addChild(new MyItem(mitglieder, "Mahnungen",
-          new MitgliedskontoMahnungAction(), "document-print.png"));
-      mitglieder.addChild(new MyItem(mitglieder, "Kontoauszüge",
-          new KontoauszugAction(), "document-print.png"));
-      mitglieder.addChild(new MyItem(mitglieder, "Freie Formulare",
-          new FreieFormulareAction(), "document-print.png"));
-      mitglieder.addChild(new MyItem(mitglieder, "Spendenbescheinigungen",
-          new SpendenbescheinigungSendAction(), "document-print.png"));
-
+          new SpendenbescheinigungListeAction(), "file-invoice.png"));
       if (Einstellungen.getEinstellung().getZusatzbetrag())
       {
         mitglieder.addChild(new MyItem(mitglieder, "Zusatzbeträge",
@@ -222,7 +211,17 @@ public class MyExtension implements Extension
       jverein.addChild(auswertung);
 
       NavigationItem mail = null;
-      mail = new MyItem(mail, "Mail", null);
+      mail = new MyItem(mail, "Drucken & Mailen", null);
+      mail.addChild(new MyItem(mail, "Rechnungen",
+          new MitgliedskontoRechnungAction(), "document-print.png"));
+      mail.addChild(new MyItem(mail, "Mahnungen",
+          new MitgliedskontoMahnungAction(), "document-print.png"));
+      mail.addChild(new MyItem(mail, "Kontoauszüge",
+          new KontoauszugAction(), "document-print.png"));
+      mail.addChild(new MyItem(mail, "Freie Formulare",
+          new FreieFormulareAction(), "document-print.png"));
+      mail.addChild(new MyItem(mail, "Spendenbescheinigungen",
+          new SpendenbescheinigungSendAction(), "document-print.png"));
       mail.addChild(
           new MyItem(mail, "Mails", new MailListeAction(), "envelope-open.png"));
       mail.addChild(new MyItem(mail, "Mail-Vorlagen", new MailVorlagenAction(),

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -53,8 +53,6 @@ public class DokumentationUtil
   public static final String KURSTEILNEHMER = PRE + FUNKTIONEN + MITGLIEDER + "kursteilnehmer";
 
   public static final String LEHRGANG = PRE + FUNKTIONEN + MITGLIEDER  + "lehrgange";
-
-  public static final String FREIESFORMULAR = PRE + FUNKTIONEN + DRUCKMAIL + "freiesformular";
   
   public static final String MITGLIEDSUCHE = PRE + FUNKTIONEN + MITGLIEDER + "content/mitglieder";
   
@@ -81,7 +79,7 @@ public class DokumentationUtil
       + "zusatzbetrage-importieren";
   
   
-  // BuchfÃ¼hrung
+  // Buchführung
   public static final String ANFANGSBESTAENDE = PRE + FUNKTIONEN + BUCHF + "anfangsbestand";
 
   public static final String BUCHUNGEN = PRE + FUNKTIONEN + BUCHF + "buchungen";
@@ -130,20 +128,22 @@ public class DokumentationUtil
   
 
   // Druck und Mail
-  public static final String KONTOAUSZUG = PRE + FUNKTIONEN + DRUCKMAIL + "kontoauszug";
+  public static final String RECHNUNG = PRE + FUNKTIONEN + DRUCKMAIL + "rechnungen";
 
   public static final String MAHNUNG = PRE + FUNKTIONEN + DRUCKMAIL+ "mahnungen";
 
+  public static final String KONTOAUSZUG = PRE + FUNKTIONEN + DRUCKMAIL + "kontoauszug";
+
+  public static final String FREIESFORMULAR = PRE + FUNKTIONEN + DRUCKMAIL + "freiesformular";
+  
+  public static final String SPENDENBESCHEINIGUNGMAIL = PRE + FUNKTIONEN + DRUCKMAIL 
+      + "spendenbescheinigungen";
+  
+  public static final String PRENOTIFICATION = PRE + FUNKTIONEN + DRUCKMAIL + "pre-notification";
+  
   public static final String MAIL = PRE + FUNKTIONEN + DRUCKMAIL + "mail";
 
   public static final String MAILVORLAGE = PRE + FUNKTIONEN + DRUCKMAIL + "mailvorlagen";
-
-  public static final String PRENOTIFICATION = PRE + FUNKTIONEN + DRUCKMAIL + "pre-notification";
-
-  public static final String RECHNUNG = PRE + FUNKTIONEN + DRUCKMAIL + "rechnungen";
-
-  public static final String SPENDENBESCHEINIGUNGMAIL = PRE + FUNKTIONEN + DRUCKMAIL 
-      + "spendenbescheinigungen";
   
   
   // Einstellungen
@@ -171,7 +171,7 @@ public class DokumentationUtil
   public static final String ADRESSTYPEN = PRE + FUNKTIONEN + ADMIN + ADMMITGLIEDER + "mitgliedstypen";
   
   
-  // Einstellungen BuchfÃ¼hrung
+  // Einstellungen Buchführung
   public static final String BUCHUNGSART = PRE + FUNKTIONEN + ADMIN + ADMBUCHF + "buchungsart.html";
 
   public static final String BUCHUNGSKLASSEN = PRE + FUNKTIONEN + ADMIN + ADMBUCHF + "buchungsklasse";


### PR DESCRIPTION
Wie schon einmal erwähnt schlage ich vor die Einträge für das drucken im Navigationsbaum zu verschieben. Wegen der jetzt vielen Einträge wurde der Mitglied Folder überfüllt. Und im umbenannten Mail Ordner passt es thematisch viel besser. Dann hat der auch etwas mehr.
Bei Spendenbescheinigungen unter Mitglieder habe ich wieder das alte Icon verwendet.

![Bildschirmfoto_20240806_082820](https://github.com/user-attachments/assets/2c2e6105-c2e0-4540-8060-c5b07339ca9e)


PS: Die Pre-Notification packe ich dann demnächst auch noch rein. Meine Idee ist einen Filter zur Auswahl des Abrechnungslaufes in den View zu setzen.