### PR TITLE
Submenü für freie Formulare

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/FreieFormulareMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FreieFormulareMenu.java
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.menu;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.FreiesFormularAction;
+import de.jost_net.JVerein.keys.FormularArt;
+import de.jost_net.JVerein.rmi.Formular;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+
+/**
+ * Kontext-Menu zu den Mails.
+ */
+public class FreieFormulareMenu extends ContextMenu
+{
+
+  public FreieFormulareMenu() throws RemoteException
+  {
+    DBIterator<Formular> it = Einstellungen.getDBService()
+        .createList(Formular.class);
+    it.addFilter("art = ?",
+        new Object[] { FormularArt.FREIESFORMULAR.getKey() });
+    while (it.hasNext())
+    {
+      Formular f = (Formular) it.next();
+      addItem(new CheckedContextMenuItem(f.getBezeichnung(),
+          new FreiesFormularAction(f.getID()), "file-invoice.png"));
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.SWT;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.NichtMitgliedDetailAction;
-import de.jost_net.JVerein.gui.action.FreiesFormularAction;
 import de.jost_net.JVerein.gui.action.KontoauszugAction;
 import de.jost_net.JVerein.gui.action.MitgliedArbeitseinsatzZuordnungAction;
 import de.jost_net.JVerein.gui.action.MitgliedDeleteAction;
@@ -111,7 +110,7 @@ public class MitgliedMenu extends ContextMenu
             throw new ApplicationException(e);
           }
         }
-      }, "arrows-alt-h.png"));
+      }, "view-refresh.png"));
     }
     else
     {
@@ -170,7 +169,7 @@ public class MitgliedMenu extends ContextMenu
             throw new ApplicationException(e);
           }
         }
-      }, "arrows-alt-h.png"));
+      }, "view-refresh.png"));
     }
     if (detailaction instanceof NichtMitgliedDetailAction)
     {
@@ -212,11 +211,12 @@ public class MitgliedMenu extends ContextMenu
         .createList(Formular.class);
     it.addFilter("art = ?",
         new Object[] { FormularArt.FREIESFORMULAR.getKey() });
-    while (it.hasNext())
+    if (it.hasNext())
     {
-      Formular f = (Formular) it.next();
-      addItem(new CheckedContextMenuItem(f.getBezeichnung(),
-          new FreiesFormularAction(f.getID()), "file-invoice.png"));
+      addItem(ContextMenuItem.SEPARATOR);
+      ContextMenu freieformularemenu = new FreieFormulareMenu();
+      freieformularemenu.setText("Freie Formulare");
+      addMenu(freieformularemenu);
     }
   }
 }


### PR DESCRIPTION
Ich habe festgestellt, dass freie Formulare automatisch in das Kontextmenü bei Mitglieder eingefügt werden. Hat man viele freie Formulare wird das Menü immer größer und unübersichtlicher. Ich habe darum ein Submenü eingebaut indem die freien Formulare aufgelistet sind.
Das Submenü wird im Mitgliedmenü nur angezeigt wenn es freie Formulare gibt.
![Bildschirmfoto_20240927_155023](https://github.com/user-attachments/assets/c6da5a16-97a7-4f2b-8b28-8d3ed2412064)

Auch habe ich das Icon für das Umwandeln der Mitglieder geändert. Es entspricht jetzt dem welches auch beim Kursteilnehmer verwendet wird. Das alte hat sowieso nicht zum Stil der andern Icons gepasst.