### PR TITLE
Fix Feldefinitionen erzeugen/importieren und Formular anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
@@ -62,6 +62,20 @@ public class FormularAnzeigeAction implements Action
     if (context != null && (context instanceof Formular))
     {
       formular = (Formular) context;
+      try
+      {
+        if (formular.isNewObject())
+        {
+          throw new ApplicationException(
+              "Vor der Anzeige des Formulars muss dieses gespeichert werden!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+        throw new ApplicationException(
+            "Fehler bei der Anzeige eines Formulars", e);
+      }
     }
     else
     {

--- a/src/de/jost_net/JVerein/gui/action/FormularfeldAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularfeldAction.java
@@ -39,6 +39,20 @@ public class FormularfeldAction implements Action
     if (context != null && (context instanceof Formular))
     {
       f = (Formular) context;
+      try
+      {
+        if (f.isNewObject())
+        {
+          throw new ApplicationException(
+              "Vor dem Anlegen der Formularfelder muss das Formular gespeichert werden!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+        throw new ApplicationException(
+            "Fehler bei der Erzeugung eines neuen Formularfeldes", e);
+      }
     }
     if (context != null && (context instanceof Formularfeld))
     {

--- a/src/de/jost_net/JVerein/gui/action/FormularfelderImportAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularfelderImportAction.java
@@ -28,6 +28,7 @@ import java.rmi.RemoteException;
 import de.jost_net.JVerein.gui.control.FormularPartControl;
 import de.jost_net.JVerein.gui.dialogs.ImportDialog;
 import de.jost_net.JVerein.gui.view.DokumentationUtil;
+import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.jameica.gui.Action;
@@ -50,7 +51,30 @@ public class FormularfelderImportAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-
+    if (context != null && (context instanceof Formular))
+    {
+      Formular f = (Formular) context;
+      try
+      {
+        if (f.isNewObject())
+        {
+          throw new ApplicationException(
+              "Vor dem Import der Formularfelder muss das Formular gespeichert werden!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+        throw new ApplicationException(
+            "Fehler beim Import der Formularfelder", e);
+      }
+    }
+    else
+    {
+      throw new ApplicationException(
+          "Es wurde kein Formular ausgewählt!");
+    }
+    
     // Nachfrage, da alle Daten gelöscht werden!
     YesNoDialog ynd = new YesNoDialog(AbstractDialog.POSITION_CENTER);
     ynd.setText("Achtung! Alle momentan vorhandenen Formularfelder für\n"

--- a/src/de/jost_net/JVerein/io/FormularfelderImportCSV.java
+++ b/src/de/jost_net/JVerein/io/FormularfelderImportCSV.java
@@ -197,13 +197,15 @@ public class FormularfelderImportCSV implements Importer
           throw new ApplicationException(e.getMessage());
         }
       }
+      monitor.setStatus(ProgressMonitor.STATUS_DONE);
+      monitor.setStatusText("Formularfelder für Formular " + f.getBezeichnung() + " importiert");
       results.close();
       stmt.close();
       conn.close();
     }
     catch (Exception e)
     {
-      monitor.log(" nicht importiert: " + e.getMessage());
+      monitor.log(" Nicht importiert: " + e.getMessage());
       Logger.error("Fehler", e);
     }
     finally


### PR DESCRIPTION
Durch die Aufnahme der Formularfelder in den Formular Detail View kann man Formularfelder erzeugen und importieren auch wenn das Formular noch nicht gespeichert ist. Dann werden die neuen Formularfelder aber nicht dem Formular zugeordnet. Ich gebe eine Meldung aus, dass das Formular erst gespeichert werden muss.

Das gleiche Szenario gibt es beim Anzeigen Button. Der funktioniert auch erst wenn das Formular gespeichert ist.

Beim CSV Import der Formularfelder habe ich eine Statusmeldung nach dem Import eingefügt. Sonst erscheint nur ein leeres Status Feld.