### PR TITLE
Familienangehörige mit Beitrag

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -71,7 +71,6 @@ import de.jost_net.OBanToo.SEPA.Basislastschrift.MandatSequence;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.Zahler;
 import de.jost_net.OBanToo.StringLatin.Zeichen;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.internal.action.Program;
 import de.willuhn.jameica.hbci.HBCIProperties;
@@ -388,11 +387,16 @@ public class AbrechnungSEPA
   {
     Double betr = 0d;
     JVereinZahler zahler = null;
+    Mitglied mZahler = m;
+    if(m.getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
+    {
+      mZahler = Einstellungen.getDBService().createObject(Mitglied.class, m.getZahlerID().toString());
+    }
     if (Einstellungen.getEinstellung()
         .getBeitragsmodel() == Beitragsmodel.FLEXIBEL)
     {
-      if (m.getZahlungstermin() != null
-          && !m.getZahlungstermin().isAbzurechnen(param.abrechnungsmonat))
+      if (mZahler.getZahlungstermin() != null
+          && !mZahler.getZahlungstermin().isAbzurechnen(param.abrechnungsmonat))
       {
         return zahler;
       }
@@ -402,7 +406,7 @@ public class AbrechnungSEPA
     {
       betr = BeitragsUtil.getBeitrag(
           Einstellungen.getEinstellung().getBeitragsmodel(),
-          m.getZahlungstermin(), m.getZahlungsrhythmus().getKey(), bg,
+          mZahler.getZahlungstermin(), mZahler.getZahlungsrhythmus().getKey(), bg,
           param.stichtag, m.getEintritt(), m.getAustritt());
     }
     catch (NullPointerException e)
@@ -422,7 +426,7 @@ public class AbrechnungSEPA
     {
       return zahler;
     }
-    if (!checkSEPA(m, monitor))
+    if (!checkSEPA(mZahler, monitor))
     {
       return zahler;
     }
@@ -439,57 +443,41 @@ public class AbrechnungSEPA
       Logger.error("Fehler bei der Aufbereitung der Variablen", e);
     }
 
-    writeMitgliedskonto(m,
+    writeMitgliedskonto(mZahler,
         param.faelligkeit,
         primaer ? vzweck : bg.getBezeichnung(), betr, abrl,
         m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
         bg.getBuchungsart());
-    if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
+    if (mZahler.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
     {
       try
       {
         zahler = new JVereinZahler();
-        zahler.setPersonId(m.getID());
+        zahler.setPersonId(mZahler.getID());
         zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
         zahler.setBetrag(
             BigDecimal.valueOf(betr).setScale(2, RoundingMode.HALF_UP));
-        new BIC(m.getBic()); // Prüfung des BIC
-        zahler.setBic(m.getBic());
-        new IBAN(m.getIban()); // Prüfung der IBAN
-        zahler.setIban(m.getIban());
-        zahler.setMandatid(m.getMandatID());
-        zahler.setMandatdatum(m.getMandatDatum());
+        new BIC(mZahler.getBic()); // Prüfung des BIC
+        zahler.setBic(mZahler.getBic());
+        new IBAN(mZahler.getIban()); // Prüfung der IBAN
+        zahler.setIban(mZahler.getIban());
+        zahler.setMandatid(mZahler.getMandatID());
+        zahler.setMandatdatum(mZahler.getMandatDatum());
         zahler.setMandatsequence(MandatSequence.RCUR);
         zahler.setFaelligkeit(param.faelligkeit);
-        if (primaer)
+        if (primaer && m.getBeitragsgruppe().getBeitragsArt() != ArtBeitragsart.FAMILIE_ANGEHOERIGER)
         {
-          zahler.setVerwendungszweck(getVerwendungszweck2(m) + " " + vzweck);
+          zahler.setVerwendungszweck(getVerwendungszweck2(mZahler) + " " + vzweck);
         }
         else
         {
           zahler.setVerwendungszweck(bg.getBezeichnung());
         }
-        if (m.getBeitragsgruppe()
-            .getBeitragsArt() == ArtBeitragsart.FAMILIE_ZAHLER)
+        if(m.getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
         {
-          DBIterator<Mitglied> angeh = Einstellungen.getDBService()
-              .createList(Mitglied.class);
-          angeh.addFilter("zahlerid = ?", m.getID());
-          String an = "";
-          int i = 0;
-          while (angeh.hasNext())
-          {
-            Mitglied a = (Mitglied) angeh.next();
-            if (i > 0)
-            {
-              an += ", ";
-            }
-            i++;
-            an += a.getVorname();
-          }
-          zahler.setVerwendungszweck(zahler.getVerwendungszweck() + " " + an);
+          zahler.setVerwendungszweck(zahler.getVerwendungszweck() + " " + m.getVorname());
         }
-        zahler.setName(m.getKontoinhaber(1));
+        zahler.setName(mZahler.getKontoinhaber(1));
       }
       catch (Exception e)
       {
@@ -522,7 +510,12 @@ public class AbrechnungSEPA
         {
           continue;
         }
-        if (!checkSEPA(m, monitor))
+        Mitglied mZahler = m;
+        if(m.getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
+        {
+          mZahler = Einstellungen.getDBService().createObject(Mitglied.class, m.getZahlerID().toString());
+        }
+        if (!checkSEPA(mZahler, monitor))
         {
           continue;
         }
@@ -539,24 +532,24 @@ public class AbrechnungSEPA
         {
           Logger.error("Fehler bei der Aufbereitung der Variablen", e);
         }
-        if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
+        if (mZahler.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
         {
           try
           {
             JVereinZahler zahler = new JVereinZahler();
-            zahler.setPersonId(m.getID());
+            zahler.setPersonId(mZahler.getID());
             zahler.setPersonTyp(JVereinZahlerTyp.MITGLIED);
             zahler.setBetrag(BigDecimal.valueOf(z.getBetrag()).setScale(2,
                 RoundingMode.HALF_UP));
-            new BIC(m.getBic());
-            new IBAN(m.getIban());
-            zahler.setBic(m.getBic());
-            zahler.setIban(m.getIban());
-            zahler.setMandatid(m.getMandatID());
-            zahler.setMandatdatum(m.getMandatDatum());
+            new BIC(mZahler.getBic());
+            new IBAN(mZahler.getIban());
+            zahler.setBic(mZahler.getBic());
+            zahler.setIban(mZahler.getIban());
+            zahler.setMandatid(mZahler.getMandatID());
+            zahler.setMandatdatum(mZahler.getMandatDatum());
             zahler.setMandatsequence(MandatSequence.RCUR);
             zahler.setFaelligkeit(param.faelligkeit);
-            zahler.setName(m.getKontoinhaber(1));
+            zahler.setName(mZahler.getKontoinhaber(1));
             zahler.setVerwendungszweck(vzweck);
             lastschrift.add(zahler);
           }
@@ -598,10 +591,10 @@ public class AbrechnungSEPA
           monitor.log(z.getMitglied().getName() + " " + debString + " " + e);
           throw e;
         }
-        writeMitgliedskonto(m,
+        writeMitgliedskonto(mZahler,
             param.faelligkeit,
             vzweck, z.getBetrag(), abrl,
-            m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
+            mZahler.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
             z.getBuchungsart());
       }
     }

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -72,12 +72,6 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
           {
             throw new ApplicationException("Betrag nicht gültig");
           }
-          if (getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER
-              && getBetrag() != 0)
-          {
-            throw new ApplicationException(
-                "Familien-Angehörige sind beitragsbefreit. Bitte als Betrag 0,00 eingeben.");
-          }
 
           break;
         case FLEXIBEL:
@@ -85,13 +79,6 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
               || getBetragHalbjaehrlich() < 0 || getBetragJaehrlich() < 0)
           {
             throw new ApplicationException("Betrag nicht gültig");
-          }
-          if (getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER
-              && (getBetragMonatlich() != 0 || getBetragVierteljaehrlich() != 0
-                  || getBetragHalbjaehrlich() != 0 || getBetragJaehrlich() != 0))
-          {
-            throw new ApplicationException(
-                "Familien-Angehörige sind beitragsbefreit. Bitte als Betrag 0,00 eingeben.");
           }
 
           break;


### PR DESCRIPTION
Hier habe ich die Möglichkeit geschaffen, dass auch Familienangehörige einen Beitrag zahlen. Bisher konnten sie nur Beitragsfrei sein, da sehe ich nicht den Grund für. Insgesamt habe ich die Frage, warum bei den Beitragsgruppen nach Zahler und Angehöriger unterschieden wird. Könnte man nicht auch für normale Beitragsgruppen andere Mitglieder als Zahler eintragen?
Das hier ist noch keine fertige Umsetzung, ich wollt erst mal eure Meinung dazu hören bevor ich daran weiter arbeite.