### PR TITLE
Mehrere Einträge gleichzeigit löschen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungsartDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungsartDeleteAction.java
@@ -33,20 +33,29 @@ public class BuchungsartDeleteAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof Buchungsart))
+    Buchungsart[] buchungsarten = null;
+    if (context == null)
     {
       throw new ApplicationException("Keine Buchungsart ausgewählt");
     }
+    else if(context instanceof Buchungsart)
+    {
+      buchungsarten = new Buchungsart[] {(Buchungsart)context};
+    }
+    else if(context instanceof Buchungsart[])
+    {
+      buchungsarten = (Buchungsart[])context;
+    }
+    else
+    {
+      return;
+    }
     try
     {
-      Buchungsart b = (Buchungsart) context;
-      if (b.isNewObject())
-      {
-        return;
-      }
+      String mehrzahl = buchungsarten.length > 1? "en":"";
       YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-      d.setTitle("Buchungsart löschen");
-      d.setText("Wollen Sie diese Buchungsart wirklich löschen?");
+      d.setTitle("Buchungsart" + mehrzahl +" löschen");
+      d.setText("Wollen Sie diese Buchungsart" + mehrzahl + " wirklich löschen?");
       try
       {
         Boolean choice = (Boolean) d.open();
@@ -59,8 +68,13 @@ public class BuchungsartDeleteAction implements Action
         return;
       }
 
-      b.delete();
-      GUI.getStatusBar().setSuccessText("Buchungsart gelöscht.");
+      for(Buchungsart b:buchungsarten)
+      {
+        if(b.isNewObject())
+          continue;
+        b.delete();
+      }
+      GUI.getStatusBar().setSuccessText("Buchungsart" + mehrzahl + " gelöscht.");
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/action/KursteilnehmerDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/KursteilnehmerDeleteAction.java
@@ -34,20 +34,28 @@ public class KursteilnehmerDeleteAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof Kursteilnehmer))
+    Kursteilnehmer[] kursteilnehmer = null;
+    if (context == null)
     {
       throw new ApplicationException("Keinen Kursteilnehmer ausgewählt");
     }
+    else if(context instanceof Kursteilnehmer)
+    {
+      kursteilnehmer = new Kursteilnehmer[] {(Kursteilnehmer)context};
+    }
+    else if(context instanceof Kursteilnehmer[])
+    {
+      kursteilnehmer = (Kursteilnehmer[])context;
+    }
+    else
+    {
+      return;
+    }
     try
     {
-      Kursteilnehmer kt = (Kursteilnehmer) context;
-      if (kt.isNewObject())
-      {
-        return;
-      }
       YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
       d.setTitle("Kursteilnehmer löschen");
-      d.setText("Wollen Sie diesen Kursteilnehmer wirklich löschen?");
+      d.setText("Wollen Sie diese" + (kursteilnehmer.length > 1?"":"n")+ " Kursteilnehmer wirklich löschen?");
 
       try
       {
@@ -60,7 +68,12 @@ public class KursteilnehmerDeleteAction implements Action
         Logger.error("Fehler beim Löschen des Kursteilnehmers", e);
         return;
       }
-      kt.delete();
+      for(Kursteilnehmer kt:kursteilnehmer)
+      {
+        if(kt.isNewObject())
+          continue;
+        kt.delete();
+      }
       GUI.getStatusBar().setSuccessText("Kursteilnehmer gelöscht.");
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/action/MailAuswahlDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailAuswahlDeleteAction.java
@@ -41,14 +41,29 @@ public class MailAuswahlDeleteAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof MailEmpfaenger))
+    MailEmpfaenger[] empfaenger = null;
+    if (context == null)
     {
       throw new ApplicationException("Keinen Empfänger ausgewählt");
     }
