### PR TITLE
Fix Buchung Duplizieren

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.view.BuchungView;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.willuhn.jameica.gui.Action;
@@ -32,12 +33,25 @@ public class BuchungDuplizierenAction implements Action
     {
       throw new ApplicationException("keine Buchung ausgewählt");
     }
-    Buchung b = null;
+    Buchung b = (Buchung) context;
     try
     {
-      b = (Buchung) context;
-      b.setID(null);
-      GUI.startView(new BuchungView(), b);
+      Buchung bu = (Buchung) Einstellungen.getDBService().createObject(Buchung.class,
+          null);
+      bu.setKonto(b.getKonto());
+      bu.setName(b.getName());
+      bu.setIban(b.getIban());
+      bu.setBetrag(b.getBetrag());
+      bu.setZweck(b.getZweck());
+      bu.setDatum(b.getDatum());
+      bu.setArt(b.getArt());
+      bu.setKommentar(b.getKommentar());
+      if (b.getBuchungsart() != null)
+        bu.setBuchungsart(b.getBuchungsartId());
+      if (b.getProjekt() != null)
+        bu.setProjektID(b.getProjektID());
+      bu.setVerzicht(b.getVerzicht());
+      GUI.startView(new BuchungView(), bu);
     }
     catch (Exception e)
     {

--- a/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
@@ -50,6 +50,8 @@ public class BuchungDuplizierenAction implements Action
         bu.setBuchungsart(b.getBuchungsartId());
       if (b.getProjekt() != null)
         bu.setProjektID(b.getProjektID());
+      bu.setAuszugsnummer(b.getAuszugsnummer());
+      bu.setBlattnummer(b.getBlattnummer());
       bu.setVerzicht(b.getVerzicht());
       GUI.startView(new BuchungView(), bu);
     }


### PR DESCRIPTION
Ich hatte gerade einen bösen Fehler entdeckt. Ich hatte letztes Jahr Spendenbescheinigungen erstellt und plötzlich war eine Buchung aus diesem Jahr einer Spendenbescheinigung aus dem letzen Jahr zugeordnet.
Das Problem war, dass ich die Buchung aus dem letzen Jahr dupliziert habe und neu gespeichert. Das führte dazu, dass auch die Referenz auf die Spendenbescheinigung mit kopiert wurde. Im Prinzip wurden außer der Id alle versteckten Attribute mit dupliziert.
Ich habe das geändert und erzeuge eine neue Buchung und kopiere die Daten rein die man dann im Dialog auch sieht und anpassen kann. 