### PR TITLE
Fix Dialog Close Verhalten

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/HibiscusKontenImportAction.java
+++ b/src/de/jost_net/JVerein/gui/action/HibiscusKontenImportAction.java
@@ -55,18 +55,17 @@ public class HibiscusKontenImportAction implements Action
       }
       catch (OperationCanceledException oce)
       {
-        GUI.getStatusBar().setErrorText("Vorgang abgebrochen");
-        return;
+        throw oce;
       }
       catch (Exception e)
       {
-        Logger.error("error while choosing konto", e);
+        Logger.error("Error while choosing konto", e);
         GUI.getStatusBar().setErrorText("Fehler bei der Auswahl des Kontos.");
       }
     }
 
     if (context == null || !(context instanceof Konto))
-      throw new ApplicationException("Kein Konto ausgewählt");
+      return;
 
     final Konto k = (Konto) context;
     try

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1521,6 +1521,8 @@ public class BuchungsControl extends AbstractControl
       
       // 20220823: sbuer: Statische Variablen fuer neue Sortiermöglichkeiten
       String sort = djs.open();
+      if (djs.getClosed())
+        return;
       query.setOrdername(sort);
 
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsjournalSortDialog.java
@@ -52,9 +52,11 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
   public final static String DATUM_BLATTNUMMER_ID = "Datum, Blattnummer, Id";
   public final static String DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID = "Datum, Auszugsnummer, Blattnummer, Id";
 
-  private String selected = DATUM;
+  private String selected = DATUM_AUSGZUGSNUMMER_BLATTNUMMER_ID;
 
   private SelectInput sortierung = null;
+  
+  private boolean closed = true;
 
   public BuchungsjournalSortDialog(int position)
   {
@@ -75,6 +77,7 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
       @Override
       public void handleAction(Object context)
       {
+        closed = false;
         close();
       }
     }, null, false, "go-next.png");
@@ -119,5 +122,10 @@ public class BuchungsjournalSortDialog extends AbstractDialog<String>
       }
     });
     return this.sortierung;
+  }
+  
+  public boolean getClosed()
+  {
+    return closed;
   }
 }


### PR DESCRIPTION
Ich habe das Verhalten bei Close und ESC bei zwei Dialogen geändert, so dass keine Meldungen mehr ausgegeben werden wie es sonst auch ist.

Beim Konten->Hibiscus-Konten-Import fange ich das ESC und Close ab.

Bei Buchungen->PDF Buchungsjournal fange ich das Close ab. Hier habe ich auch den Defaultwert geändert damit er mit dem preselected Wert übereinstimmt.