### PR TITLE
Feature Altersstufen für Beitragsklassen

### DIFF
--- a/junit/src/de/jost_net/JVereinJUnit/io/BeitragsUtilTest.java
+++ b/junit/src/de/jost_net/JVereinJUnit/io/BeitragsUtilTest.java
@@ -48,21 +48,21 @@ public class BeitragsUtilTest
       Beitragsgruppe bg = getBeitragsgruppe();
       Assert.assertEquals(10d, BeitragsUtil.getBeitrag(
           Beitragsmodel.GLEICHERTERMINFUERALLE, null, 0, bg, new Date(), null,
-          null));
+          null,0));
       Assert.assertEquals(10d, BeitragsUtil.getBeitrag(
           Beitragsmodel.MONATLICH12631, null, Zahlungsrhythmus.MONATLICH, bg,
-          new Date(), null, null));
+          new Date(), null, null,0));
       Assert.assertEquals(30d, BeitragsUtil.getBeitrag(
           Beitragsmodel.MONATLICH12631, null,
-          Zahlungsrhythmus.VIERTELJAEHRLICH, bg, new Date(), null, null));
+          Zahlungsrhythmus.VIERTELJAEHRLICH, bg, new Date(), null, null,0));
       Assert.assertEquals(60d, BeitragsUtil.getBeitrag(
           Beitragsmodel.MONATLICH12631, null, Zahlungsrhythmus.HALBJAEHRLICH,
-          bg, new Date(), null, null));
+          bg, new Date(), null, null,0));
       Assert.assertEquals(120d, BeitragsUtil.getBeitrag(
           Beitragsmodel.MONATLICH12631, null, Zahlungsrhythmus.JAEHRLICH, bg,
-          new Date(), null, null));
+          new Date(), null, null,0));
       Assert.assertEquals(20d, BeitragsUtil.getBeitrag(Beitragsmodel.FLEXIBEL,
-          Zahlungstermin.MONATLICH, 0, bg, new Date(), null, null));
+          Zahlungstermin.MONATLICH, 0, bg, new Date(), null, null,0));
 
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -149,7 +149,7 @@ public class MitgliedMap
                   Einstellungen.getEinstellung().getBeitragsmodel(),
                   m.getZahlungstermin(), m.getZahlungsrhythmus().getKey(),
                   m.getBeitragsgruppe(), new Date(), m.getEintritt(),
-                  m.getAustritt()))
+                  m.getAustritt(),m.getAlter()))
               : "");
     }
     catch (NullPointerException e)

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -390,7 +390,7 @@ public class PersonalbogenAction implements Action
         + Einstellungen.DECIMALFORMAT.format(BeitragsUtil.getBeitrag(
             Einstellungen.getEinstellung().getBeitragsmodel(),
             m.getZahlungstermin(), m.getZahlungsrhythmus().getKey(), bg,
-            new Date(), m.getEintritt(), m.getAustritt()))
+            new Date(), m.getEintritt(), m.getAustritt(),m.getAlter()))
         + " EUR";
     rpt.addColumn(beitragsgruppe, Element.ALIGN_LEFT);
   }

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -321,6 +321,8 @@ public class EinstellungControl extends AbstractControl
   private TextInput qrcodeintro;
 
   private CheckboxInput qrcodekuerzen;
+  
+  private TextInput beitragaltersstufen;
 
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
@@ -842,6 +844,17 @@ public class EinstellungControl extends AbstractControl
         new ArbeitsstundenModel(Einstellungen.getEinstellung()
             .getArbeitsstundenmodel()));
     return arbeitsstundenmodel;
+  }
+  
+  public Input getBeitragAltersgruppen() throws RemoteException
+  {
+    if (beitragaltersstufen != null)
+    {
+      return beitragaltersstufen;
+    }
+    beitragaltersstufen = new TextInput(Einstellungen.getEinstellung()
+        .getBeitragAltersstufen(), 200);
+    return beitragaltersstufen;
   }
 
   public SelectInput getSepamandatidsourcemodel() throws RemoteException
