### PR TITLE
Feature skr42

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.dialogs.BuchungsartZuordnungDialog;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.system.OperationCanceledException;
@@ -78,12 +79,14 @@ public class BuchungBuchungsartZuordnungAction implements Action
       if (!baz.getAbort())
       {
         Buchungsart ba = baz.getBuchungsart();
+        Buchungsklasse bk = baz.getBuchungsklasse();
         int counter = 0;
         if (ba == null)
         {
           for (Buchung buchung : b)
           {
             buchung.setBuchungsart(null);
+            buchung.setBuchungsklasse(null);
             buchung.store();
           }
         }
@@ -100,6 +103,10 @@ public class BuchungBuchungsartZuordnungAction implements Action
             else
             {
               buchung.setBuchungsart(Long.valueOf(ba.getID()));
+              if (bk != null)
+               buchung.setBuchungsklasse(Long.valueOf(bk.getID()));
+              else
+                buchung.setBuchungsklasse(null);
               buchung.store();
             }
           }

--- a/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
@@ -48,6 +48,8 @@ public class BuchungDuplizierenAction implements Action
       bu.setKommentar(b.getKommentar());
       if (b.getBuchungsart() != null)
         bu.setBuchungsart(b.getBuchungsartId());
+      if (b.getBuchungsklasse() != null)
+        bu.setBuchungsklasse(b.getBuchungsklasseId());
       if (b.getProjekt() != null)
         bu.setProjektID(b.getProjektID());
       bu.setAuszugsnummer(b.getAuszugsnummer());

--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -67,6 +67,8 @@ public class BuchungGegenbuchungAction implements Action
         bu.setDatum(b.getDatum());
         if (b.getBuchungsart() != null)
           bu.setBuchungsart(b.getBuchungsartId());
+        if (b.getBuchungsklasse() != null)
+          bu.setBuchungsklasse(b.getBuchungsklasseId());
         if (b.getProjekt() != null)
           bu.setProjektID(b.getProjektID());
         

--- a/src/de/jost_net/JVerein/gui/action/BuchungKontoauszugZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungKontoauszugZuordnungAction.java
@@ -18,7 +18,6 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.gui.control.BuchungsControl;
-import de.jost_net.JVerein.gui.dialogs.BuchungsartZuordnungDialog;
 import de.jost_net.JVerein.gui.dialogs.KontoauszugZuordnungDialog;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.willuhn.jameica.gui.Action;
@@ -73,7 +72,7 @@ public class BuchungKontoauszugZuordnungAction implements Action
         return;
       }
       KontoauszugZuordnungDialog kaz = new KontoauszugZuordnungDialog(
-          BuchungsartZuordnungDialog.POSITION_MOUSE, b[0].getAuszugsnummer(),
+          KontoauszugZuordnungDialog.POSITION_MOUSE, b[0].getAuszugsnummer(),
           b[0].getBlattnummer());
       kaz.open();
       Integer auszugsnummer = kaz.getAuszugsnummerWert();

--- a/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
+++ b/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
@@ -51,6 +51,7 @@ public class ZusatzbetragVorlageAuswahlAction implements Action
         part.getFaelligkeit().setValue(zbv.getFaelligkeit());
         part.getIntervall().setValue(zbv.getIntervall());
         part.getBuchungsart().setValue(zbv.getBuchungsart());
+        part.getBuchungsklasse().setValue(zbv.getBuchungsklasse());
         for (Object obj : part.getIntervall().getList())
         {
           IntervallZusatzzahlung ivz = (IntervallZusatzzahlung) obj;

--- a/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
+++ b/src/de/jost_net/JVerein/gui/action/ZusatzbetragVorlageAuswahlAction.java
@@ -51,7 +51,8 @@ public class ZusatzbetragVorlageAuswahlAction implements Action
         part.getFaelligkeit().setValue(zbv.getFaelligkeit());
         part.getIntervall().setValue(zbv.getIntervall());
         part.getBuchungsart().setValue(zbv.getBuchungsart());
-        part.getBuchungsklasse().setValue(zbv.getBuchungsklasse());
+        if (part.isBuchungsklasseActive())
+          part.getBuchungsklasse().setValue(zbv.getBuchungsklasse());
         for (Object obj : part.getIntervall().getList())
         {
           IntervallZusatzzahlung ivz = (IntervallZusatzzahlung) obj;

--- a/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
@@ -22,12 +22,15 @@ import java.text.DecimalFormat;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BeitragsgruppeDetailAction;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.NotizFormatter;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.menu.BeitragsgruppeMenu;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractControl;
@@ -64,6 +67,8 @@ public class BeitragsgruppeControl extends AbstractControl
   private DecimalInput betragjaehrlich;
 
   private SelectInput beitragsart;
+  
+  private SelectInput buchungsklasse;
 
   private Beitragsgruppe beitrag;
 
@@ -72,6 +77,8 @@ public class BeitragsgruppeControl extends AbstractControl
   private DecimalInput arbeitseinsatzbetrag;
 
   private AbstractInput buchungsart;
+  
+  
 
   private TextAreaInput notiz;
 
@@ -215,6 +222,37 @@ public class BeitragsgruppeControl extends AbstractControl
         getBeitragsgruppe().getBuchungsart());
     return buchungsart;
   }
