### PR TITLE
Fix individueller Beitrag

### DIFF
--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -180,8 +180,15 @@ public class MitgliedMap
         VarTools.maskieren(m.getIban()));
     map.put(MitgliedVar.IBAN.getName(), m.getIban());
     map.put(MitgliedVar.ID.getName(), m.getID());
+    if (m.getIndividuellerBeitrag() != null)
+    {
     map.put(MitgliedVar.INDIVIDUELLERBEITRAG.getName(),
         Einstellungen.DECIMALFORMAT.format(m.getIndividuellerBeitrag()));
+    }
+    else
+    {
+      map.put(MitgliedVar.INDIVIDUELLERBEITRAG.getName(), null);
+    }
     map.put(MitgliedVar.BANKNAME.getName(), getBankname(m));
     map.put(MitgliedVar.KONTOINHABER_ADRESSIERUNGSZUSATZ.getName(),
         m.getKtoiAdressierungszusatz());

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -310,7 +310,7 @@ public class PersonalbogenAction implements Action
       if (Einstellungen.getEinstellung().getIndividuelleBeitraege())
       {
         rpt.addColumn("Individueller Beitrag", Element.ALIGN_LEFT);
-        if (m.getIndividuellerBeitrag() > 0)
+        if (m.getIndividuellerBeitrag() != null)
         {
           rpt.addColumn(
               Einstellungen.DECIMALFORMAT.format(m.getIndividuellerBeitrag())

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1193,7 +1193,7 @@ public class MitgliedControl extends FilterControl
     }
     individuellerbeitrag = new DecimalInput(
         getMitglied().getIndividuellerBeitrag(), Einstellungen.DECIMALFORMAT);
-    individuellerbeitrag.setName("individueller Beitrag");
+    individuellerbeitrag.setName("Individueller Beitrag");
     return individuellerbeitrag;
   }
 

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -71,7 +71,6 @@ import de.jost_net.OBanToo.SEPA.Basislastschrift.MandatSequence;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.Zahler;
 import de.jost_net.OBanToo.StringLatin.Zeichen;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.internal.action.Program;
 import de.willuhn.jameica.hbci.HBCIProperties;
@@ -413,7 +412,7 @@ public class AbrechnungSEPA
     if (primaer)
     {
       if (Einstellungen.getEinstellung().getIndividuelleBeitraege()
-          && m.getIndividuellerBeitrag() > 0)
+          && m.getIndividuellerBeitrag() != null && m.getIndividuellerBeitrag() > 0)
       {
         betr = m.getIndividuellerBeitrag();
       }

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -1047,12 +1047,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   @Override
   public Double getIndividuellerBeitrag() throws RemoteException
   {
-    Double d = (Double) getAttribute("individuellerbeitrag");
-    if (d == null)
-    {
-      return Double.valueOf(0);
-    }
-    return d;
+    return (Double) getAttribute("individuellerbeitrag");
   }
 
   @Override


### PR DESCRIPTION
Das Handling des individuellen Beitrags am GUI bei Mitgliedern war etwas verwirrend. Sind individuelle Beiträge aktiv wird auch bei nicht gesetzten Werten eine 0.0 am GUI angezeigt. Sonst überall lassen wir dann das Feld leer.
Hier vermutet mann, dass eine 0.0 gesetzt wurde was nicht der Fall ist. Dieses Thema wurde auch schon im JVerein Forum beanstandet.
Die Änderungen sind jetzt:
- Das GUI beim Mitglied zeigt bei "Individueller Beitrag" jetzt an was gesetzt ist, also entweder nichts wenn nichts gesetzt ist oder die 0,00 wenn sie so gestzt wurde.
- Im Personalbogen gilt das gleiche, entweder nichts oder die 0,00 wenn explizit gesetzt.
- Das i in "Individueller Beitrag" habe ich auf Gross Schrift geändert