@@ -2060,6 +2073,7 @@ public class EinstellungControl extends AbstractControl
       e.setCt1SepaVersion((SepaVersion) ct1sepaversion.getValue());
       e.setSEPADatumOffset((Integer) sepadatumoffset.getValue());
       e.setAbrlAbschliessen((Boolean) abrlabschliessen.getValue());
+      e.setBeitragAltersstufen((String)beitragaltersstufen.getValue());
       e.store();
       Einstellungen.setEinstellung(e);
 

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
@@ -22,12 +22,16 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BeitragsgruppeSucheAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BeitragsgruppeControl;
+import de.jost_net.JVerein.gui.util.SimpleVerticalContainer;
+import de.jost_net.JVerein.keys.Beitragsmodel;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Container;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.util.ApplicationException;
 
@@ -68,9 +72,28 @@ public class BeitragsgruppeDetailView extends AbstractView
         break;
       }
     }
+    
     group.addLabelPair("Beitragsart", control.getBeitragsArt());
     group.addLabelPair("Buchungsart", control.getBuchungsart());
 
+    if(Einstellungen.getEinstellung().getBeitragsmodel() != Beitragsmodel.FLEXIBEL
+        && Einstellungen.getEinstellung().getGeburtsdatumPflicht())
+    {
+      Input[] altersstaffel = control.getAltersstaffel();
+      if (altersstaffel != null)
+      {
+        Container cont = new LabelGroup(getParent(), "Altersstaffel");
+        SimpleVerticalContainer svc = new SimpleVerticalContainer(
+            cont.getComposite(), true, 3);
+        svc.addCheckbox(control.getIsAltersstaffel(), "Nach Alter gestaffelte Beiträge verwenden");
+        for (Input inp : altersstaffel)
+        {
+          svc.addInput(inp);
+        }
+        svc.arrangeVertically();
+      }
+    }
+    
     if (Einstellungen.getEinstellung().getArbeitseinsatz())
     {
       LabelGroup groupAe = new LabelGroup(getParent(), "Arbeitseinsatz");

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
@@ -47,6 +47,7 @@ public class EinstellungenAbrechnungView extends AbstractView
         control.getSepaVersion());
     cont.addLabelPair("Arbeitsstunden Modell",
         control.getArbeitsstundenmodel());
+    cont.addLabelPair("Altersstufen für gestaffelte Beiträge",control.getBeitragAltersgruppen());
     cont.addLabelPair("Abrechnungslauf abschließen",
         control.getAbrlAbschliessen());
     cont.addSeparator();

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -409,7 +409,7 @@ public class AbrechnungSEPA
       betr = BeitragsUtil.getBeitrag(
           Einstellungen.getEinstellung().getBeitragsmodel(),
           mZahler.getZahlungstermin(), mZahler.getZahlungsrhythmus().getKey(), bg,
-          param.stichtag, m.getEintritt(), m.getAustritt());
+          param.stichtag, m.getEintritt(), m.getAustritt(),m.getAlter());
     }
     catch (NullPointerException e)
     {

--- a/src/de/jost_net/JVerein/rmi/Altersstaffel.java
+++ b/src/de/jost_net/JVerein/rmi/Altersstaffel.java
@@ -1,0 +1,21 @@
+package de.jost_net.JVerein.rmi;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.rmi.DBObject;
+
+public interface Altersstaffel extends DBObject
+{
+
+  public double getBetrag() throws RemoteException;
+  
+  public void setBetrag(double betrag) throws RemoteException;
+  
+  public Beitragsgruppe getBeitragsgruppe() throws RemoteException;
+  
+  public void setBeitragsgruppe(Beitragsgruppe beitragsgruppe) throws RemoteException;
+  
+  public int getNummer() throws RemoteException;
+  
+  public void setNummer(int nummer) throws RemoteException;
+}

--- a/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
+++ b/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.rmi;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.keys.ArtBeitragsart;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBObject;
 
 public interface Beitragsgruppe extends DBObject
@@ -72,5 +73,13 @@ public interface Beitragsgruppe extends DBObject
   public String getNotiz() throws RemoteException;
 
   public void setNotiz(String notiz) throws RemoteException;
+
+  public boolean getHasAltersstaffel() throws RemoteException;
+  
+  public void setHasAltersstaffel(boolean b) throws RemoteException;
+
+  public DBIterator<Altersstaffel> getAltersstaffelIterator() throws RemoteException;
+
+  public Altersstaffel getAltersstaffel(int nummer) throws RemoteException;
 
 }

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -595,4 +595,8 @@ public interface Einstellung extends DBObject, IBankverbindung
   public Boolean getAnhangSpeichern() throws RemoteException;
 
   public void setAnhangSpeichern(Boolean anhangspeichern) throws RemoteException;
