### PR TITLE
Spendenbescheinigung Ersatz für Aufwendungen korrekt anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
@@ -83,7 +83,7 @@ public class SpendenbescheinigungView extends AbstractView
     /*
      * Betrag kann bei Geldspenden nicht geändert werden
      */
-    if (control.getSpendenbescheinigung().getAutocreate())
+    if (control.getSpendenbescheinigung().getSpendenart() == Spendenart.GELDSPENDE)
     {
       control.getSpendenart().setEnabled(false);
       control.getBetrag().setEnabled(false);


### PR DESCRIPTION
Im Spendenbescheinigung View wurde Ersatz für Aufwendungen immer aus der Spendenbescheinigung gelesen.
Beim Generieren der Spendenbescheinigung wird bei Geldspenden aber der Wert aus der Buchung gelesen. Also stimmt die Anzeige nicht mit der tatsächlichen Ausgabe überein.

Ich habe jetzt das Feld disabled. Bei Sachspenden ist der Wert sowieso immer false. 
Bei Sammelbescheinigungen können Buchungen mit und ohne Ersatz für Aufwendungen gemischt sein. Ich habe hier neben der Checkbox den Hinweis eingefügt in der Buchungsliste zu schauen. Hier habe ich eine Spalte mit dem Wert aus der Buchung eingefügt. So kann man für jede Buchung den Wert sehen. So schaut auch die Tabelle auf der zweiten Seite der Spendenbescheinigung aus.
Ist es Geldspende und es hat nur eine Buchung zeige ich entweder den Wert aus der Buchung oder aus der Spendenbescheinigung an abhängig vom Flag Auto so wie es auch für das PDF implementiert ist. 
Das hat einen eigenen Hintergrund. Als ich die Spendenbescheinigung umgebaut habe (früherer PR) war mir das Auto Flag nicht so bewusst und ich habe es immer bei Geldspende gesetzt. Beim Umbau der Online Help habe ich gelesen, dass wenn man die Bescheinigung mit rechts Klick auf eine Istbuchung im Mitgliedskontont Tab erzeugt dies manuell ist. Erzeugt man sie mit rechts Klick auf das Mitglied oder per autocreate Button ist es auto. Das bedeutet, das das Verzicht Flag einmal aus der Bescheinigung und einmal aus der Buchung gelesen wird je nachdem wie die Bescheinigung erzeugt wurde. Das finde ich nicht gut. Wie soll man später noch wissen wie sie erzeugt wurde. In der jetzigen Implementierung kommt der Wert immer aus der Buchung da immer auto gesetzt wird.
Eigentlich könnte man das auto Flag weg machen. Aber aus Kompatibilitätsgründen zu früher erzeugten Bescheinigungen lasse ich es.