### PR TITLE
Fix abgeschlossene splitbuchung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1696,6 +1696,37 @@ public class BuchungsControl extends AbstractControl
     }
     return false;
   }
+  
+  public boolean isSplitBuchungAbgeschlossen() throws ApplicationException
+  {
+    try
+    {
+      if (!getBuchung().isNewObject())
+      {
+        DBIterator<Buchung> it = Einstellungen.getDBService()
+            .createList(Buchung.class);
+        it.addFilter("splitid = ?", getBuchung().getSplitId());
+        while (it.hasNext())
+        {
+          Buchung buchung = (Buchung) it.next();
+          Jahresabschluss ja = buchung.getJahresabschluss();
+          if (ja != null)
+          {
+            GUI.getStatusBar().setErrorText(String.format(
+                "Buchung wurde bereits am %s von %s abgeschlossen.",
+                new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
+            return true;
+          }
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException(
+          "Status der aktuellen Buchung kann nicht geprüft werden.", e);
+    }
+    return false;
+  }
 
   public Action getBuchungSpeichernAction()
   {

--- a/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.InfoPanel;
 
@@ -36,22 +37,31 @@ public class SplitBuchungView extends AbstractView
     GUI.getView().setTitle("Splitbuchungen");
 
     final BuchungsControl control = new BuchungsControl(this);
+    
+    final boolean buchungabgeschlossen = control.isBuchungAbgeschlossen();
+    
     InfoPanel   info = new InfoPanel();
     info.setText(SplitbuchungsContainer.getText());
     info.setTitle("Info");
     info.setIcon("gtk-info.png");
     info.paint(getParent());
     control.getSplitBuchungsList().paint(getParent());
+    
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPLITBUCHUNG, false, "question-circle.png");
-    buttons.addButton("Neu", new SplitbuchungNeuAction(),
+    Button neu = new Button("Neu", new SplitbuchungNeuAction(),
         control.getCurrentObject(), false, "document-new.png");
-    buttons.addButton("Auflösen", new SplitbuchungAufloesenAction(control),
+    neu.setEnabled(!buchungabgeschlossen);
+    buttons.addButton(neu);
+    Button aufloesen = new Button("Auflösen", new SplitbuchungAufloesenAction(control),
         control.getCurrentObject(), false, "unlocked.png");
-    buttons.addButton(control.getSammelueberweisungButton());
-
-    buttons.addButton("Speichern", new Action()
+    aufloesen.setEnabled(!buchungabgeschlossen);
+    buttons.addButton(aufloesen);
+    Button sammel = control.getSammelueberweisungButton();
+    sammel.setEnabled(!buchungabgeschlossen);
+    buttons.addButton(sammel);
+    Button speichern = new Button("Speichern", new Action()
     {
       @Override
       public void handleAction(Object context)
@@ -76,6 +86,8 @@ public class SplitBuchungView extends AbstractView
         }
       }
     }, null, true, "document-save.png");
+    speichern.setEnabled(!buchungabgeschlossen);
+    buttons.addButton(speichern);
     buttons.paint(getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SplitBuchungView.java
@@ -38,7 +38,7 @@ public class SplitBuchungView extends AbstractView
 
     final BuchungsControl control = new BuchungsControl(this);
     
-    final boolean buchungabgeschlossen = control.isBuchungAbgeschlossen();
+    final boolean buchungabgeschlossen = control.isSplitBuchungAbgeschlossen();
     
     InfoPanel   info = new InfoPanel();
     info.setText(SplitbuchungsContainer.getText());

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -124,7 +124,6 @@ public class SplitbuchungsContainer
 
   public static void add(Buchung b) throws RemoteException, ApplicationException
   {
-    b.plausi();
     b.setSpeicherung(false);
     if (!splitbuchungen.contains(b))
     {


### PR DESCRIPTION
In JVerein kann man Dokumente bei den Buchungen speichern. Diese möchte man später auch anschauen können, auch wenn die Buchung schon abgeschlossen ist.
Bei Buchungen geht das. Man kann sie öffnen und bekommt die Meldung, dass die Buchung abgeschlossen ist. Der Speichen Button ist disabled. Die Dokumente kann man anschauen.
Bei Splittbuchungen hat das nicht funktioniert weil beim Aufbau der Splitbuchung plausi() aufgerufen wurde und darum die Meldung kam dass man die Buchung nicht speichern kann. Ich habe diesen plausi() entfernt weil er hier falsch ist. Man könnte so auch nicht mehr Splittbuchungen öffnen wenn sie älter als 10 Jahre sind aber nicht abgeschlossen.
Erzeugt man eine neue Buchung in einer Splitbuchung wird der Check sowieso in Zeile 900 von BuchungsControl gemacht. Es sollte also kein Problem sein.
Die Buttons im Splittbuchung View sind bei abgeschlossenen Splitbuchungen disabled. Man kann die Buchung öffnen und die Dokumente anschauen. 

Der Issue kam vom JVerein Forum Eintrag "Alte Buchungen anschauen"