### PR TITLE
Keine Fehlermeldung bei AnfangsbestandNeu Dialog Abbruch

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/AnfangsbestandNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AnfangsbestandNeuAction.java
@@ -54,8 +54,6 @@ public class AnfangsbestandNeuAction implements Action
           context = d.open();
           if (context == null)
           {
-            GUI.getStatusBar().setErrorText(
-                "Kein Konto ausgewählt. Vorgang abgebrochen.");
             return;
           }
           k = (Konto) context;
@@ -63,8 +61,7 @@ public class AnfangsbestandNeuAction implements Action
         }
         catch (OperationCanceledException oce)
         {
-          GUI.getStatusBar().setErrorText("Vorgang abgebrochen");
-          return;
+          throw oce;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Wird der Kontoauswahl Dialog bei der AnfangsbestandNeu Action mit Abbruch, ESC oder Close beendet erscheint eine Fehlermeldung, dass die Aktion abgebrochen wurde. Diese erschreckt mich und sonst machen wir das ja auch nicht.
Ich habe die Meldung entfernt.