+    else if(context instanceof MailEmpfaenger)
+    {
+      empfaenger = new MailEmpfaenger[] {(MailEmpfaenger)context};
+    }
+    else if(context instanceof MailEmpfaenger[])
+    {
+      empfaenger = (MailEmpfaenger[])context;
+    }
+    else
+    {
+      return;
+    }
     try
     {
-      MailEmpfaenger me = (MailEmpfaenger) context;
-      control.removeEmpfaenger(me);
+      for(MailEmpfaenger me:empfaenger)
+      {
+        control.removeEmpfaenger(me);
+      }
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/action/MailDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailDeleteAction.java
@@ -16,8 +16,6 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
-import java.rmi.RemoteException;
-
 import de.jost_net.JVerein.rmi.Mail;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -40,42 +38,49 @@ public class MailDeleteAction implements Action
       TablePart tp = (TablePart) context;
       context = tp.getSelection();
     }
-    if (context == null || !(context instanceof Mail))
+    if (context == null)
     {
       throw new ApplicationException("Keine Mail ausgewählt");
     }
+    Mail[] mails = null;
+    if(context instanceof Mail)
+    {
+      mails = new Mail[] { (Mail) context};
+    }
+    else if(context instanceof Mail[])
+    {
+      mails = (Mail[])context;
+    }
+    else
+    {
+      return;
+    }
+    String mehrzahl = mails.length > 1 ? "s" : "";
+    YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+    d.setTitle("Mail" + mehrzahl + " löschen");
+    d.setText("Wollen Sie diese Mail" + mehrzahl + " wirklich löschen?");
+
     try
     {
-      Mail m = (Mail) context;
-      if (m.isNewObject())
+      Boolean choice = (Boolean) d.open();
+      if (!choice.booleanValue())
       {
         return;
       }
-      YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-      d.setTitle("Mail löschen");
-      d.setText("Wollen Sie diese Mail wirklich löschen?");
-
-      try
+      for (Mail m : mails)
       {
-        Boolean choice = (Boolean) d.open();
-        if (!choice.booleanValue())
+        if (m.isNewObject())
         {
-          return;
+          continue;
         }
         m.delete();
       }
-      catch (Exception e)
-      {
-        Logger.error("Fehler beim Löschen der Mail", e);
-        return;
-      }
-      GUI.getStatusBar().setSuccessText("Mail gelöscht.");
     }
-    catch (RemoteException e)
+    catch (Exception e)
     {
-      String fehler = "Fehler beim Löschen der Mail";
-      GUI.getStatusBar().setErrorText(fehler);
-      Logger.error(fehler, e);
+      Logger.error("Fehler beim Löschen der Mail", e);
+      return;
     }
+    GUI.getStatusBar().setSuccessText("Mail gelöscht.");
   }
 }

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungEmailAction.java
@@ -16,6 +16,8 @@
 package de.jost_net.JVerein.gui.action;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
