### PR TITLE
Anschreiben in Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -19,10 +19,14 @@ package de.jost_net.JVerein.gui.action;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.rmi.RemoteException;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Chunk;
@@ -34,13 +38,17 @@ import com.itextpdf.text.pdf.PdfPCell;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.Variable.VarTools;
 import de.jost_net.JVerein.io.FormularAufbereitung;
 import de.jost_net.JVerein.io.Reporter;
+import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.HerkunftSpende;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Formular;
+import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.Dateiname;
 import de.jost_net.JVerein.util.JVDateFormatJJJJ;
@@ -61,9 +69,11 @@ public class SpendenbescheinigungPrintAction implements Action
 
   private boolean standardPdf = true;
   
-  private boolean adressblatt = false;
+  private Adressblatt adressblatt = Adressblatt.OHNE_ADRESSBLATT;
 
   private String fileName = null;
+  
+  private String text = null;
 
   private de.willuhn.jameica.system.Settings settings;
 
@@ -82,12 +92,33 @@ public class SpendenbescheinigungPrintAction implements Action
    * Konstruktor. Über den Parameter kann festgelegt werden, ob das Standard-
    * oder das individuelle Dokument aufbereitet werden soll.
    * 
+   * @param txt
+   *          Anschreiben auf PDF
    * @param standard
    *          true=Standard-Dokument, false=individuelles Dokument
    * @param adressblatt
-   *          true=für Adressblatt drucken, false=für kein Adressblatt drucken
+   *          enum Adressblatt
    */