+  
+  public SelectInput getBuchungsklasse() throws RemoteException
+  {
+    if (buchungsklasse != null)
+    {
+      return buchungsklasse;
+    }
+    buchungsklasse = new BuchungsklasseInput().getBuchungsklasseInput(buchungsklasse,
+        getBeitragsgruppe().getBuchungsklasse());
+    return buchungsklasse;
+  }
+  
+  private Long getSelectedBuchungsKlasseId() throws ApplicationException
+  {
+    try
+    {
+      if (null == buchungsklasse)
+        return null;
+      Buchungsklasse buchungsKlasse = (Buchungsklasse) getBuchungsklasse().getValue();
+      if (null == buchungsKlasse)
+        return null;
+      Long id = Long.valueOf(buchungsKlasse.getID());
+      return id;
+    }
+    catch (RemoteException ex)
+    {
+      final String meldung = "Gewählte Buchungsklasse kann nicht ermittelt werden";
+      Logger.error(meldung, ex);
+      throw new ApplicationException(meldung, ex);
+    }
+  }
 
   public TextAreaInput getNotiz() throws RemoteException
   {
@@ -268,11 +306,8 @@ public class BeitragsgruppeControl extends AbstractControl
       // eingeben.");
       // }
       b.setBeitragsArt(ba.getKey());
-      Buchungsart bua = (Buchungsart) getBuchungsart().getValue();
-      if (bua != null)
-      {
-        b.setBuchungsart(bua);
-      }
+      b.setBuchungsart((Buchungsart) getBuchungsart().getValue());
+      b.setBuchungsklasse(getSelectedBuchungsKlasseId());
       Double d = (Double) getArbeitseinsatzStunden().getValue();
       b.setArbeitseinsatzStunden(d.doubleValue());
       d = (Double) getArbeitseinsatzBetrag().getValue();
@@ -332,6 +367,11 @@ public class BeitragsgruppeControl extends AbstractControl
       beitragsgruppeList.addColumn("Arbeitseinsatz-Stundensatz",
           "arbeitseinsatzbetrag",
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    }
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      beitragsgruppeList.addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
     }
     beitragsgruppeList.addColumn("Buchungsart", "buchungsart",
         new BuchungsartFormatter());

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -632,6 +632,7 @@ public class BuchungsControl extends AbstractControl
               b.setBetrag(ssub.getBetrag() * -1);
               b.setBlattnummer(master.getBlattnummer());
               b.setBuchungsart(master.getBuchungsartId());
+              b.setBuchungsklasse(master.getBuchungsklasseId());
               b.setDatum(su.getAusfuehrungsdatum());
               b.setKonto(master.getKonto());
               b.setName(ssub.getGegenkontoName());

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -50,6 +50,7 @@ import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.MitgliedskontoFormatter;
 import de.jost_net.JVerein.gui.formatter.ProjektFormatter;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.KontoauswahlInput;
 import de.jost_net.JVerein.gui.input.SollbuchungAuswahlInput;
 import de.jost_net.JVerein.gui.menu.BuchungMenu;
@@ -506,6 +507,10 @@ public class BuchungsControl extends AbstractControl
             {
               getBuchungsart().setValue(mk.getBuchungsart());
             }
+            if (getBuchungsklasse().getValue() == null)
+            {
+              getBuchungsklasse().setValue(mk.getBuchungsklasse());
+            }
           }
         }
         catch (RemoteException e)
@@ -559,33 +564,8 @@ public class BuchungsControl extends AbstractControl
     {
       return buchungsklasse;
     }
