### PR TITLE
Fix Zusatzfelder

### DIFF
--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -31,10 +31,8 @@ import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Eigenschaft;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
-import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.logging.Logger;
@@ -79,14 +77,8 @@ public class MitgliedQuery
     sql += "from mitglied ";
     Settings settings = control.getSettings();
     char synonym = 'a';
-    DBIterator<Felddefinition> fdit = Einstellungen.getDBService()
-        .createList(Felddefinition.class);
     if (control.isZusatzfelderAuswahlAktiv())
     {
-      if (settings.getInt(zusatzfelder + "selected", 0) > fdit.size())
-      {
-        settings.setAttribute(zusatzfelder + "selected", 0);
-      }
       if (settings.getInt(zusatzfelder + "selected", 0) > 0)
       {
         for (int i = 1; i <= settings.getInt(zusatzfelder + "counter", 0); i++)
@@ -138,10 +130,14 @@ public class MitgliedQuery
           }
           case Datentyp.GANZZAHL:
           {
-            int value = settings.getInt(zusatzfeld + i + ".value",
-                Integer.MIN_VALUE);
+            Integer value = null;
+            String tmp = settings.getString(zusatzfeld + i + ".value", "");
+            if (tmp != null && !tmp.isEmpty())
+            {
+              value = Integer.parseInt(tmp);
+            }
             String cond = settings.getString(zusatzfeld + i + ".cond", null);
-            if (value != Integer.MIN_VALUE)
+            if (value != null)
             {
               sql += "join zusatzfelder " + synonym + " on " + synonym
                   + ".mitglied = mitglied.id  and " + synonym + ".FELDGANZZAHL "

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -51,6 +51,7 @@ import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.gui.input.IBANInput;
+import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.menu.ArbeitseinsatzMenu;
 import de.jost_net.JVerein.gui.menu.FamilienbeitragMenu;
@@ -120,7 +121,6 @@ import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.FileInput;
 import de.willuhn.jameica.gui.input.ImageInput;
 import de.willuhn.jameica.gui.input.Input;
-import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.SpinnerInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
@@ -1514,9 +1514,12 @@ public class MitgliedControl extends FilterControl
         case Datentyp.GANZZAHL:
           if (zf.getFeldGanzzahl() == null)
           {
-            zf.setFeldGanzzahl(0);
+            zusatzfelder[i] = new IntegerNullInput();
           }
-          zusatzfelder[i] = new IntegerInput(zf.getFeldGanzzahl());
+          else
+          {
+            zusatzfelder[i] = new IntegerNullInput(zf.getFeldGanzzahl());
+          }
           break;
         case Datentyp.WAEHRUNG:
           zusatzfelder[i] = new DecimalInput(zf.getFeldWaehrung(),
@@ -2407,7 +2410,14 @@ public class MitgliedControl extends FilterControl
               zf.setFeldDatum((Date) ti.getValue());
               break;
             case Datentyp.GANZZAHL:
-              zf.setFeldGanzzahl((Integer) ti.getValue());
+              if (ti.getValue() != null)
+              {
+                zf.setFeldGanzzahl((Integer) ti.getValue());
+              }
+              else
+              {
+                zf.setFeldGanzzahl(null);
+              }
               break;
             case Datentyp.WAEHRUNG:
               if (ti.getValue() != null)

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzfelderAuswahlDialog.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -85,7 +86,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(input);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              input.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", "LIKE");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -103,7 +104,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(inputvon);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputvon.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", ">=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -128,7 +129,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(inputbis);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputbis.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", "<=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -150,35 +151,49 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
         }
         case Datentyp.GANZZAHL:
         {
-          IntegerInput inputvon = new IntegerInput(-1);
+          IntegerNullInput inputvon = new IntegerNullInput();
           inputvon.setName(fd.getLabel() + " von");
           felder.add(inputvon);
           group.addInput(inputvon);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputvon.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", ">=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
           settings.setAttribute(zusatzfeld + counter + ".definition",
               fd.getID());
-          inputvon.setValue(
-              settings.getInt(zusatzfeld + counter + ".value", -1));
+          String tmp = settings.getString(zusatzfeld + counter + ".value", "");
+          if (tmp != null && !tmp.isEmpty())
+          {
+            inputvon.setValue(Integer.parseInt(tmp));
+          }
+          else
+          {
+            inputvon.setValue(null);
+          }
 
-          IntegerInput inputbis = new IntegerInput(-1);
+          IntegerNullInput inputbis = new IntegerNullInput();
           inputbis.setName(fd.getLabel() + " bis");
           felder.add(inputbis);
           group.addInput(inputbis);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputbis.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", "<=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
           settings.setAttribute(zusatzfeld + counter + ".definition",
               fd.getID());
-          inputbis.setValue(
-              settings.getInt(zusatzfeld + counter + ".value", -1));
+          tmp = settings.getString(zusatzfeld + counter + ".value", "");
+          if (tmp != null && !tmp.isEmpty())
+          {
+            inputbis.setValue(Integer.parseInt(tmp));
+          }
+          else
+          {
+            inputbis.setValue(null);
+          }
           break;
         }
         case Datentyp.JANEIN:
@@ -189,7 +204,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(input);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              input.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", "=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -207,7 +222,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(inputvon);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputvon.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", ">=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -235,7 +250,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
           group.addInput(inputbis);
           counter++;
           settings.setAttribute(zusatzfeld + counter + ".name",
-              fd.getName());
+              inputbis.getName());
           settings.setAttribute(zusatzfeld + counter + ".cond", "<=");
           settings.setAttribute(zusatzfeld + counter + ".datentyp",
               fd.getDatentyp());
@@ -298,8 +313,7 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
               }
               else
               {
-                String s = null;
-                settings.setAttribute(zusatzfeld + counter + ".value", s);
+                settings.setAttribute(zusatzfeld + counter + ".value", "");
               }
               break;
             }
