### PR TITLE
Feature Prenotification im Navigationsbaum

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/PreNotificationAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PreNotificationAction.java
@@ -29,7 +29,7 @@ public class PreNotificationAction implements Action
   public void handleAction(Object context) throws ApplicationException
   {
     if (context != null && (context instanceof Abrechnungslauf ||
-        context instanceof Lastschrift))
+        context instanceof Lastschrift || context instanceof Lastschrift[]))
     {
       GUI.startView(PreNotificationView.class.getName(), context);
     }

--- a/src/de/jost_net/JVerein/gui/action/PreNotificationAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PreNotificationAction.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.gui.view.PreNotificationView;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.Lastschrift;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
@@ -27,14 +28,14 @@ public class PreNotificationAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null)
+    if (context != null && (context instanceof Abrechnungslauf ||
+        context instanceof Lastschrift))
     {
-      throw new ApplicationException("Keinen Abrechnunglauf ausgewählt!");
+      GUI.startView(PreNotificationView.class.getName(), context);
     }
-    if (!(context instanceof Abrechnungslauf))
+    else
     {
-      throw new ApplicationException("Programmfehler! Kein Abrechnunglauf!");
+      GUI.startView(PreNotificationView.class.getName(), null);
     }
-    GUI.startView(PreNotificationView.class.getName(), context);
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -138,7 +138,7 @@ public class DruckMailControl extends FilterControl
       return output;
     }
     Object[] values = new Object[] { EMAIL, PDF1, PDF2 };
-    output = new SelectInput(values, settings.getString("output", PDF1));
+    output = new SelectInput(values, settings.getString(settingsprefix +"output", PDF1));
     output.setName("Ausgabe");
     return output;
   }
@@ -152,7 +152,7 @@ public class DruckMailControl extends FilterControl
     Object[] values = new Object[] { NICHT_EINZELN, EINZELN_NUMMERIERT,
         EINZELN_MITGLIEDSNUMMER, EINZELN_NUMMERIERT_UND_MNR };
     pdfModus = new SelectInput(values,
-        settings.getString("pdfModus", NICHT_EINZELN));
+        settings.getString(settingsprefix +"pdfModus", NICHT_EINZELN));
     pdfModus.setName("PDF als");
     return pdfModus;
   }

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -18,9 +18,9 @@ public class DruckMailControl extends FilterControl
     super(view);
   }
   
-  public static final String EMAIL = "EMail";
+  public static final String EMAIL = "Mail";
 
-  public static final String PDF1 = "PDF (Lastschriften ohne Mailadresse)";
+  public static final String PDF1 = "PDF (Lastschriften ohne Mail Empfänger)";
 
   public static final String PDF2 = "PDF (Alle)";
 

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -36,6 +36,7 @@ import de.jost_net.JVerein.gui.dialogs.EigenschaftenAuswahlParameter;
 import de.jost_net.JVerein.gui.dialogs.ZusatzfelderAuswahlDialog;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
+import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Adresstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Eigenschaft;
@@ -54,6 +55,7 @@ import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
@@ -138,6 +140,10 @@ public class FilterControl extends AbstractControl
   protected DateInput abbuchungsdatumbis = null;
 
   protected TextInput suchtext = null;
+  
+  protected SelectInput abrechnungslaufausw = null;
+  
+  protected IntegerInput integerausw = null;
   
   public enum Mitgliedstyp {
     MITGLIED,
@@ -906,6 +912,61 @@ public class FilterControl extends AbstractControl
     return suchtext != null;
   }
   
+  public SelectInput getAbrechnungslaufAusw(int anzahl) throws RemoteException
+  {
+    if (abrechnungslaufausw != null)
+    {
+      return abrechnungslaufausw;
+    }
+    DBIterator<Abrechnungslauf> list = Einstellungen.getDBService()
+        .createList(Abrechnungslauf.class);
+    list.setOrder("ORDER BY id desc");
+    ArrayList<Abrechnungslauf> liste = null;
+    if (list != null)
+    {
+      liste = new ArrayList<>();
+      int count = 0;
+      while (list.hasNext() && count < anzahl)
+      {
+        liste.add(list.next());
+        count++;
+      }
+    }
+    abrechnungslaufausw = new SelectInput(liste, liste.get(0));
+    abrechnungslaufausw.setName("Abrechnungslauf");
+    abrechnungslaufausw.setAttribute("idtext");
+    return abrechnungslaufausw;
+  }
+  
+  public boolean isAbrechnungslaufAuswAktiv()
+  {
+    return abrechnungslaufausw != null;
+  }
+  
+  public IntegerInput getIntegerAusw()
+  {
+    if (integerausw != null)
+    {
+      return integerausw;
+    }
+    String tmp = settings.getString(settingsprefix + "intergerauswahl", "");
+    if (tmp != null && !tmp.isEmpty())
+    {
+      integerausw = new IntegerInput(Integer.parseInt(tmp));
+    }
+    else
+    {
+      integerausw = new IntegerInput(0);
+    }
+    integerausw.setName("Auswahl");
+    return integerausw;
+  }
+  
+  public boolean isIntegerAuswAktiv()
+  {
+    return integerausw != null;
+  }
+  
   /**
    * Buttons
    */