-    DBIterator<Buchungsklasse> it = Einstellungen.getDBService()
-        .createList(Buchungsklasse.class);
-    if (Einstellungen.getEinstellung()
-        .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
-    {
-      it.setOrder("ORDER BY nummer");
-    }
-    else
-    {
-      it.setOrder("ORDER BY bezeichnung");
-    }
-    buchungsklasse = new SelectInput(it != null ? PseudoIterator.asList(it) : null, 
+    buchungsklasse = new BuchungsklasseInput().getBuchungsklasseInput(buchungsklasse,
         getBuchung().getBuchungsklasse());
-
-    switch (Einstellungen.getEinstellung().getBuchungsartSort())
-    {
-      case BuchungsartSort.NACH_NUMMER:
-        buchungsklasse.setAttribute("nrbezeichnung");
-        break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
-        buchungsklasse.setAttribute("bezeichnungnr");
-        break;
-      default:
-        buchungsklasse.setAttribute("bezeichnung");
-        break;
-    }
-    buchungsklasse.setPleaseChoose("Bitte auswählen");
     if (!getBuchung().getSpeicherung() && 
         Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
     {
@@ -1128,6 +1108,8 @@ public class BuchungsControl extends AbstractControl
   {
     try
     {
+      if (null == buchungsklasse)
+        return null;
       Buchungsklasse buchungsKlasse = (Buchungsklasse) getBuchungsklasse().getValue();
       if (null == buchungsKlasse)
         return null;
@@ -1333,6 +1315,11 @@ public class BuchungsControl extends AbstractControl
       splitbuchungsList.addColumn("Blatt", "blattnummer");
       splitbuchungsList.addColumn("Name", "name");
       splitbuchungsList.addColumn("Verwendungszweck", "zweck");
+      if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+      {
+        splitbuchungsList.addColumn("Buchungsklasse", "buchungsklasse",
+            new BuchungsklasseFormatter());
+      }
       splitbuchungsList.addColumn("Buchungsart", "buchungsart",
           new BuchungsartFormatter());
       splitbuchungsList.addColumn("Betrag", "betrag",

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -507,7 +507,7 @@ public class BuchungsControl extends AbstractControl
             {
               getBuchungsart().setValue(mk.getBuchungsart());
             }
-            if (getBuchungsklasse().getValue() == null)
+            if (isBuchungsklasseActive() && getBuchungsklasse().getValue() == null)
             {
               getBuchungsklasse().setValue(mk.getBuchungsklasse());
             }
@@ -572,6 +572,11 @@ public class BuchungsControl extends AbstractControl
       buchungsklasse.setMandatory(true);
     }
     return buchungsklasse;
+  }
+  
+  public boolean isBuchungsklasseActive()
+  {
+    return buchungsklasse != null;
   }
 
   public Input getProjekt() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -300,6 +300,8 @@ public class EinstellungControl extends AbstractControl
   private ImageInput unterschrift;
   
   private CheckboxInput anhangspeichern;
+  
+  private CheckboxInput freiebuchungsklasse;
 
 
   private IntegerInput qrcodesize;
@@ -808,6 +810,17 @@ public class EinstellungControl extends AbstractControl
     optiert = new CheckboxInput(Einstellungen.getEinstellung().getOptiert());
     optiert.setName("Umsatzsteueroption");
     return optiert;
+  }
+  
+  public CheckboxInput getFreieBuchungsklasse() throws RemoteException 
+  {
+    if (freiebuchungsklasse != null) 
+    {
+      return freiebuchungsklasse;
+    }
+    freiebuchungsklasse = new CheckboxInput(Einstellungen.getEinstellung().getBuchungsklasseInBuchung());
+    freiebuchungsklasse.setName("Keine feste Zuordnung von Buchungsklasse zu Buchungsart z.B. SKR 42");
+    return freiebuchungsklasse;
   }
 
   public CheckboxInput getExterneMitgliedsnummer() throws RemoteException
@@ -2152,6 +2165,7 @@ public class EinstellungControl extends AbstractControl
       e.setUnterdrueckungKonten(klength);
       e.setKontonummerInBuchungsliste((Boolean) kontonummer_in_buchungsliste.getValue());
       e.setOptiert((Boolean) getOptiert().getValue());
+      e.setBuchungsklasseInBuchung((Boolean) getFreieBuchungsklasse().getValue());
       e.store();
       Einstellungen.setEinstellung(e);
 

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -47,6 +47,8 @@ import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.MitgliedNextBGruppeBearbeitenAction;
 import de.jost_net.JVerein.gui.action.WiedervorlageAction;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeAction;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
@@ -1675,7 +1677,13 @@ public class MitgliedControl extends FilterControl
     zusatzbetraegeList.addColumn("Buchungstext", "buchungstext");
     zusatzbetraegeList.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    zusatzbetraegeList.addColumn("Buchungsart", "buchungsart");
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      zusatzbetraegeList.addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
+    }
+    zusatzbetraegeList.addColumn("Buchungsart", "buchungsart",
+        new BuchungsartFormatter());
     zusatzbetraegeList
         .setContextMenu(new ZusatzbetraegeMenu(zusatzbetraegeList));
     return zusatzbetraegeList;

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -37,6 +37,8 @@ import com.itextpdf.text.Element;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeAction;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.menu.ZusatzbetraegeMenu;
 import de.jost_net.JVerein.gui.parts.ZusatzbetragPart;
 import de.jost_net.JVerein.io.FileViewer;
@@ -196,11 +198,9 @@ public class ZusatzbetragControl extends AbstractControl
       z.setBuchungstext(
           (String) getZusatzbetragPart().getBuchungstext().getValue());
       Double d = (Double) getZusatzbetragPart().getBetrag().getValue();
-      if (getZusatzbetragPart().getBuchungsart().getValue() != null)
-      {
-        z.setBuchungsart(
-            (Buchungsart) getZusatzbetragPart().getBuchungsart().getValue());
-      }
+      z.setBuchungsart(
+          (Buchungsart) getZusatzbetragPart().getBuchungsart().getValue());
+      z.setBuchungsklasse(getZusatzbetragPart().getSelectedBuchungsKlasseId());
       z.setBetrag(d.doubleValue());
       z.store();
       if (getVorlage().getValue().equals(MITDATUM)
@@ -218,6 +218,7 @@ public class ZusatzbetragControl extends AbstractControl
           zv.setStartdatum(z.getStartdatum());
         }
         zv.setBuchungsart(z.getBuchungsart());
+        zv.setBuchungsklasse(z.getBuchungsklasseId());
         zv.store();
       }
       GUI.getStatusBar().setSuccessText("Zusatzbetrag gespeichert");
@@ -277,7 +278,13 @@ public class ZusatzbetragControl extends AbstractControl
       zusatzbetraegeList.addColumn("Buchungstext", "buchungstext");
       zusatzbetraegeList.addColumn("Betrag", "betrag",
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-      zusatzbetraegeList.addColumn("Buchungsart", "buchungsart");
+      if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+      {
+        zusatzbetraegeList.addColumn("Buchungsklasse", "buchungsklasse",
+            new BuchungsklasseFormatter());
+      }
+      zusatzbetraegeList.addColumn("Buchungsart", "buchungsart",
+          new BuchungsartFormatter());
       zusatzbetraegeList
           .setContextMenu(new ZusatzbetraegeMenu(zusatzbetraegeList));
       zusatzbetraegeList.setRememberColWidths(true);

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
@@ -279,32 +280,8 @@ public class BuchungsartZuordnungDialog extends AbstractDialog<Buchungsart>
     {
       return buchungsklassen;
     }
-    DBIterator<Buchungsklasse> it = Einstellungen.getDBService()
-        .createList(Buchungsklasse.class);
-    if (Einstellungen.getEinstellung()
-        .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
-    {
-      it.setOrder("ORDER BY nummer");
-    }
-    else
-    {
-      it.setOrder("ORDER BY bezeichnung");
-    }
-    buchungsklassen = new SelectInput(it != null ? PseudoIterator.asList(it) : null, null);
-
-    switch (Einstellungen.getEinstellung().getBuchungsartSort())
-    {
-      case BuchungsartSort.NACH_NUMMER:
-        buchungsklassen.setAttribute("nrbezeichnung");
-        break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
-        buchungsklassen.setAttribute("bezeichnungnr");
-        break;
-      default:
-        buchungsklassen.setAttribute("bezeichnung");
-        break;
-    }
-    buchungsklassen.setPleaseChoose("Bitte auswählen");
+    buchungsklassen = new BuchungsklasseInput().getBuchungsklasseInput(buchungsklassen,
+        null);
     return buchungsklassen;
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedZusatzbetragZuordnungDialog.java
@@ -94,6 +94,7 @@ public class MitgliedZusatzbetragZuordnungDialog extends AbstractDialog<String>
             zb.setMitglied(Integer.parseInt(mit.getID()));
             zb.setStartdatum((Date) part.getStartdatum(true).getValue());
             zb.setBuchungsart((Buchungsart) part.getBuchungsart().getValue());
+            zb.setBuchungsklasse(part.getSelectedBuchungsKlasseId());
             zb.store();
             count++;
           }

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
@@ -22,6 +22,8 @@ import java.rmi.RemoteException;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.menu.ZusatzbetragVorlageMenu;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -114,7 +116,11 @@ public class ZusatzbetragVorlageDialog
     tab.addColumn("Buchungstext", "buchungstext");
     tab.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    tab.addColumn("Buchungsart", "buchungsart");
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+      tab.addColumn("Buchungsklasse", "buchungsklasse", 
+          new BuchungsklasseFormatter());
+    tab.addColumn("Buchungsart", "buchungsart",
+        new BuchungsartFormatter());
     tab.setContextMenu(new ZusatzbetragVorlageMenu());
     tab.setRememberColWidths(true);
     tab.setRememberOrder(true);

--- a/src/de/jost_net/JVerein/gui/formatter/BuchungsklasseFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/BuchungsklasseFormatter.java
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.formatter;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.BuchungsartSort;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.logging.Logger;
+
+public class BuchungsklasseFormatter implements Formatter
+{
+  @Override
+  public String format(Object o)
+  {
+    Buchungsklasse bk = (Buchungsklasse) o;
+    if (bk == null)
+    {
+      return null;
+    }
+    String bez = null;
+    try
+    {
+      switch (Einstellungen.getEinstellung().getBuchungsartSort())
+      {
+        case BuchungsartSort.NACH_NUMMER:
+          bez = bk.getNummer() + " - " + bk.getBezeichnung(); 
+          break;
+        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+          bez = bk.getBezeichnung() + " (" + bk.getNummer() + ")"; 
+      	  break;
+        default:
+          bez = bk.getBezeichnung();
+      	  break;
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+    }
+    return bez;
+  }
+}

--- a/src/de/jost_net/JVerein/gui/input/BuchungsklasseInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsklasseInput.java
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.input;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.BuchungsartSort;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.input.SelectInput;
+
+public class BuchungsklasseInput
+{
+  public SelectInput getBuchungsklasseInput(SelectInput buchungsklasse,
+      Buchungsklasse klasse) throws RemoteException
+  {
+    DBIterator<Buchungsklasse> it = Einstellungen.getDBService()
+        .createList(Buchungsklasse.class);
+    if (Einstellungen.getEinstellung()
+        .getBuchungsartSort() == BuchungsartSort.NACH_NUMMER)
+    {
+      it.setOrder("ORDER BY nummer");
+    }
+    else
+    {
+      it.setOrder("ORDER BY bezeichnung");
+    }
+    buchungsklasse = new SelectInput(it != null ? PseudoIterator.asList(it) : null, 
+        klasse);
+
+    switch (Einstellungen.getEinstellung().getBuchungsartSort())
+    {
+      case BuchungsartSort.NACH_NUMMER:
+        buchungsklasse.setAttribute("nrbezeichnung");
+        break;
+      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        buchungsklasse.setAttribute("bezeichnungnr");
+        break;
+      default:
+        buchungsklasse.setAttribute("bezeichnung");
+        break;
+    }
+    buchungsklasse.setPleaseChoose("Bitte auswählen");
+    buchungsklasse.setValue(klasse);
+    return buchungsklasse;
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
+++ b/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
@@ -134,6 +134,7 @@ public class SollbuchungAuswahlInput
             buchungen[0].setDatum(new Date());
             buchungen[0]
                 .setBuchungsart(Long.valueOf(konto.getBuchungsart().getID()));
+            buchungen[0].setBuchungsklasse(konto.getBuchungsklasseId());
           }
         }
         else if (event.data instanceof Mitglied)

--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -85,6 +85,10 @@ public class BuchungPart implements Part
 
     grBuchungsinfos.addHeadline("Buchungsinfos");
     grBuchungsinfos.addLabelPair("Buchungsart", control.getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      grBuchungsinfos.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
+    }
     grBuchungsinfos.addLabelPair("Projekt", control.getProjekt());
     grBuchungsinfos.addLabelPair("Auszugsnummer", control.getAuszugsnummer());
     grBuchungsinfos.addLabelPair("Blattnummer", control.getBlattnummer());

--- a/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
@@ -263,6 +263,11 @@ public class ZusatzbetragPart implements Part
     return buchungsklasse;
   }
   
+  public boolean isBuchungsklasseActive()
+  {
+    return buchungsklasse != null;
+  }
+  
   public Long getSelectedBuchungsKlasseId() throws ApplicationException
   {
     try

--- a/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
@@ -25,7 +25,9 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Part;
@@ -35,6 +37,8 @@ import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class ZusatzbetragPart implements Part
 {
@@ -55,6 +59,8 @@ public class ZusatzbetragPart implements Part
   private DateInput ausfuehrung = null;
 
   private AbstractInput buchungsart;
+  
+  private SelectInput buchungsklasse;
 
   public ZusatzbetragPart(Zusatzbetrag zusatzbetrag)
   {
@@ -72,6 +78,8 @@ public class ZusatzbetragPart implements Part
     group.addLabelPair("Buchungstext", getBuchungstext());
     group.addLabelPair("Betrag", getBetrag());
     group.addLabelPair("Buchungsart", getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+      group.addLabelPair("Buchungsklasse", getBuchungsklasse());
   }
 
   public DateInput getFaelligkeit() throws RemoteException
@@ -243,4 +251,36 @@ public class ZusatzbetragPart implements Part
         zusatzbetrag.getBuchungsart());
     return buchungsart;
   }
+  
+  public SelectInput getBuchungsklasse() throws RemoteException
+  {
+    if (buchungsklasse != null)
+    {
+      return buchungsklasse;
+    }
+    buchungsklasse = new BuchungsklasseInput().getBuchungsklasseInput(buchungsklasse,
+        zusatzbetrag.getBuchungsklasse());
+    return buchungsklasse;
+  }
+  
+  public Long getSelectedBuchungsKlasseId() throws ApplicationException
+  {
+    try
+    {
+      if (null == buchungsklasse)
+        return null;
+      Buchungsklasse buchungsKlasse = (Buchungsklasse) getBuchungsklasse().getValue();
+      if (null == buchungsKlasse)
+        return null;
+      Long id = Long.valueOf(buchungsKlasse.getID());
+      return id;
+    }
+    catch (RemoteException ex)
+    {
+      final String meldung = "Gewählte Buchungsklasse kann nicht ermittelt werden";
+      Logger.error(meldung, ex);
+      throw new ApplicationException(meldung, ex);
+    }
+  }
+  
 }

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
@@ -70,6 +70,10 @@ public class BeitragsgruppeDetailView extends AbstractView
     }
     group.addLabelPair("Beitragsart", control.getBeitragsArt());
     group.addLabelPair("Buchungsart", control.getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      group.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
+    }
 
     if (Einstellungen.getEinstellung().getArbeitseinsatz())
     {

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -47,6 +47,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     cont.addInput(control.getUnterdrueckungOhneBuchung());
     cont.addInput(control.getKontonummerInBuchungsliste());
     cont.addInput(control.getOptiert());
+    cont.addInput(control.getFreieBuchungsklasse());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
@@ -49,6 +50,10 @@ public class SollbuchungDetailView extends AbstractView
     control.getBetrag().setMandatory(true);
     grBuchung.addLabelPair("Betrag", control.getBetrag());
     grBuchung.addLabelPair("Buchungsart", control.getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      grBuchung.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
+    }
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -51,6 +51,7 @@ import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Lastschrift;
@@ -245,7 +246,7 @@ public class AbrechnungSEPA
     if (!summemitgliedskonto.equals(BigDecimal.valueOf(0)))
     {
       writeMitgliedskonto(null, new Date(), "Gegenbuchung",
-          summemitgliedskonto.doubleValue() * -1, abrl, true, getKonto(), null);
+          summemitgliedskonto.doubleValue() * -1, abrl, true, getKonto(), null, null);
     }
     if (param.abbuchungsausgabe == Abrechnungsausgabe.HIBISCUS)
     {
@@ -442,7 +443,7 @@ public class AbrechnungSEPA
         param.faelligkeit,
         primaer ? vzweck : bg.getBezeichnung(), betr, abrl,
         m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
-        bg.getBuchungsart());
+        bg.getBuchungsart(), bg.getBuchungsklasseId());
     if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT)
     {
       try
@@ -601,7 +602,8 @@ public class AbrechnungSEPA
             param.faelligkeit,
             vzweck, z.getBetrag(), abrl,
             m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT, konto,
-            z.getBuchungsart());
+            z.getBuchungsart(),
+            z.getBuchungsklasseId());
       }
     }
   }