-  public SpendenbescheinigungPrintAction(boolean standard, boolean adressblatt)
+  public SpendenbescheinigungPrintAction(String text, boolean standard, Adressblatt adressblatt)
+  {
+    super();
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+    standardPdf = standard;
+    this.adressblatt = adressblatt;
+    this.text = text;
+  }
+  
+  /**
+   * Konstruktor. Über den Parameter kann festgelegt werden, ob das Standard-
+   * oder das individuelle Dokument aufbereitet werden soll.
+   * 
+   * @param standard
+   *          true=Standard-Dokument, false=individuelles Dokument
+   * @param adressblatt
+   *          enum Adressblatt
+   */
+  public SpendenbescheinigungPrintAction(boolean standard, Adressblatt adressblatt)
   {
     super();
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
@@ -103,11 +134,11 @@ public class SpendenbescheinigungPrintAction implements Action
    * @param standard
    *          true=Standard-Dokument, false=individuelles Dokument
    * @param adressblatt
-   *          true=Standard-Dokument, false=individuelles Dokument
+   *          enum Adressblatt
    * @param fileName
    *          Dateiname als Vorgabe inklusive Pfad
    */
-  public SpendenbescheinigungPrintAction(boolean standard, boolean adressblatt, String fileName)
+  public SpendenbescheinigungPrintAction(boolean standard, Adressblatt adressblatt, String fileName)
   {
     super();
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
@@ -235,11 +266,24 @@ public class SpendenbescheinigungPrintAction implements Action
           map = new AllgemeineMap().getMap(map);
           FormularAufbereitung fa = new FormularAufbereitung(file);
           fa.writeForm(fo, map);
+          if (adressblatt != Adressblatt.OHNE_ADRESSBLATT)
+          {
+            // Neue Seite für Anschrift in Fenster in querem Brief
+            // oder für Anschreiben
+            fa.printNeueSeite();
+          }
           // Brieffenster drucken bei Spendenbescheinigung
-          if (adressblatt)
+          if (adressblatt == Adressblatt.MIT_ADRESSE ||
+              adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
           {
             fa.printAdressfenster(getAussteller(), 
                 (String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()));
+          }
+          // Anschreiben drucken
+          if (adressblatt == Adressblatt.MIT_ANSCHREIBEN ||
+              adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
+          {
+            fa.printAnschreiben(spb, text);
           }
           fa.closeFormular();
         }
@@ -944,7 +988,7 @@ public class SpendenbescheinigungPrintAction implements Action
    * @throws DocumentException
    */
   private void generiereSpendenbescheinigungStandardAb2014(
-      Spendenbescheinigung spb, String fileName, boolean adressblatt)
+      Spendenbescheinigung spb, String fileName, Adressblatt adressblatt)
       throws IOException, DocumentException
   {
     final File file = new File(fileName);
@@ -1393,16 +1437,41 @@ public class SpendenbescheinigungPrintAction implements Action
       rpt.closeTable();      
     }
     
-    if (adressblatt)
+    if (adressblatt != Adressblatt.OHNE_ADRESSBLATT)
     {
-      // Neue Seite mit Anschrift für Fenster in querem Brief
+      // Neue Seite für Anschrift in Fenster in querem Brief
+      // oder für Anschreiben
       rpt.newPage();
+    }
+    
+    if (adressblatt == Adressblatt.MIT_ADRESSE ||
+        adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
+    {
+      // Anschrift für Fenster in querem Brief
       rpt.add(new Paragraph(" ", Reporter.getFreeSans(12)));
       rpt.add("\n\n\n\n\n", 12);
       rpt.addUnderline(getAussteller(),8);
       rpt.addLight((String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()),9);
     }
-
+    
+    if (adressblatt == Adressblatt.MIT_ANSCHREIBEN ||
+        adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
+    {
+      // Anschreiben
+      rpt.add("\n\n\n", 12);
+      Mitglied m = spb.getMitglied();
+      VelocityContext context = new VelocityContext();
+      context.put("dateformat", new JVDateFormatTTMMJJJJ());
+      context.put("decimalformat", Einstellungen.DECIMALFORMAT);
+      context.put("email", m.getEmail());
+      Map<String, Object> mmap = new MitgliedMap().getMap(m, null);
+      mmap = new AllgemeineMap().getMap(mmap);
+      VarTools.add(context, mmap);
+      StringWriter wtext = new StringWriter();
+      Velocity.evaluate(context, wtext, "LOG", text);
+      rpt.addLight(wtext.getBuffer().toString(), 10);
+    }
+    
     rpt.close();
     fos.close();
   }

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -3,6 +3,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.input.FormularInput;
+import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Ausgabesortierung;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -126,9 +127,8 @@ public class DruckMailControl extends FilterControl
     {
       return adressblatt;
     }
-    adressblatt = new SelectInput( 
-        new String[] { "Ohne", "Mit" },
-        settings.getString(settingsprefix + "adressblatt", "Ohne"));
+    adressblatt = new SelectInput( Adressblatt.values(),
+        Adressblatt.getByKey(settings.getInt(settingsprefix + "adressblatt", 1)));
     adressblatt.setName("Adressblatt");
     return adressblatt;
   }
@@ -200,8 +200,8 @@ public class DruckMailControl extends FilterControl
     }
     if (adressblatt != null)
     {
-      String ab = (String) getAdressblatt().getValue();
-      settings.setAttribute(settingsprefix + "adressblatt", ab);
+      Adressblatt ab = (Adressblatt) getAdressblatt().getValue();
+      settings.setAttribute(settingsprefix + "adressblatt", ab.getKey());
     }
     if (ausgabesortierung != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -52,6 +52,7 @@ import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.FormularAufbereitung;
 import de.jost_net.JVerein.io.MailSender;
+import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.keys.HerkunftSpende;
@@ -316,6 +317,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     {
       formular = new FormularInput(FormularArt.SPENDENBESCHEINIGUNG, def);
     }
+    formular.setPleaseChoose("Bitte auswählen");
     return formular;
   }
 
@@ -486,13 +488,22 @@ public class SpendenbescheinigungControl extends DruckMailControl
     }
   }
 