+  
+  public String getBeitragAltersstufen() throws RemoteException;
+
+  public void setBeitragAltersstufen(String altersstufen) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/AltersstaffelImpl.java
+++ b/src/de/jost_net/JVerein/server/AltersstaffelImpl.java
@@ -1,0 +1,86 @@
+package de.jost_net.JVerein.server;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.rmi.Altersstaffel;
+import de.jost_net.JVerein.rmi.Beitragsgruppe;
+import de.willuhn.datasource.db.AbstractDBObject;
+
+public class AltersstaffelImpl extends AbstractDBObject implements Altersstaffel
+{
+
+  private static final long serialVersionUID = 1L;
+
+  public AltersstaffelImpl() throws RemoteException
+  {
+    super();
+  }
+
+  @Override
+  public double getBetrag() throws RemoteException
+  {
+    Double d = (Double) getAttribute("betrag");
+    if (d == null)
+    {
+      return 0;
+    }
+    return d.doubleValue();
+  }
+
+  @Override
+  public void setBetrag(double betrag) throws RemoteException
+  {
+    setAttribute("betrag", Double.valueOf(betrag));
+  }
+
+  @Override
+  public Beitragsgruppe getBeitragsgruppe() throws RemoteException
+  {
+    return (Beitragsgruppe) getAttribute("beitragsgruppe");
+  }
+
+  @Override
+  public void setBeitragsgruppe(Beitragsgruppe beitragsgruppe) throws RemoteException
+  {
+    setAttribute("beitragsgruppe", beitragsgruppe);
+  }
+
+  @Override
+  protected String getTableName()
+  {
+    return "altersstaffel";
+  }
+
+  @Override
+  public int getNummer() throws RemoteException
+  {
+    Integer i = (Integer) getAttribute("nummer");
+    if (i == null)
+    {
+      return 0;
+    }
+    return i.intValue();
+  }
+
+  @Override
+  public void setNummer(int nummer) throws RemoteException
+  {
+    setAttribute("nummer", Integer.valueOf(nummer));
+  }
+
+  @Override
+  public String getPrimaryAttribute() throws RemoteException
+  {
+   return "id";
+  }
+
+  @Override
+  protected Class<?> getForeignObject(String arg0)
+  {
+    if (arg0.equals("beitragsgruppe"))
+    {
+      return Beitragsgruppe.class;
+    }
+    return null;
+  }
+}

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
+import de.jost_net.JVerein.rmi.Altersstaffel;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Mitglied;
@@ -346,5 +347,43 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   public Object getAttribute(String fieldName) throws RemoteException
   {
     return super.getAttribute(fieldName);
+  }
+
+  @Override
+  public boolean getHasAltersstaffel() throws RemoteException
+  {
+    return (boolean) getAttribute("altersstaffel");
+  }
+  
+  @Override
+  public DBIterator<Altersstaffel> getAltersstaffelIterator()
+      throws RemoteException
+  {
+    DBIterator<Altersstaffel> a = Einstellungen.getDBService()
+        .createList(Altersstaffel.class);
+    a.addFilter("beitragsgruppe = ?", getID());
+    a.setOrder("order by nummer");
+    return a;
+  }
+  
+
+  @Override
+  public Altersstaffel getAltersstaffel(int nummer)
+      throws RemoteException
+  {
+    DBIterator<Altersstaffel> a = Einstellungen.getDBService()
+        .createList(Altersstaffel.class);
+    a.addFilter("beitragsgruppe = ?", getID());
+    a.addFilter("nummer = ?",nummer);
+    if(a.hasNext())
+      return a.next();
+    else
+      return null;
+  }
+
+  @Override
+  public void setHasAltersstaffel(boolean b) throws RemoteException
+  {
+    setAttribute("altersstaffel", b);
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0445.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0445.java
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.jost_net.JVerein.server.DDLTool.Table;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0445 extends AbstractDDLUpdate
+{
+  public Update0445(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    Table t = new Table("altersstaffel");
+    Column pk = new Column("id", COLTYPE.BIGINT, 10, null, true, true);
+    t.add(pk);
+    Column beitragsgruppe = new Column("beitragsgruppe", COLTYPE.BIGINT, 10,
+        null, true, false);
+    t.add(beitragsgruppe);
+    Column nummer = new Column("nummer", COLTYPE.BIGINT, 10, null, true,
+        false);
+    t.add(nummer);
+    Column betrag = new Column("betrag", COLTYPE.DOUBLE, 10, null, true,
+        false);
+    t.add(betrag);
+    t.setPrimaryKey(pk);
+    execute(this.createTable(t));
+    
+    execute(this.createForeignKey("fk_altersstaffel",
+        "altersstaffel", "beitragsgruppe", "beitragsgruppe", "id",
+        "RESTRICT", "CASCADE"));
+    
+    execute(addColumn("beitragsgruppe", new Column("altersstaffel",
+        COLTYPE.BOOLEAN, 0, "FALSE", true, false)));
+    
+    execute(addColumn("einstellung", new Column("beitragaltersstufen",
+        COLTYPE.VARCHAR, 200, "'0-6,7-12,13-18,19-99'", false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.server;
 
 import java.io.Serializable;
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Date;
+import de.jost_net.JVerein.util.VonBis;
 import org.kapott.hbci.sepa.SepaVersion;
 
 import de.jost_net.JVerein.Einstellungen;
@@ -122,6 +124,34 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
         throw new ApplicationException(e.getMessage());
       }
 
+      try
+      {
+        AltersgruppenParser ap = new AltersgruppenParser(getBeitragAltersstufen());
+        ArrayList<VonBis> vbs = new ArrayList<VonBis>();
+        while(ap.hasNext())
+        {
+          vbs.add(ap.getNext());
+        }
+        for(int i=0;i<100;i++)
+        {
+          boolean found = false;
+          for(VonBis vb : vbs)
+          {
+            if(i >= vb.getVon() && i <= vb.getBis())
+            {
+              found = true;
+              break;
+            }
+          }
+          if(!found)
+            throw new ApplicationException("Keine passende Altersstufe gefunden für " + i + " Jahre");
+        }
+      }
+      catch (RuntimeException e)
+      {
+        throw new ApplicationException(e.getMessage());
+      }
+      
       if (getDokumentenspeicherung())
       {
         if (!JVereinPlugin.isArchiveServiceActive())
@@ -2021,5 +2051,22 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   public void setAnhangSpeichern(Boolean anhangspeichern) throws RemoteException
   {
     setAttribute("anhangspeichern", anhangspeichern);
+  }
+
+  @Override
+  public String getBeitragAltersstufen() throws RemoteException
+  {
+    String altersstufe = (String) getAttribute("beitragaltersstufen");
+    if (altersstufe == null)
+    {
+      return "0-99";
+    }
+    return altersstufe;
+  }
+
+  @Override
+  public void setBeitragAltersstufen(String altersstufen) throws RemoteException
+  {
+    setAttribute("beitragaltersstufen", altersstufen);
   }
 }

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -185,7 +185,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
             Einstellungen.getEinstellung().getBeitragsmodel(),
             this.getZahlungstermin(), this.getZahlungsrhythmus().getKey(),
             this.getBeitragsgruppe(), new Date(), getEintritt(),
-            getAustritt()) > 0)
+            getAustritt(),getAlter()) > 0)
     {
       if (getBic() == null || getBic().length() == 0 || getIban() == null
           || getIban().length() == 0)


### PR DESCRIPTION
Die Beiträge automatisch abhängig vom Alter berechnen. Bei den Beitragsgruppen können unterschiedliche Beiträge angegeben werden. Wegen der Unübersichtlichkeit habe ich es bei Flexibler Abrechnung nicht ermöglicht.
Wegen der Datenbankversion kann es erst nach #307 und #296 übernommen werden.