@@ -1020,6 +1081,8 @@ public class FilterControl extends AbstractControl
           abbuchungsdatumbis.setValue(null);
         if (suchtext != null)
           suchtext.setValue("");
+        if (integerausw != null)
+          integerausw.setValue(0);
         refresh();
       }
     }, null, false, "eraser.png");
@@ -1404,6 +1467,18 @@ public class FilterControl extends AbstractControl
       }
     }
     
+    if (integerausw != null)
+    {
+      Integer tmp = (Integer) integerausw.getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute(settingsprefix + "intergerauswahl", tmp);
+      }
+      else
+      {
+        settings.setAttribute(settingsprefix + "intergerauswahl", "");
+      }
+    }
   }
   
   private void saveDate(Date tmp, String setting)

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -35,6 +35,7 @@ import de.jost_net.JVerein.gui.dialogs.EigenschaftenAuswahlDialog;
 import de.jost_net.JVerein.gui.dialogs.EigenschaftenAuswahlParameter;
 import de.jost_net.JVerein.gui.dialogs.ZusatzfelderAuswahlDialog;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
+import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Adresstyp;
@@ -55,7 +56,6 @@ import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.input.Input;
-import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
@@ -143,7 +143,7 @@ public class FilterControl extends AbstractControl
   
   protected SelectInput abrechnungslaufausw = null;
   
-  protected IntegerInput integerausw = null;
+  protected IntegerNullInput integerausw = null;
   
   public enum Mitgliedstyp {
     MITGLIED,
@@ -943,7 +943,7 @@ public class FilterControl extends AbstractControl
     return abrechnungslaufausw != null;
   }
   
-  public IntegerInput getIntegerAusw()
+  public IntegerNullInput getIntegerAusw()
   {
     if (integerausw != null)
     {
@@ -952,11 +952,11 @@ public class FilterControl extends AbstractControl
     String tmp = settings.getString(settingsprefix + "intergerauswahl", "");
     if (tmp != null && !tmp.isEmpty())
     {
-      integerausw = new IntegerInput(Integer.parseInt(tmp));
+      integerausw = new IntegerNullInput(Integer.parseInt(tmp));
     }
     else
     {
-      integerausw = new IntegerInput(0);
+      integerausw = new IntegerNullInput();
     }
     integerausw.setName("Auswahl");
     return integerausw;
@@ -1082,7 +1082,7 @@ public class FilterControl extends AbstractControl
         if (suchtext != null)
           suchtext.setValue("");
         if (integerausw != null)
-          integerausw.setValue(0);
+          integerausw.setValue(null);
         refresh();
       }
     }, null, false, "eraser.png");

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -54,6 +54,7 @@ public class LastschriftControl extends FilterControl
     }
     lastschriftList = new TablePart(getLastschriften(), null);
     lastschriftList.addColumn("Nr", "id");
+    lastschriftList.addColumn("Abrechnungslauf", "abrechnungslauf");
     lastschriftList.addColumn("Name", "name");
     lastschriftList.addColumn("Vorname", "vorname");
     lastschriftList.addColumn("Zweck", "verwendungszweck");