+
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.jameica.gui.Action;
@@ -37,7 +39,8 @@ public class SpendenbescheinigungEmailAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    Spendenbescheinigung spb = null;
+    ArrayList<Mitglied> mitglieder = new ArrayList<>();
+    Spendenbescheinigung[] bescheinigungen = null;
     if (context instanceof TablePart)
     {
       TablePart tp = (TablePart) context;
@@ -49,7 +52,11 @@ public class SpendenbescheinigungEmailAction implements Action
     }
     else if (context instanceof Spendenbescheinigung)
     {
-      spb = (Spendenbescheinigung) context;
+      bescheinigungen = new Spendenbescheinigung[] {(Spendenbescheinigung) context};
+    }
+    else if (context instanceof Spendenbescheinigung[])
+    {
+      bescheinigungen = (Spendenbescheinigung[]) context;
     }
     else
     {
@@ -57,23 +64,20 @@ public class SpendenbescheinigungEmailAction implements Action
     }
     try
     {
-      Mitglied member = spb.getMitglied();
-      if (member == null)
+      for(Spendenbescheinigung spb:bescheinigungen)
       {
-        String fehler = "Kein Mitglied zugewiesen";
-        GUI.getStatusBar().setErrorText(fehler);
-        Logger.error(fehler);
-        return;
-      }
-      if (member.getEmail() == null || member.getEmail().length() == 0)
-      {
-        String fehler = "Mitglied hat keine E-Mail Adresse";
-        GUI.getStatusBar().setErrorText(fehler);
-        Logger.error(fehler);
-        return;
+        Mitglied member = spb.getMitglied();
+        if (member == null)
+        {
+          String fehler = spb.getZeile1() + spb.getZeile2() + ": Kein Mitglied zugewiesen";
+          GUI.getStatusBar().setErrorText(fehler);
+          Logger.error(fehler);
+          return;
+        }
+        mitglieder.add(spb.getMitglied());
       }
       MitgliedMailSendenAction mailSendenAction = new MitgliedMailSendenAction();
-      mailSendenAction.handleAction(member);
+      mailSendenAction.handleAction(mitglieder.toArray(new Mitglied[mitglieder.size()]));
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -507,6 +507,7 @@ public class BuchungsartControl extends AbstractControl
         }
       }, false, Column.ALIGN_RIGHT);
       buchungsartList.setContextMenu(new BuchungsartMenu());
+      buchungsartList.setMulti(true);
       buchungsartList.setRememberColWidths(true);
       buchungsartList.setRememberOrder(true);
       buchungsartList.setRememberState(true);

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -387,6 +387,7 @@ public class KursteilnehmerControl extends FilterControl
     part.addColumn("Abbuchungsdatum", "abbudatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     part.setContextMenu(new KursteilnehmerMenu(part));
+    part.setMulti(true);
 
     return part;
   }

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -139,6 +139,7 @@ public class MailControl extends FilterControl
     empfaenger.addColumn("Versand", "versand",
         new DateFormatter(new JVDateFormatDATETIME()));
     empfaenger.setContextMenu(new MailAuswahlMenu(this));
+    empfaenger.setMulti(true);
     empfaenger.setRememberOrder(true);
     empfaenger.removeFeature(FeatureSummary.class);
     return empfaenger;
@@ -625,6 +626,7 @@ public class MailControl extends FilterControl
         new DateFormatter(new JVDateFormatDATETIME()));
     mailsList.setRememberColWidths(true);
     mailsList.setContextMenu(new MailMenu());
+    mailsList.setMulti(true);
     mailsList.setRememberOrder(true);
     return mailsList;
   }

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -26,6 +26,7 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
@@ -110,7 +111,7 @@ public class MailVorlageControl extends AbstractControl
     }
   }
 
