### PR TITLE
Fehler bei Migration, Import, Dignose Backup behoben

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
@@ -28,9 +28,13 @@ import org.eclipse.swt.widgets.FileDialog;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.SekundaereBeitragsgruppe;
+import de.jost_net.JVerein.rmi.Suchprofil;
 import de.jost_net.JVerein.rmi.ZusatzbetragAbrechnungslauf;
+import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.jost_net.JVerein.server.AbrechnungslaufImpl;
 import de.jost_net.JVerein.server.AdresstypImpl;
+import de.jost_net.JVerein.server.AltersstaffelImpl;
 import de.jost_net.JVerein.server.AnfangsbestandImpl;
 import de.jost_net.JVerein.server.ArbeitseinsatzImpl;
 import de.jost_net.JVerein.server.BuchungDokumentImpl;
@@ -145,168 +149,184 @@ public class BackupCreateAction implements Action
           writer = new XmlWriter(
               new BufferedOutputStream(new FileOutputStream(file)));
 
+          monitor.setStatusText("Speichere Einstellungen");
+          backup(EinstellungImpl.class, writer, monitor);
+          monitor.addPercentComplete(1);
+          
           monitor.setStatusText("Speichere Abrechnungslauf-Informationen");
           backup(AbrechnungslaufImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mitgliedstypen");
           backup(AdresstypImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Buchungsklassen");
           backup(BuchungsklasseImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
+          
+          monitor.setStatusText("Speichere Buchungsarten");
+          backup(Buchungsart.class, writer, monitor);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Eigenschaftengruppen");
           backup(EigenschaftGruppeImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
-
-          monitor.setStatusText("Speichere Einstellungen");
-          backup(EinstellungImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Felddefinitionen");
           backup(FelddefinitionImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Formulare");
           backup(FormularImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Formularfelder");
           backup(FormularfeldImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Konten");
           backup(KontoImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Kursteilnehmer");
           backup(KursteilnehmerImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Lehrgangsarten");
           backup(LehrgangsartImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Lesefelder");
           backup(LesefeldImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mails");
           backup(MailImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mailanhänge");
           backup(MailAnhangImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mailvorlagen");
           backup(MailVorlageImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
-
-          monitor.setStatusText(
-              "Speichere Informationen über zukünftige Beitragsgruppen");
-          backup(MitgliedNextBGruppeImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Projekte");
           backup(ProjektImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Informationen über QIF-Header");
           backup(QIFImportHeadImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Informationen über QIF-Positionen");
           backup(QIFImportPosImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Anfangsbestände");
           backup(AnfangsbestandImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
-
-          monitor.setStatusText("Speichere Buchungsarten");
-          backup(Buchungsart.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Eingenschaften");
           backup(EigenschaftImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Beitragsgruppen");
           backup(Beitragsgruppe.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
+          
+          monitor.setStatusText("Speichere Altersstaffel");
+          backup(AltersstaffelImpl.class, writer, monitor);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mitglieder");
           backup(MitgliedImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Dokumente der Mitglieder");
           backup(MitgliedDokumentImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Fotos der Mitglieder");
           backup(MitgliedfotoImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
+          
+          monitor.setStatusText(
+              "Speichere Informationen über zukünftige Beitragsgruppen");
+          backup(MitgliedNextBGruppeImpl.class, writer, monitor);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mitgliedskonten");
           backup(MitgliedskontoImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Spendenbescheinigungen");
           backup(SpendenbescheinigungImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Wiedervorlagen");
           backup(WiedervorlageImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Zusatzbeträge");
           backup(ZusatzbetragImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText(
               "Speichere Informatioen über Abrechnungsläufe von Zusatzbeträgen");
           backup(ZusatzbetragAbrechnungslauf.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Zusatzfelder");
           backup(ZusatzfelderImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Arbeitseinsätze");
           backup(ArbeitseinsatzImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Buchungen");
           backup(BuchungImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Dokumente zu Buchungen");
           backup(BuchungDokumentImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Jahresabschlüsse");
           backup(JahresabschlussImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Eigenschaften der Mitglieder");
           backup(EigenschaftenImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Lastschriften");
           backup(LastschriftImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Lehrgänge");
           backup(LehrgangImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mailempfänger");
           backup(MailEmpfaengerImpl.class, writer, monitor);
-          monitor.addPercentComplete(2);
+          monitor.addPercentComplete(1);
 
+          monitor.setStatusText("Speichere Sekundäre Beitragsgruppen der Mitglieder");
+          backup(SekundaereBeitragsgruppe.class, writer, monitor);
+          monitor.addPercentComplete(1);
+          
+          monitor.setStatusText("Speichere Suchprofile");
+          backup(Suchprofil.class, writer, monitor);
+          monitor.addPercentComplete(1);
+          
+          monitor.setStatusText("Speichere Zusatzbetrag Vorlagen");
+          backup(ZusatzbetragVorlage.class, writer, monitor);
+          monitor.addPercentComplete(1);
+          
           // Die Versionstabelle wird nicht mit kopiert
 
           monitor.setStatus(ProgressMonitor.STATUS_DONE);

--- a/src/de/jost_net/JVerein/io/InternalColumns.java
+++ b/src/de/jost_net/JVerein/io/InternalColumns.java
@@ -25,8 +25,7 @@ public enum InternalColumns
   ADRZUSATZ("Adressierungszusatz", false), //
   ANREDE("Anrede", true), //
   AUSTRITTSDATUM("Austritt", true), //
-  BIC("BIC", false), // TODO true), //
-  BLZ("Bankleitzahl", true), //
+  BIC("BIC", false),  //
   BEITRAG("Beitrag_1", true), //
   BEITRAGSART("Beitragsart_1", true), //
   BEITRAGINDI("Individuellerbeitrag", false), //
@@ -35,7 +34,6 @@ public enum InternalColumns
   GEBDATUM("Geburtsdatum", true), //
   GESCHLECHT("Geschlecht", true), //
   IBAN("IBAN", true), //
-  KONTONR("Kontonummer", true), //
   KTOIPERSONENART("KtoiPersonenart", false), //
   KTOIANREDE("KtoiAnrede", false), //
   KTOITITEL("KtoiTitel", false), //

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -582,11 +582,11 @@ public class MitgliederImport implements Importer
             m.setGeschlecht(geschlecht.toLowerCase());
           }
           else
-            throw new ApplicationException("Geschlecht fehlt");
+            m.setGeschlecht("o");
         }
         catch (SQLException e)
         {
-          throw new ApplicationException("Geschlecht fehlt");
+          m.setGeschlecht("o");
         }
 
         try

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -87,18 +87,29 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
 
           break;
       }
-      Beitragsgruppe gruppeAlt = (Beitragsgruppe) Einstellungen.getDBService().createObject(Beitragsgruppe.class,getID());
+      Beitragsgruppe gruppeAlt = null;
+      try
+      {
+        gruppeAlt = (Beitragsgruppe) Einstellungen.getDBService().createObject(Beitragsgruppe.class,getID());
+      }
+      catch (RemoteException e)
+      {
+        //Alte Beitragsgruppe nicht gefunden
+      }
       if(getBeitragsArt() != null) {
-        //Dases die Beitragsart ZAHLER nicht mehr gibt sie aber noch in der Datenbank stehen kann, müssen wir auf null prüfen
-        ArtBeitragsart artAlt = gruppeAlt.getBeitragsArt();
-        if(artAlt == null)
-            artAlt = ArtBeitragsart.NORMAL;
-        if(gruppeAlt != null && artAlt.getKey() != getBeitragsArt().getKey()) {
-          DBIterator<Mitglied> list = Einstellungen.getDBService()
-              .createList(Mitglied.class);
-          list.addFilter("beitragsgruppe = ?", getID());
-          if(list.hasNext()) {
-            throw new ApplicationException("Es existieren Mitglieder mit diesem Beitrag, Beitragsart kann nicht geändert werden!");
+        if(gruppeAlt != null)
+        {
+          //Da es die Beitragsart ZAHLER nicht mehr gibt sie aber noch in der Datenbank stehen kann, müssen wir auf null prüfen
+          ArtBeitragsart artAlt = gruppeAlt.getBeitragsArt();
+          if(artAlt == null)
+              artAlt = ArtBeitragsart.NORMAL;
+          if(artAlt.getKey() != getBeitragsArt().getKey()) {
+            DBIterator<Mitglied> list = Einstellungen.getDBService()
+                .createList(Mitglied.class);
+            list.addFilter("beitragsgruppe = ?", getID());
+            if(list.hasNext()) {
+              throw new ApplicationException("Es existieren Mitglieder mit diesem Beitrag, Beitragsart kann nicht geändert werden!");
+            }
           }
         }
         if(getSekundaer() && getBeitragsArt().getKey() == ArtBeitragsart.FAMILIE_ANGEHOERIGER.getKey())


### PR DESCRIPTION
Migration: unnötige (Pflicht-)Felder entfernt, BIC automatisch bestimmen
Import: Geschlecht optional
Diagnose Backup: Fehlende DBObject hinzugefügt, einfolge der exporte korrigiert, Statusmeldunge ausgeben