@@ -638,7 +640,7 @@ public class AbrechnungSEPA
         kt.setAbbudatum(param.faelligkeit);
         kt.store();
         writeMitgliedskonto(kt, param.faelligkeit, kt.getVZweck1(), 
-            zahler.getBetrag().doubleValue(), abrl, true, konto, null);
+            zahler.getBetrag().doubleValue(), abrl, true, konto, null, null);
       }
       catch (Exception e)
       {
@@ -800,7 +802,7 @@ public class AbrechnungSEPA
 
   private void writeMitgliedskonto(Object mitglied, Date datum, String zweck1,
       double betrag, Abrechnungslauf abrl, boolean haben, Konto konto,
-      Buchungsart buchungsart) throws ApplicationException, RemoteException
+      Buchungsart buchungsart, Long buchungsklasseId) throws ApplicationException, RemoteException
   {
     Mitgliedskonto mk = null;
     if (mitglied != null && mitglied instanceof Mitglied) /*
@@ -823,6 +825,7 @@ public class AbrechnungSEPA
         mk.setBuchungsart(buchungsart);
         steuersatz = buchungsart.getSteuersatz();
       }
+      mk.setBuchungsklasse(buchungsklasseId);
       // Set tax rate
       mk.setSteuersatz(steuersatz);
       // Set bill amount without taxes
@@ -852,6 +855,7 @@ public class AbrechnungSEPA
       {
         buchung.setBuchungsart(Long.valueOf(buchungsart.getID()));
       }
+      buchung.setBuchungsklasse(buchungsklasseId);
       buchung.store();
     }
   }

--- a/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
+++ b/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
@@ -30,6 +30,7 @@ import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.Variable.BuchungVar;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Konto;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.system.Application;
@@ -174,6 +175,25 @@ public class CSVBuchungsImport implements Importer
             }
             Buchungsart b1 = (Buchungsart) bit.next();
             bu.setBuchungsart(Long.valueOf(b1.getID()));
+          }
+          catch (SQLException e)
+          {
+            // Optionales Feld
+          }
+          try
+          {
+            Integer bukl = results
+                .getInt(BuchungVar.BUCHUNGSKLASSENUMMER.getName());
+            DBIterator<Buchungsklasse> bit = Einstellungen.getDBService()
+                .createList(Buchungsklasse.class);
+            bit.addFilter("nummer = ?", bukl);
+            if (bit.size() != 1)
+            {
+              throw new ApplicationException(String
+                  .format("Buchungsklasse %d existiert nicht in JVerein!", bukl));
+            }
+            Buchungsklasse b1 = (Buchungsklasse) bit.next();
+            bu.setBuchungsklasse(Long.valueOf(b1.getID()));
           }
           catch (SQLException e)
           {

--- a/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
+++ b/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.willuhn.datasource.rmi.DBIterator;
@@ -290,6 +291,25 @@ public class DefaultZusatzbetraegeImport implements Importer
               }
               Buchungsart bu = it.next();
               zus.setBuchungsart(bu);
+            }
+            catch (SQLException e)
+            {
+              //
+            }
+            try
+            {
+              String buchungsklasse = results.getString("Buchungsklasse");
+              DBIterator<Buchungsklasse> it = Einstellungen.getDBService()
+                  .createList(Buchungsklasse.class);
+              it.addFilter("nummer = ?", buchungsklasse);
+              if (it.size() == 0)
+              {
+                monitor.setStatusText(String.format(
+                    "Buchungsklasse mit der Nummer %s nicht gefunden",
+                    buchungsklasse));
+                fehlerInDaten = true;
+              }
+              zus.setBuchungsklasse(Long.valueOf(buchungsklasse));
             }
             catch (SQLException e)
             {

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -290,6 +290,7 @@ public class SplitbuchungsContainer
     buch.setBetrag(b.getBetrag() * -1);
     buch.setBlattnummer(b.getBlattnummer());
     buch.setBuchungsart(b.getBuchungsartId());
+    buch.setBuchungsklasse(b.getBuchungsklasseId());
     buch.setDatum(b.getDatum());
     buch.setKommentar(b.getKommentar());
     buch.setKonto(b.getKonto());
@@ -311,6 +312,7 @@ public class SplitbuchungsContainer
     buch.setBetrag(origin.getBetrag());
     buch.setBlattnummer(master.getBlattnummer());
     buch.setBuchungsart(origin.getBuchungsartId());
+    buch.setBuchungsklasse(origin.getBuchungsklasseId());
     buch.setDatum(master.getDatum());
     buch.setKommentar(origin.getKommentar());
     buch.setKonto(master.getKonto());

--- a/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
+++ b/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
@@ -68,6 +68,12 @@ public interface Beitragsgruppe extends DBObject
   public Buchungsart getBuchungsart() throws RemoteException;
 
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException;
+  
+  public Buchungsklasse getBuchungsklasse() throws RemoteException;
+  
+  public Long getBuchungsklasseId() throws RemoteException;
+
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException;
 
   public String getNotiz() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -80,6 +80,12 @@ public interface Buchung extends DBObject
   public Long getBuchungsartId() throws RemoteException;
 
   public void setBuchungsart(Long buchungsart) throws RemoteException;
+  
+  public Buchungsklasse getBuchungsklasse() throws RemoteException;
+  
+  public Long getBuchungsklasseId() throws RemoteException;
+
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException;
 
   public Abrechnungslauf getAbrechnungslauf() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Buchungsart.java
+++ b/src/de/jost_net/JVerein/rmi/Buchungsart.java
@@ -36,7 +36,7 @@ public interface Buchungsart extends DBObject
 
   public Buchungsklasse getBuchungsklasse() throws RemoteException;
 
-  public int getBuchungsklasseId() throws RemoteException;
+  public Long getBuchungsklasseId() throws RemoteException;
 
   public void setBuchungsklasse(Integer buchungsklasse) throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -595,4 +595,8 @@ public interface Einstellung extends DBObject, IBankverbindung
   public Boolean getAnhangSpeichern() throws RemoteException;
 
   public void setAnhangSpeichern(Boolean anhangspeichern) throws RemoteException;
+  
+  public Boolean getBuchungsklasseInBuchung() throws RemoteException;
+
+  public void setBuchungsklasseInBuchung(Boolean buchungsklasseInBuchung) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -598,5 +598,5 @@ public interface Einstellung extends DBObject, IBankverbindung
   
   public Boolean getBuchungsklasseInBuchung() throws RemoteException;
 
-  public void setBuchungsklasseInBuchung(Boolean buchungsklasseInBuchung) throws RemoteException;
+  public void setBuchungsklasseInBuchung(Boolean bkinbuchung) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
+++ b/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
@@ -66,4 +66,9 @@ public interface Mitgliedskonto extends DBObject
 
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException;
 
+  public Buchungsklasse getBuchungsklasse() throws RemoteException;
+  
+  public Long getBuchungsklasseId() throws RemoteException;
+
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
+++ b/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
@@ -66,4 +66,10 @@ public interface Zusatzbetrag extends DBObject
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException;
 
   public Buchungsart getBuchungsart() throws RemoteException;
+
+  public Buchungsklasse getBuchungsklasse() throws RemoteException;
+  
+  public Long getBuchungsklasseId() throws RemoteException;
+
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/ZusatzbetragVorlage.java
+++ b/src/de/jost_net/JVerein/rmi/ZusatzbetragVorlage.java
@@ -53,5 +53,10 @@ public interface ZusatzbetragVorlage extends DBObject
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException;
 
   public Buchungsart getBuchungsart() throws RemoteException;
+  
+  public Buchungsklasse getBuchungsklasse() throws RemoteException;
+  
+  public Long getBuchungsklasseId() throws RemoteException;
 
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -246,6 +247,31 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   {
     setAttribute("beitragsart", art);
   }
+  
+  @Override
+  public Buchungsklasse getBuchungsklasse() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsklasse");
+    if (l == null)
+    {
+      return null; // Keine Buchungsklasse zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsklasse.class, true);
+    return (Buchungsklasse) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsklasseId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsklasse().getID());
+  }
+  
+  @Override
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException
+  {
+    setAttribute("buchungsklasse", buchungsklasse);
+  }
 
   @Override
   public double getArbeitseinsatzStunden() throws RemoteException
@@ -310,6 +336,10 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
+    if (fieldName.equals("buchungsklasse"))
+    {
+      return getBuchungsklasse();
+    }
     return super.getAttribute(fieldName);
   }
 }

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -264,7 +264,7 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   @Override
   public Long getBuchungsklasseId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -411,7 +411,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Long getBuchungsklasseId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
@@ -393,6 +394,31 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("buchungsart", buchungsart);
   }
+  
+  @Override
+  public Buchungsklasse getBuchungsklasse() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsklasse");
+    if (l == null)
+    {
+      return null; // Keine Buchungsklasse zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsklasse.class, true);
+    return (Buchungsklasse) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsklasseId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsklasse().getID());
+  }
+  
+  @Override
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException
+  {
+    setAttribute("buchungsklasse", buchungsklasse);
+  }
 
   @Override
   public Abrechnungslauf getAbrechnungslauf() throws RemoteException
@@ -623,6 +649,9 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
 
     if ("buchungsart".equals(fieldName))
       return getBuchungsart();
+    
+    if ("buchungsklasse".equals(fieldName))
+      return getBuchungsklasse();
 
     if ("konto".equals(fieldName))
       return getKonto();

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -147,9 +147,9 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   }
 
   @Override
-  public int getBuchungsklasseId() throws RemoteException
+  public Long getBuchungsklasseId() throws RemoteException
   {
-    return Integer.parseInt(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
@@ -32,7 +32,7 @@ public class Update0444 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
-        COLTYPE.BOOLEAN, 0, "FALSE", false, false)));
+        COLTYPE.BOOLEAN, 0, null, false, false)));
     
     execute(addColumn("buchung", new Column("buchungsklasse",
         COLTYPE.BIGINT, 0, null, false, false)));

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
@@ -31,7 +31,7 @@ public class Update0444 extends AbstractDDLUpdate
   @Override
   public void run() throws ApplicationException
   {
-    /*execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
+    execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
         COLTYPE.BOOLEAN, 0, "FALSE", false, false)));
     
     execute(addColumn("buchung", new Column("buchungsklasse",
@@ -42,12 +42,12 @@ public class Update0444 extends AbstractDDLUpdate
     idx.add(col);
     execute(idx.getCreateIndex("buchung"));
     execute(createForeignKey("fkBuchung7", "buchung",
-        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));*/
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
     
     execute(addColumn("mitgliedskonto", new Column("buchungsklasse",
         COLTYPE.BIGINT, 0, null, false, false)));
-    Index idx = new Index("ixMitgliedkonto4", false);
-    Column col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+    idx = new Index("ixMitgliedkonto4", false);
+    col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
         false);
     idx.add(col);
     execute(idx.getCreateIndex("mitgliedskonto"));

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
@@ -31,7 +31,7 @@ public class Update0444 extends AbstractDDLUpdate
   @Override
   public void run() throws ApplicationException
   {
-    execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
+    /*execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
         COLTYPE.BOOLEAN, 0, "FALSE", false, false)));
     
     execute(addColumn("buchung", new Column("buchungsklasse",
@@ -42,6 +42,46 @@ public class Update0444 extends AbstractDDLUpdate
     idx.add(col);
     execute(idx.getCreateIndex("buchung"));
     execute(createForeignKey("fkBuchung7", "buchung",
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));*/
+    
+    execute(addColumn("mitgliedskonto", new Column("buchungsklasse",
+        COLTYPE.BIGINT, 0, null, false, false)));
+    Index idx = new Index("ixMitgliedkonto4", false);
+    Column col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+        false);
+    idx.add(col);
+    execute(idx.getCreateIndex("mitgliedskonto"));
+    execute(createForeignKey("fkMitgliedkonto4", "mitgliedskonto",
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
+    
+    execute(addColumn("zusatzabbuchung", new Column("buchungsklasse",
+        COLTYPE.BIGINT, 0, null, false, false)));
+    idx = new Index("ixZusatzabbuchung3", false);
+    col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+        false);
+    idx.add(col);
+    execute(idx.getCreateIndex("zusatzabbuchung"));
+    execute(createForeignKey("fkZusatzabbuchung3", "zusatzabbuchung",
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
+    
+    execute(addColumn("zusatzbetragvorlage", new Column("buchungsklasse",
+        COLTYPE.BIGINT, 0, null, false, false)));
+    idx = new Index("ixZusatzbetragvorlage3", false);
+    col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+        false);
+    idx.add(col);
+    execute(idx.getCreateIndex("zusatzbetragvorlage"));
+    execute(createForeignKey("fkZusatzbetragvorlage3", "zusatzbetragvorlage",
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
+    
+    execute(addColumn("beitragsgruppe", new Column("buchungsklasse",
+        COLTYPE.BIGINT, 0, null, false, false)));
+    idx = new Index("ixBeitragsgruppe2", false);
+    col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+        false);
+    idx.add(col);
+    execute(idx.getCreateIndex("beitragsgruppe"));
+    execute(createForeignKey("fkBeitragsgruppe2", "beitragsgruppe",
         "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
@@ -31,7 +31,7 @@ public class Update0444 extends AbstractDDLUpdate
   @Override
   public void run() throws ApplicationException
   {
-    execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
+    execute(addColumn("einstellung", new Column("bkinbuchung",
         COLTYPE.BOOLEAN, 0, null, false, false)));
     
     execute(addColumn("buchung", new Column("buchungsklasse",

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0444.java
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.jost_net.JVerein.server.DDLTool.Index;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0444 extends AbstractDDLUpdate
+{
+  public Update0444(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("buchungsklasseInBuchung",
+        COLTYPE.BOOLEAN, 0, "FALSE", false, false)));
+    
+    execute(addColumn("buchung", new Column("buchungsklasse",
+        COLTYPE.BIGINT, 0, null, false, false)));
+    Index idx = new Index("ixBuchung7", false);
+    Column col = new Column("buchungsklasse", COLTYPE.BIGINT, 0, null, false,
+        false);
+    idx.add(col);
+    execute(idx.getCreateIndex("buchung"));
+    execute(createForeignKey("fkBuchung7", "buchung",
+        "buchungsklasse", "buchungsklasse", "id", "RESTRICT", "NO ACTION"));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2026,12 +2026,12 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   @Override
   public Boolean getBuchungsklasseInBuchung() throws RemoteException
   {
-    return Util.getBoolean(getAttribute("buchungsklasseInBuchung"));
+    return Util.getBoolean(getAttribute("bkinbuchung"));
   }
 
   @Override
-  public void setBuchungsklasseInBuchung(Boolean buchungsklasseInBuchung) throws RemoteException
+  public void setBuchungsklasseInBuchung(Boolean bkinbuchung) throws RemoteException
   {
-    setAttribute("buchungsklasseInBuchung", buchungsklasseInBuchung);
+    setAttribute("bkinbuchung", bkinbuchung);
   }
 }

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2022,4 +2022,16 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   {
     setAttribute("anhangspeichern", anhangspeichern);
   }
+  
+  @Override
+  public Boolean getBuchungsklasseInBuchung() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("buchungsklasseInBuchung"));
+  }
+
+  @Override
+  public void setBuchungsklasseInBuchung(Boolean buchungsklasseInBuchung) throws RemoteException
+  {
+    setAttribute("buchungsklasseInBuchung", buchungsklasseInBuchung);
+  }
 }

--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.datasource.db.AbstractDBObject;
@@ -138,7 +139,35 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
   @Override
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException
   {
-    setAttribute("buchungsart", Long.valueOf(buchungsart.getID()));
+    if (buchungsart != null)
+      setAttribute("buchungsart", Long.valueOf(buchungsart.getID()));
+    else
+      setAttribute("buchungsart", null);
+  }
+  
+  @Override
+  public Buchungsklasse getBuchungsklasse() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsklasse");
+    if (l == null)
+    {
+      return null; // Keine Buchungsklasse zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsklasse.class, true);
+    return (Buchungsklasse) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsklasseId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsklasse().getID());
+  }
+  
+  @Override
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException
+  {
+    setAttribute("buchungsklasse", buchungsklasse);
   }
 
   @Override
@@ -307,6 +336,10 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
     if (fieldName.equals("abrechnungslauf"))
     {
       return getAbrechnungslauf();
+    }
+    if (fieldName.equals("buchungsklasse"))
+    {
+      return getBuchungsklasse();
     }
     return super.getAttribute(fieldName);
   }

--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -161,7 +161,7 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
   @Override
   public Long getBuchungsklasseId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -272,7 +272,7 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
   @Override
   public Long getBuchungsklasseId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.util.Datum;
@@ -256,6 +257,31 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
   }
 
   @Override
+  public Buchungsklasse getBuchungsklasse() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsklasse");
+    if (l == null)
+    {
+      return null; // Keine Buchungsklasse zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsklasse.class, true);
+    return (Buchungsklasse) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsklasseId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsklasse().getID());
+  }
+  
+  @Override
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException
+  {
+    setAttribute("buchungsklasse", buchungsklasse);
+  }
+
+  @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
     if (fieldName.equals("intervalltext"))
@@ -269,6 +295,10 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
     if (fieldName.equals("buchungsart"))
     {
       return getBuchungsart();
+    }
+    if (fieldName.equals("buchungsklasse"))
+    {
+      return getBuchungsklasse();
     }
     return super.getAttribute(fieldName);
   }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