-  public TablePart getMailVorlageTable() throws RemoteException
+  public TablePart getMailVorlageTable(Action action) throws RemoteException
   {
     if (mailvorlageList != null)
     {
@@ -118,7 +119,7 @@ public class MailVorlageControl extends AbstractControl
     }
     DBService service = Einstellungen.getDBService();
     DBIterator<MailVorlage> fdef = service.createList(MailVorlage.class);
-    mailvorlageList = new TablePart(fdef, new MailVorlageDetailAction());
+    mailvorlageList = new TablePart(fdef, action);
     mailvorlageList.addColumn("Betreff", "betreff");
     mailvorlageList.setContextMenu(new MailVorlageMenu());
     return mailvorlageList;

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -56,11 +56,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
   protected void paint(Composite parent) throws Exception
   {
 
-    control.getMailVorlageTable().paint(parent);
-
-    ButtonArea b = new ButtonArea();
-    
-    b.addButton("Verwenden", new Action()
+    Action action = new Action()
     {
 
       @Override
@@ -68,7 +64,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
       {
         try
         {
-          retval = (MailVorlage) control.getMailVorlageTable().getSelection();
+          retval = (MailVorlage) control.getMailVorlageTable(null).getSelection();
         }
         catch (RemoteException e)
         {
@@ -77,7 +73,12 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
         abort = false;
         close();
       }
-    }, null, true, "ok.png");
+    };
+    control.getMailVorlageTable(action).paint(parent);
+
+    ButtonArea b = new ButtonArea();
+    
+    b.addButton("Verwenden", action , null, true, "ok.png");
     
     if (mailsenden)
     {

--- a/src/de/jost_net/JVerein/gui/menu/KursteilnehmerMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/KursteilnehmerMenu.java
@@ -38,9 +38,9 @@ public class KursteilnehmerMenu extends ContextMenu
   {
     addItem(new CheckedSingleContextMenuItem("Bearbeiten", new KursteilnehmerDetailAction(),
         "text-x-generic.png"));
-    addItem(new CheckedContextMenuItem("Abbuchungsdatum löschen",
+    addItem(new CheckedSingleContextMenuItem("Abbuchungsdatum löschen",
         new KursteilnehmerAbuResetAction(table), "user-trash-full.png"));
-    addItem(new CheckedContextMenuItem("Zu Mitglied übernehmen",
+    addItem(new CheckedSingleContextMenuItem("Zu Mitglied übernehmen",
         new KursteilnehmerWirdMitgliedAction(), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Löschen",
         new KursteilnehmerDeleteAction(), "user-trash-full.png"));

--- a/src/de/jost_net/JVerein/gui/menu/MailAuswahlMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MailAuswahlMenu.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.gui.dialogs.ShowVariablesDialog;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -39,7 +40,7 @@ public class MailAuswahlMenu extends ContextMenu
   public MailAuswahlMenu(MailControl control)
   {
     final MailControl contr = control;
-    addItem(new CheckedContextMenuItem("Variable", new Action()
+    addItem(new CheckedSingleContextMenuItem("Variable", new Action()
     {
 
       @Override
@@ -67,7 +68,7 @@ public class MailAuswahlMenu extends ContextMenu
       }
 
     }, "bookmark.png"));
-    addItem(new CheckedContextMenuItem("Vorschau", new Action()
+    addItem(new CheckedSingleContextMenuItem("Vorschau", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -173,12 +173,12 @@ public class MitgliedMenu extends ContextMenu
     }
     if (detailaction instanceof NichtMitgliedDetailAction)
     {
-    addItem(new CheckedSingleContextMenuItem("Löschen",
+    addItem(new CheckedContextMenuItem("Löschen",
         new NichtMitgliedDeleteAction(), "user-trash-full.png"));
     }
     else
     {
-      addItem(new CheckedSingleContextMenuItem("Löschen",
+      addItem(new CheckedContextMenuItem("Löschen",
           new MitgliedDeleteAction(), "user-trash-full.png"));
     }
     addItem(ContextMenuItem.SEPARATOR);

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -48,7 +48,7 @@ public class SpendenbescheinigungMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("PDF (Individuell, Mit Adressblatt)",
         new SpendenbescheinigungPrintAction(false, true), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedSingleContextMenuItem("E-Mail an Spender",
+    addItem(new CheckedContextMenuItem("E-Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));
     addItem(new CheckedContextMenuItem("Spendenbescheinigungen versenden",
         new SpendenbescheinigungSendAction(), "envelope-open.png"));

--- a/src/de/jost_net/JVerein/gui/view/MailVorlagenUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlagenUebersichtView.java
@@ -33,7 +33,7 @@ public class MailVorlagenUebersichtView extends AbstractView
 
     MailVorlageControl control = new MailVorlageControl(this);
 
-    control.getMailVorlageTable().paint(this.getParent());
+    control.getMailVorlageTable(new MailVorlageDetailAction()).paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),


### PR DESCRIPTION
 Mitglieder, Nicht-Mitglieder, Kursteilnehmer, Emails, Emailempfänger, Buchungsarten
 "Mail an Spender" auch bei Mehrfachauswahl

Außerdem habe ich noch gefixt:
MailVorlageDialog Doppelklick -> übernehmen statt bearbeiten