### PR TITLE
Einstellungen neu laden wenn beim speichern eine exception auftritt

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -225,6 +225,11 @@ public class Einstellungen
   {
     einstellung = einst;
   }
+  
+  public static void reloadEinstellung() throws RemoteException
+  {
+	  einstellung = (Einstellung) getDBService().createObject(Einstellung.class, "1");
+  }
 
   /**
    * Prueft, ob die MD5-Checksumme der Datenbank geprueft werden soll.

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -1973,10 +1973,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+      try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2028,10 +2038,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2067,10 +2087,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2090,10 +2120,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2127,10 +2167,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2159,10 +2209,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2197,10 +2257,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2214,6 +2284,11 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2274,6 +2349,11 @@ public class EinstellungControl extends AbstractControl
     }
     catch (Exception e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2296,10 +2376,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }
@@ -2353,10 +2443,20 @@ public class EinstellungControl extends AbstractControl
     }
     catch (RemoteException e)
     {
+	  try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (ApplicationException e)
     {
+      try {
+		Einstellungen.reloadEinstellung();
+	  } catch (RemoteException e1) {
+		  Logger.error("Reload der Einstellungen felgeschlagen");
+	  }
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
   }


### PR DESCRIPTION
Momentan werden die Einstellungen beim Speichern in das statische Einstellungen Object geschrieben, auch wenn das Speichern fehl schlägt. So sind die Falschen Einstellungen in der aktuellen Session weiter vorhanden. Durch diese Änderung werden die Einstellungen bei einem Fehler beim Speichern aus der DB neu geladen.