@@ -21,6 +21,7 @@ import java.util.Date;
 
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
@@ -189,6 +190,31 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject implements
   {
     return (Buchungsart) getAttribute("buchungsart");
   }
+  
+  @Override
+  public Buchungsklasse getBuchungsklasse() throws RemoteException
+  {
+    Long l = (Long) super.getAttribute("buchungsklasse");
+    if (l == null)
+    {
+      return null; // Keine Buchungsklasse zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsklasse.class, true);
+    return (Buchungsklasse) cache.get(l);
+  }
+
+  @Override
+  public Long getBuchungsklasseId() throws RemoteException
+  {
+    return Long.parseLong(getBuchungsklasse().getID());
+  }
+  
+  @Override
+  public void setBuchungsklasse(Long buchungsklasse) throws RemoteException
+  {
+    setAttribute("buchungsklasse", buchungsklasse);
+  }
 
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
@@ -196,6 +222,10 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject implements
     if (fieldName.equals("intervalltext"))
     {
       return getIntervallText();
+    }
+    if (fieldName.equals("buchungsklasse"))
+    {
+      return getBuchungsklasse();
     }
     return super.getAttribute(fieldName);
   }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
@@ -207,7 +207,7 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject implements
   @Override
   public Long getBuchungsklasseId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsklasse().getID());
