### PR TITLE
Formularfelder in  Formular Detail View anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/FormularfelderImportAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularfelderImportAction.java
@@ -25,7 +25,7 @@ package de.jost_net.JVerein.gui.action;
 
 import java.rmi.RemoteException;
 
-import de.jost_net.JVerein.gui.control.FormularfeldControl;
+import de.jost_net.JVerein.gui.control.FormularPartControl;
 import de.jost_net.JVerein.gui.dialogs.ImportDialog;
 import de.jost_net.JVerein.gui.view.DokumentationUtil;
 import de.jost_net.JVerein.rmi.Formularfeld;
@@ -40,9 +40,9 @@ import de.willuhn.util.ApplicationException;
 
 public class FormularfelderImportAction implements Action
 {
-  FormularfeldControl control;
+  FormularPartControl control;
 
-  public FormularfelderImportAction(FormularfeldControl control)
+  public FormularfelderImportAction(FormularPartControl control)
   {
     this.control = control;
   }

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -33,7 +33,6 @@ import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.server.FormularImpl;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
-import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.Part;
@@ -47,7 +46,7 @@ import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class FormularControl extends AbstractControl
+public class FormularControl extends FormularPartControl
 {
 
   private de.willuhn.jameica.system.Settings settings;
@@ -66,9 +65,9 @@ public class FormularControl extends AbstractControl
 
   private SelectInput formlink;
 
-  public FormularControl(AbstractView view)
+  public FormularControl(AbstractView view, Formular formular)
   {
-    super(view);
+    super(view, formular);
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
     settings.setStoreWhenRead(true);
   }
@@ -268,7 +267,7 @@ public class FormularControl extends AbstractControl
     return formularList;
   }
 
-  public void refreshTable() throws RemoteException
+  public void refreshFormularTable() throws RemoteException
   {
     formularList.removeAll();
     DBIterator<Formular> formulare = Einstellungen.getDBService()

--- a/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.FormularfeldAction;
+import de.jost_net.JVerein.gui.menu.FormularfeldMenu;
+import de.jost_net.JVerein.rmi.Formular;
+import de.jost_net.JVerein.rmi.Formularfeld;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+
+public class FormularPartControl extends AbstractControl
+{
+  protected TablePart formularfelderList;
+
+  protected Formular formular;
+ 
+
+  public FormularPartControl(AbstractView view, Formular formular)
+  {
+    super(view);
+    this.formular = formular;
+  }
+
+  public Part getFormularfeldList() throws RemoteException
+  {
+    DBService service = Einstellungen.getDBService();
+    DBIterator<Formularfeld> formularfelder = service
+        .createList(Formularfeld.class);
+    formularfelder.addFilter("formular = ?", new Object[] { formular.getID() });
+    formularfelder.setOrder("ORDER BY seite, x, y");
+
+    formularfelderList = new TablePart(formularfelder,
+        new FormularfeldAction());
+    formularfelderList.addColumn("Name", "name");
+    formularfelderList.addColumn("Seite", "seite");
+    formularfelderList.addColumn("Von links", "x");
+    formularfelderList.addColumn("Von unten", "y");
+    formularfelderList.addColumn("Font", "font");
+    formularfelderList.addColumn("Fonthöhe", "fontsize");
+
+    formularfelderList.setRememberColWidths(true);
+    formularfelderList.setContextMenu(new FormularfeldMenu());
+    formularfelderList.setRememberOrder(true);
+    formularfelderList.removeFeature(FeatureSummary.class);
+    return formularfelderList;
+  }
+
+  public void refreshTable() throws RemoteException
+  {
+    formularfelderList.removeAll();
+    DBIterator<Formularfeld> formularfelder = Einstellungen.getDBService()
+        .createList(Formularfeld.class);
+    formularfelder.addFilter("formular = ?", new Object[] { formular.getID() });
+    formularfelder.setOrder("ORDER BY x, y");
+    while (formularfelder.hasNext())
+    {
+      formularfelderList.addItem(formularfelder.next());
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
@@ -27,34 +27,26 @@ import de.jost_net.JVerein.Variable.LastschriftVar;
 import de.jost_net.JVerein.Variable.MitgliedVar;
 import de.jost_net.JVerein.Variable.MitgliedskontoVar;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
-import de.jost_net.JVerein.gui.action.FormularfeldAction;
-import de.jost_net.JVerein.gui.menu.FormularfeldMenu;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
 import de.jost_net.JVerein.rmi.Lesefeld;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.datasource.rmi.DBService;
-import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
-import de.willuhn.jameica.gui.parts.TablePart;
-import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+
 import de.willuhn.logging.Logger;
 
-public class FormularfeldControl extends AbstractControl
+public class FormularfeldControl extends FormularPartControl
 {
 
   private de.willuhn.jameica.system.Settings settings;
-
-  private TablePart formularfelderList;
 
   private SelectInput name;
 
@@ -67,8 +59,6 @@ public class FormularfeldControl extends AbstractControl
   private SelectInput font;
 
   private IntegerInput fontsize;
-
-  private Formular formular;
 
   private Formularfeld formularfeld;
 
@@ -149,10 +139,9 @@ public class FormularfeldControl extends AbstractControl
 
   public FormularfeldControl(AbstractView view, Formular formular)
   {
-    super(view);
+    super(view, formular);
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
     settings.setStoreWhenRead(true);
-    this.formular = formular;
   }
 
   public Input getFormularTyp() throws RemoteException
@@ -372,7 +361,8 @@ public class FormularfeldControl extends AbstractControl
       f.setFont((String) getFont().getValue());
       f.setFontsize((Integer) getFontsize().getValue());
       f.store();
-
+      if (GUI.hasPreviousView())
+        GUI.startPreviousView();
       GUI.getStatusBar().setSuccessText("Formularfeld gespeichert");
     }
     catch (RemoteException e)
@@ -384,43 +374,6 @@ public class FormularfeldControl extends AbstractControl
     catch (Exception e)
     {
       GUI.getStatusBar().setErrorText(e.getMessage());
-    }
-  }
-
-  public Part getFormularfeldList() throws RemoteException
-  {
-    DBService service = Einstellungen.getDBService();
-    DBIterator<Formularfeld> formularfelder = service
-        .createList(Formularfeld.class);
-    formularfelder.addFilter("formular = ?", new Object[] { formular.getID() });
-    formularfelder.setOrder("ORDER BY seite, x, y");
-
-    formularfelderList = new TablePart(formularfelder,
-        new FormularfeldAction());
-    formularfelderList.addColumn("Name", "name");
-    formularfelderList.addColumn("Seite", "seite");
-    formularfelderList.addColumn("Von links", "x");
-    formularfelderList.addColumn("Von unten", "y");
-    formularfelderList.addColumn("Font", "font");
-    formularfelderList.addColumn("Fonthöhe", "fontsize");
-
-    formularfelderList.setRememberColWidths(true);
-    formularfelderList.setContextMenu(new FormularfeldMenu());
-    formularfelderList.setRememberOrder(true);
-    formularfelderList.removeFeature(FeatureSummary.class);
-    return formularfelderList;
-  }
-
-  public void refreshTable() throws RemoteException
-  {
-    formularfelderList.removeAll();
-    DBIterator<Formularfeld> formularfelder = Einstellungen.getDBService()
-        .createList(Formularfeld.class);
-    formularfelder.addFilter("formular = ?", new Object[] { formular.getID() });
-    formularfelder.setOrder("ORDER BY x, y");
-    while (formularfelder.hasNext())
-    {
-      formularfelderList.addItem(formularfelder.next());
     }
   }
 

--- a/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
@@ -17,9 +17,12 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.FormularAnzeigeAction;
 import de.jost_net.JVerein.gui.action.FormularfeldAction;
-import de.jost_net.JVerein.gui.action.FormularfelderListeAction;
+import de.jost_net.JVerein.gui.action.FormularfelderExportAction;
+import de.jost_net.JVerein.gui.action.FormularfelderImportAction;
 import de.jost_net.JVerein.gui.control.FormularControl;
+import de.jost_net.JVerein.rmi.Formular;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -34,7 +37,7 @@ public class FormularDetailView extends AbstractView
   {
     GUI.getView().setTitle("Formular");
 
-    final FormularControl control = new FormularControl(this);
+    final FormularControl control = new FormularControl(this, (Formular) getCurrentObject());
 
     LabelGroup group = new LabelGroup(getParent(), "Formular");
     group.addLabelPair("Bezeichnung", control.getBezeichnung(true));
@@ -42,12 +45,25 @@ public class FormularDetailView extends AbstractView
     group.addLabelPair("Datei", control.getDatei());
     group.addLabelPair("Fortlaufende Nr.", control.getZaehler());
     group.addLabelPair("Formularverknüpfung", control.getFormlink());
+    
+    LabelGroup cont = new LabelGroup(getParent(), "Formularfelder", true);
+    control.getFormularfeldList().paint(cont.getComposite());
+    
+    ButtonArea buttons1 = new ButtonArea();
+    buttons1.addButton("Export", new FormularfelderExportAction(),
+        getCurrentObject(), false, "document-save.png");
+    buttons1.addButton("Import", new FormularfelderImportAction(control),
+        getCurrentObject(), false, "file-import.png");
+    buttons1.addButton("Neu", new FormularfeldAction(), getCurrentObject(),
+        false, "document-new.png");
+    cont.addButtonArea(buttons1);
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
-    buttons.addButton("Formularfelder", new FormularfelderListeAction(),
-        control.getFormular(), true, "file-invoice.png");
+    buttons.addButton("Anzeigen", new FormularAnzeigeAction(),
+        getCurrentObject(), false, "edit-copy.png");
+
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/FormularListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularListeView.java
@@ -31,7 +31,7 @@ public class FormularListeView extends AbstractView
   {
     GUI.getView().setTitle("Formulare");
 
-    FormularControl control = new FormularControl(this);
+    FormularControl control = new FormularControl(this, null);
 
     control.getFormularList().paint(this.getParent());
 


### PR DESCRIPTION
Das Erzeugen von Felddefinitionen bei neuen Views war etwas umständlich. Auch sieht man beim Formular Detail View nicht direkt die zugehörigen Felddefinitionen.
Ich zeige jetzt die Felddefinitionen auch im  Formular Detail View an. Die Frage wäre ob der separate View für die Anzeige der Felddefinitionen noch nötig ist. Er wird im Kontextmenü des Formulars aufgerufen.

![Bildschirmfoto_20241004_102715](https://github.com/user-attachments/assets/1826406d-da2e-4aec-a135-defb82ab5a87)