-  public Button getPDFStandardButton(final boolean adressblatt)
+  public Button getPDFStandardButton(final Adressblatt adressblatt)
   {
-    String label = "PDF (Standard)";
-    if (adressblatt)
+    String label = "";
+    switch (adressblatt)
     {
-      label = "PDF (Standard, Mit Adressblatt)";
+      case OHNE_ADRESSBLATT:
+        label = "PDF (Standard)";
+        break;
+      case MIT_ADRESSE:
+        label = "PDF (Standard, Mit Adresse)";
+        break;
+      case MIT_ANSCHREIBEN:  // Hier nicht unterstützt
+      case MIT_ADRESSE_ANSCHREIBEN:
+        break;
     }
+    
     Button b = new Button(label, new Action()
     {
 
@@ -565,13 +576,22 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return b;
   }
 
-  public Button getPDFIndividuellButton(final boolean adressblatt)
+  public Button getPDFIndividuellButton(final Adressblatt adressblatt)
   {
-    String label = "PDF (Individuell)";
-    if (adressblatt)
+    String label = "";
+    switch (adressblatt)
     {
-      label = "PDF (Individuell, Mit Adressblatt)";
+      case OHNE_ADRESSBLATT:
+        label = "PDF (Individuell)";
+        break;
+      case MIT_ADRESSE:
+        label = "PDF (Individuell, Mit Adresse)";
+        break;
+      case MIT_ANSCHREIBEN:  // Hier nicht unterstützt
+      case MIT_ADRESSE_ANSCHREIBEN:
+        break;
     }
+
     Button b = new Button(label, new Action()
     {
 
@@ -599,7 +619,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return b;
   }
 
-  private void generiereSpendenbescheinigungIndividuell(boolean adressblatt) throws IOException
+  private void generiereSpendenbescheinigungIndividuell(Adressblatt adressblatt) throws IOException
   {
     Spendenbescheinigung spb = getSpendenbescheinigung();
     if (spb.isNewObject())
@@ -659,8 +679,9 @@ public class SpendenbescheinigungControl extends DruckMailControl
     FormularAufbereitung fa = new FormularAufbereitung(file);
     fa.writeForm(fo, map);
     // Brieffenster drucken bei Spendenbescheinigung
-    if (adressblatt)
+    if (adressblatt == Adressblatt.MIT_ADRESSE)
     {
+      fa.printNeueSeite();
       fa.printAdressfenster(getAussteller(), 
           (String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()));
     }
@@ -885,10 +906,9 @@ public class SpendenbescheinigungControl extends DruckMailControl
           {
             return;
           }
-          generatePdf((String) art.getValue(),
-              (String) adressblatt.getValue(), spbArray);
-          if (ausgabeart == null || 
-              (Ausgabeart) ausgabeart.getValue() == Ausgabeart.MAIL)
+          generatePdf((String) mailtext.getValue(), (String) art.getValue(),
+              (Adressblatt) adressblatt.getValue(), spbArray);
+          if ((Ausgabeart) ausgabeart.getValue() == Ausgabeart.MAIL)
           {
             sendeMail((String) mailbetreff.getValue(),
                 (String) mailtext.getValue(), spbArray);
@@ -904,17 +924,14 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return button;
   }
 
-  private void generatePdf(String ar, String ab, Spendenbescheinigung[] spba)
+  private void generatePdf(String text, String ar, Adressblatt adressblatt, Spendenbescheinigung[] spba)
       throws ApplicationException
   {
     boolean standard = true;
     if (ar.equalsIgnoreCase("Individuell"))
       standard = false;
-    boolean adressblatt = false;
-    if (ab.equalsIgnoreCase("Mit"))
-      adressblatt = true;
     SpendenbescheinigungPrintAction action = 
-        new SpendenbescheinigungPrintAction(standard, adressblatt);
+        new SpendenbescheinigungPrintAction(text, standard, adressblatt);
     action.handleAction(spba);
   }
   

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.gui.action.SpendenbescheinigungDeleteAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungDuplizierenAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungEmailAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungSendAction;
+import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.jameica.gui.Action;
@@ -40,18 +41,18 @@ public class SpendenbescheinigungMenu extends ContextMenu
   public SpendenbescheinigungMenu()
   {
     addItem(new CheckedContextMenuItem("PDF (Standard)",
-        new SpendenbescheinigungPrintAction(true, false), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("PDF (Standard, Mit Adressblatt)",
-        new SpendenbescheinigungPrintAction(true, true), "file-pdf.png"));
+        new SpendenbescheinigungPrintAction(true, Adressblatt.OHNE_ADRESSBLATT), "file-pdf.png"));
+    addItem(new CheckedContextMenuItem("PDF (Standard, Mit Adresse)",
+        new SpendenbescheinigungPrintAction(true, Adressblatt.MIT_ADRESSE), "file-pdf.png"));
     addItem(new CheckedContextMenuItem("PDF (Individuell)",
-        new SpendenbescheinigungPrintAction(false, false), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("PDF (Individuell, Mit Adressblatt)",
-        new SpendenbescheinigungPrintAction(false, true), "file-pdf.png"));
+        new SpendenbescheinigungPrintAction(false, Adressblatt.OHNE_ADRESSBLATT), "file-pdf.png"));
+    addItem(new CheckedContextMenuItem("PDF (Individuell, Mit Adresse)",
+        new SpendenbescheinigungPrintAction(false, Adressblatt.MIT_ADRESSE), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedContextMenuItem("Druck und Mail",
+        new SpendenbescheinigungSendAction(), "document-print.png"));
     addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));
-    addItem(new CheckedContextMenuItem("Spendenbescheinigungen versenden",
-        new SpendenbescheinigungSendAction(), "envelope-open.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new DuplicateMenuItem("Als Vorlage für neue Spende",
         new SpendenbescheinigungDuplizierenAction(), "edit-copy.png"));

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -69,10 +69,7 @@ public class SpendenbescheinigungMailView extends AbstractView
     
     SimpleContainer cont2 = new SimpleContainer(getParent(), false);
     cont2.addHeadline("Parameter");
-    if (this.getCurrentObject() == null)
-    {
-      cont2.addInput(control.getAusgabeart());
-    }
+    cont2.addInput(control.getAusgabeart());
     cont2.addInput(control.getArt());
     cont2.addInput(control.getAdressblatt());
     

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
+import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -101,10 +102,10 @@ public class SpendenbescheinigungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
-    buttons.addButton(control.getPDFStandardButton(false));
-    buttons.addButton(control.getPDFStandardButton(true));
-    buttons.addButton(control.getPDFIndividuellButton(false));
-    buttons.addButton(control.getPDFIndividuellButton(true));
+    buttons.addButton(control.getPDFStandardButton(Adressblatt.OHNE_ADRESSBLATT));
+    buttons.addButton(control.getPDFStandardButton(Adressblatt.MIT_ADRESSE));
+    buttons.addButton(control.getPDFIndividuellButton(Adressblatt.OHNE_ADRESSBLATT));
+    buttons.addButton(control.getPDFIndividuellButton(Adressblatt.MIT_ADRESSE));
     buttons.addButton("Neu (Sachspende)", new SpendenbescheinigungAction(Spendenart.SACHSPENDE), null, false,
         "document-new.png");
     buttons.addButton("Speichern", new Action()

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -21,11 +21,15 @@ import java.awt.Image;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.EncodeHintType;
@@ -44,12 +48,17 @@ import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.PdfWriter;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.AllgemeineVar;
+import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.MitgliedVar;
 import de.jost_net.JVerein.Variable.MitgliedskontoVar;
+import de.jost_net.JVerein.Variable.VarTools;
 import de.jost_net.JVerein.rmi.Einstellung;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.rmi.DBIterator;
@@ -509,13 +518,18 @@ public class FormularAufbereitung
     return stringVal.toString();
   }
   
+  public void printNeueSeite()
+  {
+    // Neue Seite mit Anschrift für Fenster in querem Brief
+      doc.newPage();
+  }
+  
   public void printAdressfenster(String aussteller, String empfaenger)
       throws RemoteException
   {
     // Neue Seite mit Anschrift für Fenster in querem Brief
     try
     {
-      doc.newPage();
       doc.add(new Paragraph(" ", Reporter.getFreeSans(12)));
       doc.add(new Paragraph("\n\n\n\n\n\n", Reporter.getFreeSans(12)));
       Paragraph paragraph = new Paragraph(aussteller, Reporter.getFreeSansUnderline(8));
@@ -524,6 +538,34 @@ public class FormularAufbereitung
       paragraph = new Paragraph(empfaenger, Reporter.getFreeSans(9));
       paragraph.setIndentationLeft(40);
       doc.add(paragraph);
+    }
+    catch (DocumentException e)
+    {
+      throw new RemoteException("Fehler", e);
+    }
+  }
+  
+  public void printAnschreiben(Spendenbescheinigung spb, String text)
+      throws RemoteException
+  {
+    // Anschreiben drucken
+    try
+    {
+      doc.add(new Paragraph("\n\n\n",  Reporter.getFreeSans(12)));
+      Mitglied m = spb.getMitglied();
+      VelocityContext context = new VelocityContext();
+      context.put("dateformat", new JVDateFormatTTMMJJJJ());
+      context.put("decimalformat", Einstellungen.DECIMALFORMAT);
+      context.put("email", m.getEmail());
+      Map<String, Object> mmap = new MitgliedMap().getMap(m, null);
+      mmap = new AllgemeineMap().getMap(mmap);
+      VarTools.add(context, mmap);
+      StringWriter wtext = new StringWriter();
+      Velocity.evaluate(context, wtext, "LOG", text);
+      Paragraph p = new Paragraph(
+          new Paragraph(wtext.getBuffer().toString(), Reporter.getFreeSans(10)));
+      p.setIndentationLeft(40);;
+      doc.add(p);
     }
     catch (DocumentException e)
     {

--- a/src/de/jost_net/JVerein/keys/Adressblatt.java
+++ b/src/de/jost_net/JVerein/keys/Adressblatt.java
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.keys;
+
+/**
+ * Adressblatt
+ */
+public enum Adressblatt
+{
+
+  OHNE_ADRESSBLATT(1, "Ohne Adressblatt"),
+  MIT_ADRESSE(2, "Mit Adresse"),
+  MIT_ANSCHREIBEN(3, "Mit Anschreiben"),
+  MIT_ADRESSE_ANSCHREIBEN(4, "Mit Adresse und Anschreiben");
+
+  private final String text;
+
+  private final int key;
+  
+  Adressblatt(int key, String text)
+  {
+    this.key = key;
+    this.text = text;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public String getText()
+  {
+    return text;
+  }
+
+  public static Adressblatt getByKey(int key)
+  {
+    for (Adressblatt blatt : Adressblatt.values())
+    {
+      if (blatt.getKey() == key)
+      {
+        return blatt;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return getText();
+  }
+}


### PR DESCRIPTION
Im Forum wurden Erweiterungen zur Spendenbescheinigung vorgeschlagen.
Ein erster Schritt hier ist es auf der extra Seite neben der Adresse auch ein Anschreiben einzufügen. Ich habe dazu folgende Erweiterung gemacht.
- Im Kontextmenü der Spendenbescheinigung habe ich den per Mail versenden Eintrag geändert in "Druck und Mail". Damit kommt man zum bisherigen Mail Versenden View, hat aber die Auswahl zwischen DRUCK und MAIL. Das ist so wie wenn es vom Navigationsbaum aufgerufen wird.
![Bildschirmfoto_20241001_201936](https://github.com/user-attachments/assets/b8877150-9089-4cc6-b1a0-9663fef7a16f)
- Bei den PDF Einträgen im Menü habe ich Adressblatt in Adresse geändert, da hier nur die Adresse gedruckt wird. Das Anschreiben ist hier nicht verfügbar.
- Im View gibt es jetzt für das Adressblatt folgende Optionen zur Auswahl von Adresse und/oder Anschreiben.
![Bildschirmfoto_20241001_202437](https://github.com/user-attachments/assets/b5daf036-4473-4442-a112-cb3d5b6388dd)
- Für das Anschreiben wird der Text aus dem Mail Bereich ausgegeben mit den gleichen Ersetzungsmöglichkeiten wie bei der Mail.


Den weiteren Wunsch einen Hintergrund (Vereinspapier) bei der Standard Spendenbescheinigung zu hinterlegen schaue ich mit separat an. Das sollte ein eigener PR werden.