+    return (Long) super.getAttribute("buchungsklasse");
   }
   
   @Override


### PR DESCRIPTION
Ich habe das Feature zum Support des SKR 42 implementiert. Es erlaubt die feste Zuordnung der Buchungsklasse zur Buchungsart aufzuheben. Die Buchungsklasse muss dann in der Buchung und sonstigen Klassen die die Buchungsklasse haben (z.B. Zusatzbeitrag, Beitragsgruppe etc.) separat gesetzt werden.
Mit einem Schalter in den Einstellungen-Buchführung lässt sich das Feature aktivieren.
![Bildschirmfoto_20240826_162638](https://github.com/user-attachments/assets/9b22b28a-5703-41bd-8243-19d2ba687b5b)
Das Buchungsklassensaldo ist nicht kompatibel mit alten Buchungen und liefert nur die Summe als "Nicht zugeordnet". Es wäre zu aufwändig beides zu können. Will man nach einem Umstieg auf die neue Art ein Saldo für alte Jahre sehen muss man kurz das Feature ausschalten und dann wieder ein. Eine Alternative wäre noch pro Jahr wählen zu können was angezeigt wird.

Wegen der Migration Upgrade0444 kann das Feature erst nach z.B. #296 und nach Lösen des Merge Conflict übernommen werden. Wer schon die Migration 443 gemacht hat kann dieses Feature aber schon testen.

PS: Der Kontenrahmen Export/Import ist noch für das alte Format und müsste mit einem eigen PR noch angepasst werden.

Insgesammt war es dann doch aufwändiger als gedacht.