### PR TITLE
Hilfe Button für Buchungskorrektur

### DIFF
--- a/src/com/schlevoigt/JVerein/gui/control/BuchungsTextKorrekturControl.java
+++ b/src/com/schlevoigt/JVerein/gui/control/BuchungsTextKorrekturControl.java
@@ -61,7 +61,7 @@ public class BuchungsTextKorrekturControl extends AbstractControl {
 			public void handleAction(Object context) {
 				starteKorrektur();
 			}
-		}, null, true, "import_obj.gif"); // "true" defines this button as the
+		}, null, true, "walking.png"); // "true" defines this button as the
 											// default
 		return b;
 	}

--- a/src/com/schlevoigt/JVerein/gui/view/BuchungsTexteKorrigierenView.java
+++ b/src/com/schlevoigt/JVerein/gui/view/BuchungsTexteKorrigierenView.java
@@ -18,6 +18,8 @@ package com.schlevoigt.JVerein.gui.view;
 
 import com.schlevoigt.JVerein.gui.control.BuchungsTextKorrekturControl;
 
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.view.DokumentationUtil;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -33,6 +35,8 @@ public class BuchungsTexteKorrigierenView extends AbstractView {
 		control.getBuchungsList().paint(this.getParent());
 
 		ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.BUCHUNGSKORREKTUR, false, "question-circle.png");
 		buttons.addButton(control.getStartKorrekturButton());
 		buttons.paint(this.getParent());
 	}

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -91,6 +91,8 @@ public class DokumentationUtil
   public static final String BUCHUNGSUEBERNAHME = PRE + FUNKTIONEN + BUCHF
       + "buchungsubernahme";
 
+  public static final String BUCHUNGSKORREKTUR = PRE + FUNKTIONEN + BUCHF + "buchungskorrektur";
+  
   public static final String JAHRESABSCHLUSS = PRE + FUNKTIONEN + BUCHF + "jahresabschluss";
   
   public static final String KONTEN = PRE + FUNKTIONEN + BUCHF + "konten";


### PR DESCRIPTION
Nachdem ich in unserer Online Help eine Beschreibung der Buchungskorrektur erstellt habe, habe ich den Link auf die Doku in den Buchungskorrektur View eingebaut und bei Korrektur ein vorhandenes Icon gesetzt (gleiches wie bei den Drucken Views, das import_obj.gif gab es ja sowieso nicht).

![Bildschirmfoto_20240808_104220](https://github.com/user-attachments/assets/e014f02a-788e-490c-8bc7-287bb81a0e27)

