### PR TITLE
Nicht existierendes Icon ersetzt

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
@@ -90,7 +90,7 @@ public class LesefeldDetailView extends AbstractView implements Listener
     }, null, false, "view-refresh.png");
     buttonArea.addButton(button);
     button = new Button("Variablen anzeigen (F6)",
-        new OpenInsertVariableDialogAction(), null, false, "zuordnung.png");
+        new OpenInsertVariableDialogAction(), null, false, "bookmark.png");
     buttonArea.addButton(button);
     button = new Button("Speichern", new SaveLesefeldAction(), null,
         false, "document-save.png");


### PR DESCRIPTION
In LesefeldDetailView hatte der Button für Variablen anzeigen ein nicht existierendes Icon gesetzt. Ich habe es ersetzt durch das welches auch im Mail View im Kontextmenü bei Mailempfänger für den Eintrag Variable verwendet wird.
![Bildschirmfoto_20241007_175511](https://github.com/user-attachments/assets/92330226-1a7f-4437-b9da-92dd693b0c50)
