### PR TITLE
Sortieren nach id numerisch satt alphabetisch

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -255,7 +255,7 @@ public class JahresabschlussControl extends AbstractControl
     jahresabschluesse.setOrder("ORDER BY von desc");
 
     jahresabschlussList = new TablePart(jahresabschluesse, null);
-    jahresabschlussList.addColumn("Nr", "id");
+    jahresabschlussList.addColumn("Nr", "id-int");
     jahresabschlussList.addColumn("Von", "von",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     jahresabschlussList.addColumn("Bis", "bis",

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -53,7 +53,7 @@ public class LastschriftControl extends FilterControl
       return lastschriftList;
     }
     lastschriftList = new TablePart(getLastschriften(), null);
-    lastschriftList.addColumn("Nr", "id");
+    lastschriftList.addColumn("Nr", "id-int");
     lastschriftList.addColumn("Abrechnungslauf", "abrechnungslauf");
     lastschriftList.addColumn("Name", "name");
     lastschriftList.addColumn("Vorname", "vorname");

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -617,7 +617,7 @@ public class MailControl extends FilterControl
       return mailsList;
     }
     mailsList = new TablePart(getMails(), new MailDetailAction());
-    mailsList.addColumn("Nr", "id");
+    mailsList.addColumn("Nr", "id-int");
     mailsList.addColumn("Betreff", "betreff");
     mailsList.addColumn("Bearbeitung", "bearbeitung",
         new DateFormatter(new JVDateFormatDATETIME()));

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -684,7 +684,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     }
     spbList = new TablePart(getSpendenbescheinigungen(),
         new SpendenbescheinigungAction(Spendenart.SACHSPENDE));
-    spbList.addColumn("Nr", "id");
+    spbList.addColumn("Nr", "id-int");
     spbList.addColumn("Bescheinigungsdatum", "bescheinigungsdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     spbList.addColumn("Spendedatum", "spendedatum",

--- a/src/de/jost_net/JVerein/server/JahresabschlussImpl.java
+++ b/src/de/jost_net/JVerein/server/JahresabschlussImpl.java
@@ -174,6 +174,18 @@ public class JahresabschlussImpl extends AbstractDBObject
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
+    if ("id-int".equals(fieldName))
+    {
+      try
+      {
+        return Integer.valueOf(getID());
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to parse id: " + getID());
+        return getID();
+      }
+    }
     return super.getAttribute(fieldName);
   }
 }

--- a/src/de/jost_net/JVerein/server/LastschriftImpl.java
+++ b/src/de/jost_net/JVerein/server/LastschriftImpl.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.logging.Logger;
 
 public class LastschriftImpl extends AbstractDBObject implements Lastschrift
 {
@@ -380,6 +381,18 @@ public class LastschriftImpl extends AbstractDBObject implements Lastschrift
     else if(fieldName.equals("abrechnungslauf"))
     {
     	return getAbrechnungslauf();
+    }
+    else if ("id-int".equals(fieldName))
+    {
+      try
+      {
+        return Integer.valueOf(getID());
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to parse id: " + getID());
+        return getID();
+      }
     }
     else
     {

--- a/src/de/jost_net/JVerein/server/MailImpl.java
+++ b/src/de/jost_net/JVerein/server/MailImpl.java
@@ -174,6 +174,18 @@ public class MailImpl extends AbstractDBObject implements Mail
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
+    if ("id-int".equals(fieldName))
+    {
+      try
+      {
+        return Integer.valueOf(getID());
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to parse id: " + getID());
+        return getID();
+      }
+    }
     return super.getAttribute(fieldName);
   }
 }

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -350,6 +350,18 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
+    if ("id-int".equals(fieldName))
+    {
+      try
+      {
+        return Integer.valueOf(getID());
+      }
+      catch (Exception e)
+      {
+        Logger.error("unable to parse id: " + getID());
+        return getID();
+      }
+    }
     return super.getAttribute(fieldName);
   }
 


### PR DESCRIPTION
In Jahresabschluss, Lastschrift, Mail, Spendenbescheinigung id nummersich sortieren statt alhabetisch.