@@ -149,6 +150,11 @@ public class LastschriftControl extends FilterControl
     {
       lastschriften.addFilter("faelligkeit <= ?",
           new Object[] { (Date) getDatumbis().getValue() });
+    }
+    if (isIntegerAuswAktiv() && getIntegerAusw().getValue() != null)
+    {
+      lastschriften.addFilter("abrechnungslauf >= ?",
+          new Object[] { (Integer) getIntegerAusw().getValue() });
     }
     
     lastschriften.setOrder("ORDER BY name");

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -150,6 +150,7 @@ public class PreNotificationControl extends DruckMailControl
       {
         try
         {
+          saveDruckMailSettings();
           Object object = currentObject;
           if (object == null)
           {
@@ -204,6 +205,7 @@ public class PreNotificationControl extends DruckMailControl
       {
         try
         {
+          saveDruckMailSettings();
           Object object = currentObject;
           if (object == null)
           {
@@ -232,7 +234,7 @@ public class PreNotificationControl extends DruckMailControl
               (String) getVerwendungszweck().getValue());
           settings.setAttribute(settingsprefix + "tab.selection", 
               folder.getSelectionIndex());
-          generiere1ct(currentObject);
+          generiere1ct(object);
         }
         catch (OperationCanceledException oce)
         {

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.rmi.RemoteException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeSet;
@@ -53,7 +54,6 @@ import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.JVDateFormatDATETIME;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -67,13 +67,10 @@ import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
-import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class PreNotificationControl extends AbstractControl
+public class PreNotificationControl extends FilterControl
 {
-
-  private Settings settings = null;
 
   private TabFolder folder = null;
 
@@ -238,6 +235,20 @@ public class PreNotificationControl extends AbstractControl
       {
         try
         {
+          Object object = currentObject;
+          if (object == null)
+          {
+            if (abrechnungslaufausw != null && abrechnungslaufausw.getValue() != null)
+            {
+              object = abrechnungslaufausw.getValue();
+            }
+            else
+            {
+              GUI.getStatusBar().setErrorText(
+                  "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+              return;
+            }
+          }
           String val = (String) getOutput().getValue();
           String pdfMode = (String) getPdfModus().getValue();
 
@@ -250,15 +261,15 @@ public class PreNotificationControl extends AbstractControl
 
           if (val.equals(PDF1))
           {
-            generierePDF(currentObject, false, pdfMode);
+            generierePDF(object, false, pdfMode);
           }
           if (val.equals(PDF2))
           {
-            generierePDF(currentObject, true, pdfMode);
+            generierePDF(object, true, pdfMode);
           }
           if (val.equals(EMAIL))
           {
-            generiereEMail(currentObject);
+            generiereEMail(object);
           }
         }
         catch (Exception e)
@@ -281,6 +292,20 @@ public class PreNotificationControl extends AbstractControl
       {
         try
         {
+          Object object = currentObject;
+          if (object == null)
+          {
+            if (abrechnungslaufausw != null && abrechnungslaufausw.getValue() != null)
+            {
+              object = abrechnungslaufausw.getValue();
+            }
+            else
+            {
+              GUI.getStatusBar().setErrorText(
+                  "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+              return;
+            }
+          }
           Ct1Ausgabe aa = (Ct1Ausgabe) ct1ausgabe.getValue();
           settings.setAttribute("ct1ausgabe", aa.getKey());
           if (ausfuehrungsdatum.getValue() == null)
@@ -294,7 +319,7 @@ public class PreNotificationControl extends AbstractControl
           settings.setAttribute("verwendungszweck",
               (String) getVerwendungszweck().getValue());
           settings.setAttribute("tab.selection", folder.getSelectionIndex());
-          generiere1ct(currentObject);
+          generiere1ct(object);
         }
         catch (OperationCanceledException oce)
         {
@@ -313,6 +338,57 @@ public class PreNotificationControl extends AbstractControl
   private void generierePDF(Object currentObject, boolean mitMail,
       String pdfMode) throws IOException
   {
+    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
+    if (currentObject instanceof Abrechnungslauf)
+    {
+      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+      DBIterator<Lastschrift> it = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", abrl.getID());
+      if (!mitMail)
+      {
+        it.addFilter("(email is null or length(email)=0)");
+      }
+      it.setOrder("order by name, vorname");
+      while (it.hasNext())
+      {
+        lastschriften.add((Lastschrift) it.next());
+      }
+      
+      if (lastschriften.size() == 0 && !mitMail)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Der Abrechnungslauf hat keine Lastschriften ohne Mailadresse");
+        return;
+      }
+      if (lastschriften.size() == 0)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Der Abrechnungslauf hat keine Lastschriften");
+        return;
+      }
+    }
+    else if (currentObject instanceof Lastschrift)
+    {
+      Lastschrift lastschrift = (Lastschrift) currentObject;
+      if (!mitMail && lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
+      {
+        GUI.getStatusBar().setErrorText(
+            "Die ausgewählte Lastschrift hat eine Mail Adresse");
+        return;
+      }
+      else
+      {
+        lastschriften.add(lastschrift);
+      }
+    }
+    else
+    {
+      GUI.getStatusBar().setErrorText(
+          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+      return;
+    }
+    
     boolean einzelnePdfs = false;
     if (pdfMode.equals(EINZELN_NUMMERIERT)
         || pdfMode.equals(EINZELN_MITGLIEDSNUMMER)
@@ -321,7 +397,6 @@ public class PreNotificationControl extends AbstractControl
       einzelnePdfs = true;
     }
 
-    Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
     FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
     fd.setText("Ausgabedatei wählen.");
     String path = settings.getString("lastdir",
@@ -357,23 +432,13 @@ public class PreNotificationControl extends AbstractControl
     {
       fa = new FormularAufbereitung(file);
     }
-    DBIterator<Lastschrift> it = Einstellungen.getDBService()
-        .createList(Lastschrift.class);
-    it.addFilter("abrechnungslauf = ?", abrl.getID());
-    if (!mitMail)
-    {
-      it.addFilter("(email is null or length(email)=0)");
-    }
-    it.setOrder("order by name, vorname");
-
+    
     int dateinummer = 0;
     String postfix = ".pdf";
     String prefix = s.substring(0, s.length() - postfix.length());
 
-    while (it.hasNext())
+    for (Lastschrift ls : lastschriften)
     {
-      Lastschrift ls = (Lastschrift) it.next();
-
       if (einzelnePdfs)
       {
         // schalte Dateinamen um
@@ -410,7 +475,36 @@ public class PreNotificationControl extends AbstractControl
 
   private void generiere1ct(Object currentObject) throws Exception
   {
-    Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
+    if (currentObject instanceof Abrechnungslauf)
+    {
+      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+      DBIterator<Lastschrift> it = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", abrl.getID());
+      it.setOrder("order by name, vorname");
+      while (it.hasNext())
+      {
+        lastschriften.add((Lastschrift) it.next());
+      }
+      if (lastschriften.size() == 0)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Der Abrechnungslauf hat keine Lastschriften");
+        return;
+      }
+    }
+    else if (currentObject instanceof Lastschrift)
+    {
+      lastschriften.add((Lastschrift) currentObject);
+    }
+    else
+    {
+      GUI.getStatusBar().setErrorText(
+          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+      return;
+    }
+
     File file = null;
     Ct1Ausgabe aa = Ct1Ausgabe.getByKey(
         settings.getInt("ct1ausgabe", Ct1Ausgabe.SEPA_DATEI.getKey()));
@@ -447,22 +541,57 @@ public class PreNotificationControl extends AbstractControl
         settings.getInt("ct1ausgabe", Ct1Ausgabe.SEPA_DATEI.getKey()));
     String verwendungszweck = settings.getString("verwendungszweck", "");
     Ct1Ueberweisung ct1ueberweisung = new Ct1Ueberweisung();
-    int anzahl = ct1ueberweisung.write(abrl, file, faell, ct1ausgabe,
+    int anzahl = ct1ueberweisung.write(lastschriften, file, faell, ct1ausgabe,
         verwendungszweck);
     GUI.getStatusBar().setSuccessText("Anzahl Überweisungen: " + anzahl);
   }
 
   private void generiereEMail(Object currentObject) throws IOException
   {
-    Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
-    DBIterator<Lastschrift> it = Einstellungen.getDBService()
-        .createList(Lastschrift.class);
-    it.addFilter("abrechnungslauf = ?", abrl.getID());
-    it.addFilter("email is not null and length(email) > 0");
-    it.setOrder("order by name, vorname");
+    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
+    if (currentObject instanceof Abrechnungslauf)
+    {
+      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+      DBIterator<Lastschrift> it = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", abrl.getID());
+      it.addFilter("email is not null and length(email) > 0");
+      it.setOrder("order by name, vorname");
+      while (it.hasNext())
+      {
+        lastschriften.add((Lastschrift) it.next());
+      }
+      if (lastschriften.size() == 0)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Der Abrechnungslauf hat keine Lastschriften mit Mail Adresse");
+        return;
+      }
+    }
+    else if (currentObject instanceof Lastschrift)
+    {
+      Lastschrift lastschrift = (Lastschrift) currentObject;
+      if (lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
+      {
+        lastschriften.add(lastschrift);
+      }
+      else
+      {
+        GUI.getStatusBar().setErrorText(
+            "Die ausgewählte Lastschrift hat keine Mail Adresse");
+        return;
+      }
+    }
+    else
+    {
+      GUI.getStatusBar().setErrorText(
+          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+      return;
+    }
+
     String betr = (String) getMailSubject().getValue();
     String text = (String) getMailBody().getValue();
-    sendeMail(it, betr, text);
+    sendeMail(lastschriften, betr, text);
   }
 
   private void aufbereitenFormular(Lastschrift ls, Formular fo)
@@ -473,7 +602,7 @@ public class PreNotificationControl extends AbstractControl
     fa.writeForm(fo, map);
   }
 
-  private void sendeMail(final DBIterator<Lastschrift> it, final String betr,
+  private void sendeMail(final ArrayList<Lastschrift> lastschriften, final String betr,
       final String txt) throws RemoteException
   {
 
@@ -505,10 +634,9 @@ public class PreNotificationControl extends AbstractControl
           monitor.setPercentComplete(0);
           int sentCount = 0;
           int zae = 0;
-          int size = it.size();
-          while (it.hasNext())
+          int size = lastschriften.size();
+          for (Lastschrift ls : lastschriften)
           {
-            Lastschrift ls = (Lastschrift) it.next();
             VelocityContext context = new VelocityContext();
             context.put("dateformat", new JVDateFormatTTMMJJJJ());
             context.put("decimalformat", Einstellungen.DECIMALFORMAT);
@@ -566,12 +694,6 @@ public class PreNotificationControl extends AbstractControl
               String.format("Anzahl verschickter Mails: %d", sentCount));
           GUI.getStatusBar().setSuccessText(
               "Mail" + (sentCount > 1 ? "s" : "") + " verschickt");
-          GUI.getCurrentView().reload();
-        }
-        catch (ApplicationException ae)
-        {
-          Logger.error("", ae);
-          monitor.log(ae.getMessage());
         }
         catch (Exception re)
         {

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -286,6 +286,13 @@ public class PreNotificationControl extends DruckMailControl
     else if (currentObject instanceof Lastschrift)
     {
       Lastschrift lastschrift = (Lastschrift) currentObject;
+      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+      if (abrl.getAbgeschlossen())
+      {
+        GUI.getStatusBar().setErrorText(
+            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
+        return;
+      }
       if (!mitMail && lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
       {
         GUI.getStatusBar().setErrorText(
@@ -295,6 +302,31 @@ public class PreNotificationControl extends DruckMailControl
       else
       {
         lastschriften.add(lastschrift);
+      }
+    }
+    else if (currentObject instanceof Lastschrift[])
+    {
+      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
+      for (Lastschrift lastschrift : lastschriftarray)
+      {
+        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+        if (abrl.getAbgeschlossen())
+        {
+          GUI.getStatusBar().setErrorText(
+              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID() 
+              + " ist bereits abgeschlossen");
+          return;
+        }
+        if (!(!mitMail && lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty()))
+        {
+          lastschriften.add(lastschrift);
+        }
+      }
+      if (lastschriften.size() == 0)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Alle ausgewählten Lastschriften haben eine Mail Adresse");
+        return;
       }
     }
     else
@@ -411,7 +443,31 @@ public class PreNotificationControl extends DruckMailControl
     }
     else if (currentObject instanceof Lastschrift)
     {
+      Lastschrift lastschrift = (Lastschrift) currentObject;
+      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+      if (abrl.getAbgeschlossen())
+      {
+        GUI.getStatusBar().setErrorText(
+            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
+        return;
+      }
       lastschriften.add((Lastschrift) currentObject);
+    }
+    else if (currentObject instanceof Lastschrift[])
+    {
+      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
+      for (Lastschrift lastschrift : lastschriftarray)
+      {
+        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+        if (abrl.getAbgeschlossen())
+        {
+          GUI.getStatusBar().setErrorText(
+              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID() 
+              + " ist bereits abgeschlossen");
+          return;
+        }
+        lastschriften.add(lastschrift);
+      }
     }
     else
     {
@@ -487,6 +543,13 @@ public class PreNotificationControl extends DruckMailControl
     else if (currentObject instanceof Lastschrift)
     {
       Lastschrift lastschrift = (Lastschrift) currentObject;
+      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+      if (abrl.getAbgeschlossen())
+      {
+        GUI.getStatusBar().setErrorText(
+            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
+        return;
+      }
       if (lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
       {
         lastschriften.add(lastschrift);
@@ -495,6 +558,31 @@ public class PreNotificationControl extends DruckMailControl
       {
         GUI.getStatusBar().setErrorText(
             "Die ausgewählte Lastschrift hat keine Mail Adresse");
+        return;
+      }
+    }
+    else if (currentObject instanceof Lastschrift[])
+    {
+      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
+      for (Lastschrift lastschrift : lastschriftarray)
+      {
+        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+        if (abrl.getAbgeschlossen())
+        {
+          GUI.getStatusBar().setErrorText(
+              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID() 
+              + " ist bereits abgeschlossen");
+          return;
+        }
+        if (lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
+        {
+          lastschriften.add(lastschrift);
+        }
+      }
+      if (lastschriften.size() == 0)
+      {
+        GUI.getStatusBar().setErrorText(
+            "Keine der ausgewählten Lastschriften hat eine Mail Adresse");
         return;
       }
     }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -888,7 +888,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
           generatePdf((String) art.getValue(),
               (String) adressblatt.getValue(), spbArray);
           if (ausgabeart == null || 
-              (Ausgabeart) ausgabeart.getValue() == Ausgabeart.EMAIL)
+              (Ausgabeart) ausgabeart.getValue() == Ausgabeart.MAIL)
           {
             sendeMail((String) mailbetreff.getValue(),
                 (String) mailtext.getValue(), spbArray);

--- a/src/de/jost_net/JVerein/gui/input/IntegerNullInput.java
+++ b/src/de/jost_net/JVerein/gui/input/IntegerNullInput.java
@@ -1,0 +1,81 @@
+package de.jost_net.JVerein.gui.input;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.logging.Logger;
+
+public class IntegerNullInput extends TextInput
+{
+
+  /**
+   * ct.
+   * Parameterloser Konstruktor fuer ein Eingabefeld ohne Wert-Vorbelegung.
+   * BUGZILLA 1275
+   */
+  public IntegerNullInput()
+  {
+    super("");
+  }
+  
+  /**
+   * Erzeugt ein neues Eingabefeld und schreibt den uebergebenen Wert rein.
+   * @param value anzuzeigender Wert.
+   */
+  public IntegerNullInput(int value)
+  {
+    super(value < 0 ? "" : "" +value);
+  }
+  
+  @Override
+  public Control getControl()
+  {
+    Control c = super.getControl();
+    text.addListener (SWT.Verify, new Listener() {
+      public void handleEvent (Event e) {
+        char[] chars = e.text.toCharArray();
+        for (int i=0; i<chars.length; i++) {
+          if (!('0' <= chars[i] && chars[i] <= '9')) {
+            e.doit = false;
+            return;
+          }
+        }
+      }
+     });
+    return c;
+  }
+
+  /**
+   * Die Funktion liefert ein Objekt des Typs {@link java.lang.Integer} zurueck
+   * oder {@code null} wenn nichts eingegeben wurde.
+   */
+  @Override
+  public Object getValue()
+  {
+    Object value = super.getValue();
+    if (value == null || value.toString().length() == 0)
+      return null;
+    try {
+      return Integer.valueOf(value.toString());
+    }
+    catch (NumberFormatException e)
+    {
+      Logger.error("error while parsing from int input",e);
+    }
+    return null;
+  }
+  
+  /**
+   * Erwartet ein Objekt des Typs {@link java.lang.Integer}.
+   */
+  @Override
+  public void setValue(Object value)
+  {
+    if (value == null || (value instanceof Integer))
+      super.setValue(value);
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
@@ -16,13 +16,8 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.menu;
 
-import java.rmi.RemoteException;
-
 import de.jost_net.JVerein.gui.action.LastschriftDeleteAction;
 import de.jost_net.JVerein.gui.action.PreNotificationAction;
-import de.jost_net.JVerein.rmi.Abrechnungslauf;
-import de.jost_net.JVerein.rmi.Lastschrift;
-import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
 
@@ -37,43 +32,9 @@ public class LastschriftMenu extends ContextMenu
    */
   public LastschriftMenu()
   {
-    addItem(new AbgeschlossenDisabledItem("Pre-Notification",
+    addItem(new CheckedContextMenuItem("Pre-Notification",
         new PreNotificationAction(), "document-new.png"));
     addItem(new CheckedContextMenuItem("Löschen...", new LastschriftDeleteAction(),
         "user-trash-full.png"));
-  }
-  
-  private static class AbgeschlossenDisabledItem extends CheckedContextMenuItem
-  {
-
-    private AbgeschlossenDisabledItem(String text, Action action, String icon)
-    {
-      super(text, action, icon);
-    }
-
-    @Override
-    public boolean isEnabledFor(Object o)
-    {
-      if (o instanceof Lastschrift)
-      {
-        try
-        {
-          Abrechnungslauf abrl = (Abrechnungslauf) ((Lastschrift) o).getAbrechnungslauf();
-          if (abrl.getAbgeschlossen())
-          {
-            return false;
-          }
-          else
-          {
-            return true;
-          }
-        }
-        catch (RemoteException e)
-        {
-          return false;
-        }
-      }
-      return false;
-    }
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LastschriftMenu.java
@@ -16,7 +16,13 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.menu;
 
+import java.rmi.RemoteException;
+
 import de.jost_net.JVerein.gui.action.LastschriftDeleteAction;
+import de.jost_net.JVerein.gui.action.PreNotificationAction;
+import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.Lastschrift;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
 
@@ -31,7 +37,43 @@ public class LastschriftMenu extends ContextMenu
    */
   public LastschriftMenu()
   {
+    addItem(new AbgeschlossenDisabledItem("Pre-Notification",
+        new PreNotificationAction(), "document-new.png"));
     addItem(new CheckedContextMenuItem("Löschen...", new LastschriftDeleteAction(),
         "user-trash-full.png"));
+  }
+  
+  private static class AbgeschlossenDisabledItem extends CheckedContextMenuItem
+  {
+
+    private AbgeschlossenDisabledItem(String text, Action action, String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      if (o instanceof Lastschrift)
+      {
+        try
+        {
+          Abrechnungslauf abrl = (Abrechnungslauf) ((Lastschrift) o).getAbrechnungslauf();
+          if (abrl.getAbgeschlossen())
+          {
+            return false;
+          }
+          else
+          {
+            return true;
+          }
+        }
+        catch (RemoteException e)
+        {
+          return false;
+        }
+      }
+      return false;
+    }
   }
 }

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -212,7 +212,7 @@ public class MyExtension implements Extension
       jverein.addChild(auswertung);
 
       NavigationItem mail = null;
-      mail = new MyItem(mail, "Drucken & Mailen", null);
+      mail = new MyItem(mail, "Druck & Mail", null);
       mail.addChild(new MyItem(mail, "Rechnungen",
           new MitgliedskontoRechnungAction(), "document-print.png"));
       mail.addChild(new MyItem(mail, "Mahnungen",

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -34,6 +34,7 @@ import de.jost_net.JVerein.gui.action.AdministrationEinstellungenRechnungenActio
 import de.jost_net.JVerein.gui.action.AdministrationEinstellungenSpendenbescheinigungenAction;
 import de.jost_net.JVerein.gui.action.AdministrationEinstellungenStatistikAction;
 import de.jost_net.JVerein.gui.action.NichtMitgliedSucheAction;
+import de.jost_net.JVerein.gui.action.PreNotificationAction;
 import de.jost_net.JVerein.gui.action.MitgliedstypListAction;
 import de.jost_net.JVerein.gui.action.AnfangsbestandListAction;
 import de.jost_net.JVerein.gui.action.ArbeitseinsatzUeberpruefungAction;
@@ -220,6 +221,8 @@ public class MyExtension implements Extension
           new KontoauszugAction(), "document-print.png"));
       mail.addChild(new MyItem(mail, "Freie Formulare",
           new FreieFormulareAction(), "document-print.png"));
+      mail.addChild(new MyItem(mail, "Pre-Notification",
+          new PreNotificationAction(), "document-print.png"));
       mail.addChild(new MyItem(mail, "Spendenbescheinigungen",
           new SpendenbescheinigungSendAction(), "document-print.png"));
       mail.addChild(

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -46,6 +46,7 @@ public class LastschriftListeView extends AbstractView
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addLabelPair("Fälligkeit von", control.getDatumvon());
     right.addLabelPair("Fälligkeit bis", control.getDatumbis());
+    right.addLabelPair("Abrechnungslauf ab", control.getIntegerAusw());
     
     ButtonArea fbuttons = new ButtonArea();
     fbuttons.addButton(control.getResetButton());

--- a/src/de/jost_net/JVerein/gui/view/PreNotificationView.java
+++ b/src/de/jost_net/JVerein/gui/view/PreNotificationView.java
@@ -28,6 +28,7 @@ import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.TabGroup;
+import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class PreNotificationView extends AbstractView
@@ -40,6 +41,12 @@ public class PreNotificationView extends AbstractView
 
     final PreNotificationControl control = new PreNotificationControl(this);
 
+    if (this.getCurrentObject() == null)
+    {
+      LabelGroup group = new LabelGroup(getParent(), "Filter");
+      group.addInput(control.getAbrechnungslaufAusw(10));
+    }
+    
     TabFolder folder = control.getFolder(getParent());
     folder.setLayoutData(new GridData(GridData.FILL_BOTH));
 

--- a/src/de/jost_net/JVerein/io/AbstractMitgliedskontoDokument.java
+++ b/src/de/jost_net/JVerein/io/AbstractMitgliedskontoDokument.java
@@ -72,7 +72,7 @@ public abstract class AbstractMitgliedskontoDokument
         file = getDateiAuswahl("pdf");
         formularaufbereitung = new FormularAufbereitung(file);
         break;
-      case EMAIL:
+      case MAIL:
         file = getDateiAuswahl("zip");
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
@@ -88,7 +88,7 @@ public abstract class AbstractMitgliedskontoDokument
         case DRUCK:
           aufbereitenFormular(mk, formularaufbereitung, formular);
           break;
-        case EMAIL:
+        case MAIL:
           File f = File.createTempFile(getDateiname(mk), ".pdf");
           formularaufbereitung = new FormularAufbereitung(f);
           aufbereitenFormular(mk, formularaufbereitung, formular);
@@ -111,7 +111,7 @@ public abstract class AbstractMitgliedskontoDokument
       case DRUCK:
         formularaufbereitung.showFormular();
         break;
-      case EMAIL:
+      case MAIL:
         zos.close();
         new ZipMailer(file, (String) control.getBetreff().getValue(),
             (String) control.getTxt().getValue(), typ.name() + ".pdf");

--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -57,7 +57,7 @@ public class FreiesFormularAusgabe
         file = getDateiAuswahl("pdf", formular.getBezeichnung());
         formularaufbereitung = new FormularAufbereitung(file);
         break;
-      case EMAIL:
+      case MAIL:
         file = getDateiAuswahl("zip", formular.getBezeichnung());
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
@@ -88,7 +88,7 @@ public class FreiesFormularAusgabe
         case DRUCK:
           aufbereitenFormular(m, formularaufbereitung, formular);
           break;
-        case EMAIL:
+        case MAIL:
           if (m.getEmail() == null || m.getEmail().isEmpty())
           {
             continue;
@@ -115,7 +115,7 @@ public class FreiesFormularAusgabe
       case DRUCK:
         formularaufbereitung.showFormular();
         break;
-      case EMAIL:
+      case MAIL:
         zos.close();
         new ZipMailer(file, (String) control.getBetreff().getValue(),
             (String) control.getTxt().getValue(),

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -123,7 +123,7 @@ public class Kontoauszug
         rpt.close();
         zeigeDokument();
         break;
-      case EMAIL:
+      case MAIL:
         init("zip");
         if (file == null)
         {

--- a/src/de/jost_net/JVerein/keys/Ausgabeart.java
+++ b/src/de/jost_net/JVerein/keys/Ausgabeart.java
@@ -18,5 +18,5 @@ package de.jost_net.JVerein.keys;
 
 public enum Ausgabeart
 {
-  DRUCK, EMAIL;
+  DRUCK, MAIL;
 }


### PR DESCRIPTION
Ich habe jetzt auch die Pre-Notification in den Navigationsbaum eingebaut. So findet man die Pre-Notification leichter und es passt auch zum Rest.
Tree:
![Bildschirmfoto_20240809_092140](https://github.com/user-attachments/assets/a0a80995-f45d-4c5d-a51e-e88434f67bbe)
Den zugehörigen Abrechnungslauf wählt man in diesem Fall im Pre-Notification View aus:
![Bildschirmfoto_20240809_092154](https://github.com/user-attachments/assets/b553821b-5d71-4a22-8d74-6e6c52721857)
Der Filter bietet maximal die letzten 10 Abrechnungsläufe an. Das sollte reichen, sonst könnte der Dialog über den Bildschirm hinaus reichen.

Beim Testen habe ich festgestellt, dass es sinnvoll ist im Lastschriften View auch den Abrechnungslauf in der Tabelle zu haben. So sieht man besser wie viele Pre-Notifications zu einem Abrechnungslauf generiert werden. Ich habe dann in das leere Filter Feld auch einen Filter für Abrechnungslauf eingefügt.
![Bildschirmfoto_20240809_093016](https://github.com/user-attachments/assets/73c55859-5d13-48b1-bf40-35d68201d290)

Dann habe ich auch noch Pre-Notification in das Menü bei der Lastschrift aufgenommen. Das ist möglicherweise sinnvoll. Bei wiederkehrenden Lastschriften muß man die Pre-Notification nur das erste Mal schicken. Hat das Mitglied eine Mail schicke ich das jedes Mal. Bei Mitgliedern ohne Mail schicke ich den Brief nur einmal. Bei neu eingetretenen Mitgliedern kann man dann hier diese erste Pre-Notification drucken und erhält nicht alle.

PS: Ich mache auch die Konsistenzchecks am Anfang. so kann ich eine spezifische Fehlermeldung ausgeben und der File Dialog erscheint nur wenn auch alles klappt.