@@ -372,9 +386,9 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
             }
             case Datentyp.GANZZAHL:
             {
-              settings.setAttribute(zusatzfeld + counter + ".value", -1);
+              settings.setAttribute(zusatzfeld + counter + ".value", "");
               counter++;
-              settings.setAttribute(zusatzfeld + counter + ".value", -1);
+              settings.setAttribute(zusatzfeld + counter + ".value", "");
               break;
             }
             case Datentyp.JANEIN:
@@ -407,8 +421,8 @@ public class ZusatzfelderAuswahlDialog extends AbstractDialog<Object>
         }
         else if (f instanceof IntegerInput)
         {
-          settings.setAttribute(zusatzfeld + counter + ".value", -1);
-          f.setValue(-1);
+          settings.setAttribute(zusatzfeld + counter + ".value", "");
+          f.setValue(null);
         }
         else if (f instanceof DecimalInput)
         {

--- a/src/de/jost_net/JVerein/gui/input/IntegerNullInput.java
+++ b/src/de/jost_net/JVerein/gui/input/IntegerNullInput.java
@@ -1,0 +1,81 @@
+package de.jost_net.JVerein.gui.input;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.logging.Logger;
+
+public class IntegerNullInput extends TextInput
+{
+
+  /**
+   * ct.
+   * Parameterloser Konstruktor fuer ein Eingabefeld ohne Wert-Vorbelegung.
+   * BUGZILLA 1275
+   */
+  public IntegerNullInput()
+  {
+    super("");
+  }
+  
+  /**
+   * Erzeugt ein neues Eingabefeld und schreibt den uebergebenen Wert rein.
+   * @param value anzuzeigender Wert.
+   */
+  public IntegerNullInput(int value)
+  {
+    super(value < 0 ? "" : "" +value);
+  }
+  
+  @Override
+  public Control getControl()
+  {
+    Control c = super.getControl();
+    text.addListener (SWT.Verify, new Listener() {
+      public void handleEvent (Event e) {
+        char[] chars = e.text.toCharArray();
+        for (int i=0; i<chars.length; i++) {
+          if (!('0' <= chars[i] && chars[i] <= '9')) {
+            e.doit = false;
+            return;
+          }
+        }
+      }
+     });
+    return c;
+  }
+
+  /**
+   * Die Funktion liefert ein Objekt des Typs {@link java.lang.Integer} zurueck
+   * oder {@code null} wenn nichts eingegeben wurde.
+   */
+  @Override
+  public Object getValue()
+  {
+    Object value = super.getValue();
+    if (value == null || value.toString().length() == 0)
+      return null;
+    try {
+      return Integer.valueOf(value.toString());
+    }
+    catch (NumberFormatException e)
+    {
+      Logger.error("error while parsing from int input",e);
+    }
+    return null;
+  }
+  
+  /**
+   * Erwartet ein Objekt des Typs {@link java.lang.Integer}.
+   */
+  @Override
+  public void setValue(Object value)
+  {
+    if (value == null || (value instanceof Integer))
+      super.setValue(value);
+  }
+
+}


### PR DESCRIPTION
Ich habe einige Fehler bezüglich der Zusatzfelder gefixed die mir schon früher aufgefallen sind. Dabei habe ich gesehen, dass ich in #290 den IntegerNullInput nicht gebraucht hätte. Man kann mit -1 in den Settings auch das IntegerInput Feld auf null setzen. Allerdings brauche ich es hier für den Fix.
Es gab mehrere Fehler zu korrigieren:
- Im Mitglieder Tab für Zusatzfelder wurde bei Integer Inputs beim Speichern eine 0 gespeichert wenn nichts gezetzt war (null war). Man konnte die 0 auch nicht löschen. Hatte man schon Mitglieder bevor man das Integer Zusatzfeld erzeugt hat, dann hatten die den Wert null und es wurde nichts angezeigt in der Tabelle. Nur wenn man das Mitglied editiert hat wurde der Wert auf 0 gesetzt. Darum gab es eine Mix aus null und 0. Ich lasse jetzt beim Speichern den Wert null.
- MitgliedQuery hat geprüft ob die Anzahl der selektierten Einträge größer ist als die Anzahl der Zusatzfelder Definitionen. Dann wird die Anzahl auf 0 gesetzt. Das ist aber falsch. Bei Integer, Datum etc. sind im Dialog je zwei Einträge für von und bis. Also kann die Anzahl der selektierten Einträge auch großer sein. Ich habe den Check entfernt.
- In der Parameter Liste der PDF Reports bei Auswertung Mitglieder werden alle gesetzten Parameter ausgegeben und dabei auf null und false geprüft. Nicht gesetzte Inter Werte wurden mit -1 in den Settings gespeichert. Das ist nicht null und darum werden sie mit dem Wert -1 in den Parametern aufgeführt obwohl sie da nicht hingehören. Ich dachte schon ich ignoriere auch die "-1" allerdings könnte man ja in einem Textfeld -1 eintragen. Das würde dann auch ignoriert. Darum habe ich hier nun den IntegerNullInput genommen und setzte auch bei Integer bei null den Wert in den Settings auf "" so wie auch bei Datum etc.
- In der Parameter Liste wurde bei den Parameter Namen der name ausgegeben und nicht das Label wie am GUI. Das war unschön, schon wegen der Kleinschrift. Ich nehme jetzt das Label.
- Dann gab es das Problem, dass die von und bis Einträge den gleichen Namen hatten. Das führte in der params Map dazu, dass der bis Eintrag den von Eintrag überschrieben hat. Es war dann im Report nur ein Eintrag und man wusste auch nicht ob es der von oder bis Eintrag ist. Ich speichere in den Settings jetzt nicht nur das Label aus der Felddefinition sondern das GUI Label mit dem von und bis. Damit ist der Key unterschiedlich und man sieht auch ob der angezeigte Wert der von oder bis Wert ist.