### PR TITLE
Anlagenkonto über Menüeintrag erzeugen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
@@ -73,6 +73,7 @@ public class AnlagenkontoNeuAction implements Action
         DBTransaction.commit();
         GUI.startView(new KontoView(), konto);
       }
+      DBTransaction.rollback();
     }
     catch (OperationCanceledException oce)
     {

--- a/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
@@ -17,6 +17,7 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.gui.dialogs.AnlagenkontoNeuDialog;
 import de.jost_net.JVerein.gui.view.KontoView;
 import de.jost_net.JVerein.rmi.Anfangsbestand;
@@ -42,7 +43,7 @@ public class AnlagenkontoNeuAction implements Action
     Konto konto = null;
     try
     {
-
+      DBTransaction.starten();
       AnlagenkontoNeuDialog d = new AnlagenkontoNeuDialog(
           AnlagenkontoNeuDialog.POSITION_CENTER, buchung);
       konto = (Konto) d.open();
@@ -69,17 +70,20 @@ public class AnlagenkontoNeuAction implements Action
           bu.setProjektID(buchung.getProjektID());
         bu.setKommentar(buchung.getKommentar());
         bu.store();
-
+        DBTransaction.commit();
         GUI.startView(new KontoView(), konto);
       }
     }
     catch (OperationCanceledException oce)
     {
+      DBTransaction.rollback();
       throw oce;
     }
     catch (Exception e)
     {
-      GUI.getStatusBar().setErrorText("Fehler bei der Erstellung eines Anlagenkontos.");
+      DBTransaction.rollback();
+      GUI.getStatusBar().setErrorText(
+          "Fehler bei der Erstellung des Anlagenkontos: " + e.getMessage());
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.dialogs.AnlagenkontoNeuDialog;
+import de.jost_net.JVerein.gui.view.KontoView;
+import de.jost_net.JVerein.rmi.Anfangsbestand;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Konto;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
+
+public class AnlagenkontoNeuAction implements Action
+{
+  
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+ 
+    if (context == null || !(context instanceof Buchung))
+    {
+      throw new ApplicationException("Keine Buchung ausgewählt");
+    }
+    Buchung buchung = (Buchung) context;
+    Konto konto = null;
+    try
+    {
+
+      AnlagenkontoNeuDialog d = new AnlagenkontoNeuDialog(
+          AnlagenkontoNeuDialog.POSITION_CENTER, buchung);
+      konto = (Konto) d.open();
+
+      if (konto != null && !konto.isNewObject())
+      {
+        Anfangsbestand anf = (Anfangsbestand) Einstellungen.getDBService().createObject(
+            Anfangsbestand.class, null);
+        anf.setKonto(konto);
+        anf.setDatum(buchung.getDatum());
+        anf.setBetrag(0d);
+        anf.store();
+        
+        Buchung bu = (Buchung) Einstellungen.getDBService().
+            createObject(Buchung.class, null);
+        bu.setKonto(konto);
+        bu.setName(buchung.getName());
+        bu.setBetrag(-buchung.getBetrag());
+        bu.setZweck(buchung.getZweck());
+        bu.setDatum(buchung.getDatum());
+        if (buchung.getBuchungsart() != null)
+          bu.setBuchungsart(buchung.getBuchungsartId());
+        if (buchung.getProjekt() != null)
+          bu.setProjektID(buchung.getProjektID());
+        bu.setKommentar(buchung.getKommentar());
+        bu.store();
+
+        GUI.startView(new KontoView(), konto);
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (Exception e)
+    {
+      GUI.getStatusBar().setErrorText("Fehler bei der Erstellung eines Anlagenkontos.");
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/AnlagenkontoNeuDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/AnlagenkontoNeuDialog.java
@@ -1,0 +1,370 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.KontoControl;
+import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.IntegerNullInput;
+import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
+import de.jost_net.JVerein.keys.AfaMode;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.jost_net.JVerein.rmi.Konto;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.AbstractInput;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.LabelInput;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Dialog zur Zuordnung einer Buchungsart.
+ */
+public class AnlagenkontoNeuDialog extends AbstractDialog<Konto>
+{
+  
+  private TextInput nummer;
+
+  private TextInput bezeichnung;
+  
+  private AbstractInput anlagenart;
+  
+  private SelectInput anlagenklasse;
+  
+  private AbstractInput afaart;
+  
+  private IntegerNullInput nutzungsdauer;
+  
+  private LabelInput message = null;
+  
+  private Konto konto = null;
+  
+  private Buchung buchung = null;
+  
+  final KontoControl control = new KontoControl(null);
+
+  /**
+   * @param position
+   */
+  public AnlagenkontoNeuDialog(int position, Buchung buchung)
+  {
+    super(position);
+    setTitle("Neues Anlagenkonto");
+    setSize(650, SWT.DEFAULT);
+    this.buchung = buchung;
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+       
+    LabelGroup group = new LabelGroup(parent, "");
+    group.addLabelPair("Nummer", getNummer());
+    group.addLabelPair("Bezeichnung", getBezeichnung());
+    group.addLabelPair("Anlagen Buchungsklasse", getAnlagenklasse());
+    group.addLabelPair("Anlagen Buchungsart", getAnlagenart());
+    group.addLabelPair("AfA Buchungsart", getAfaart());
+    group.addLabelPair("Nutzungsdauer", getNutzungsdauer());
+    group.addLabelPair("", getMessage());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Übernehmen", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        try
+        {
+          if (konto == null)
+            konto = (Konto) Einstellungen.getDBService().createObject(Konto.class, null);
+        }
+        catch (RemoteException e)
+        {
+          konto = null;
+          return;
+        }
+        handleStore();
+        close();
+      }
+    }, null, true, "ok.png");
+
+    buttons.addButton("Abbrechen", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        konto = null;
+        close();
+      }
+    }, null, false, "process-stop.png");
+
+    buttons.paint(parent);
+    getShell().setMinimumSize(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT));
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  @Override
+  public Konto getData() throws Exception
+  {
+    return konto;
+  }
+  
+  private void handleStore() throws ApplicationException
+  {
+    try
+    {
+      konto.setNummer((String) getNummer().getValue());
+      konto.setBezeichnung((String) getBezeichnung().getValue());
+      konto.setEroeffnung(buchung.getDatum());
+      konto.setAnlagenkonto(true);
+      konto.setHibiscusId(-1);
+      konto.setAnlagenartId(getSelectedAnlagenartId());
+      konto.setAnlagenklasseId(getSelectedAnlagenklasseId());
+      konto.setAfaartId(getSelectedAfaartId());
+      konto.setAfaRestwert(Einstellungen.getEinstellung().getAfaRestwert());
+      konto.setAfaMode(AfaMode.AUTO);
+      konto.setNutzungsdauer((Integer)getNutzungsdauer().getValue());
+      konto.setKommentar(buchung.getKommentar());
+      konto.store();
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException(e.getMessage());
+    }
+    catch (ApplicationException e)
+    {
+      throw new ApplicationException(e.getMessage());
+    }
+  }
+  
+  public TextInput getNummer() throws RemoteException
+  {
+    if (nummer != null)
+    {
+      return nummer;
+    }
+    nummer = new TextInput("", 35);
+    return nummer;
+  }
+  
+  public TextInput getBezeichnung() throws RemoteException
+  {
+    if (bezeichnung != null)
+    {
+      return bezeichnung;
+    }
+    bezeichnung = new TextInput("", 255);
+    return bezeichnung;
+  }
+  
+  public Input getAnlagenart() throws RemoteException
+  {
+    if (anlagenart != null)
+    {
+      return anlagenart;
+    }
+    anlagenart = new BuchungsartInput().getBuchungsartInput( anlagenart,
+        buchung.getBuchungsart(), buchungsarttyp.ANLAGENART);
+    anlagenart.addListener(new AnlagenartListener());
+    return anlagenart;
+  }
+  
+  private Long getSelectedAnlagenartId() throws ApplicationException
+  {
+    try
+    {
+      Buchungsart buchungsArt = (Buchungsart) getAnlagenart().getValue();
+      if (null == buchungsArt)
+        return null;
+      Long id = Long.valueOf(buchungsArt.getID());
+      return id;
+    }
+    catch (RemoteException ex)
+    {
+      final String meldung = "Gewählte Anlagensart kann nicht ermittelt werden";
+      Logger.error(meldung, ex);
+      throw new ApplicationException(meldung, ex);
+    }
+  }
+  
+  public Input getAnlagenklasse() throws RemoteException
+  {
+    if (anlagenklasse != null)
+    {
+      return anlagenklasse;
+    }
+    DBIterator<Buchungsklasse> list = Einstellungen.getDBService()
+        .createList(Buchungsklasse.class);
+    list.setOrder(control.getBuchungartSortOrder());
+    Buchungsklasse bk = buchung.getBuchungsart().getBuchungsklasse();
+    if (bk != null)
+    {
+      anlagenklasse = new SelectInput(list != null ? 
+          PseudoIterator.asList(list) : null, bk);
+    }
+    else
+    {
+      anlagenklasse = new SelectInput(list != null ? 
+          PseudoIterator.asList(list) : null, null);
+    }
+    anlagenklasse.setAttribute(control.getBuchungartAttribute());
+    anlagenklasse.setPleaseChoose("Bitte auswählen");
+    return anlagenklasse;
+  }
+  
+  private Long getSelectedAnlagenklasseId() throws ApplicationException
+  {
+    try
+    {
+      Buchungsklasse buchungsKlasse = (Buchungsklasse) getAnlagenklasse().getValue();
+      if (null == buchungsKlasse)
+        return null;
+      Long id = Long.valueOf(buchungsKlasse.getID());
+      return id;
+    }
+    catch (RemoteException ex)
+    {
+      final String meldung = "Gewählte Anlagenklasse kann nicht ermittelt werden";
+      Logger.error(meldung, ex);
+      throw new ApplicationException(meldung, ex);
+    }
+  }
+  
+  public Input getAfaart() throws RemoteException
+  {
+    if (afaart != null)
+    {
+      return afaart;
+    }
+    afaart = new BuchungsartInput().getBuchungsartInput( afaart,
+        null, buchungsarttyp.AFAART);
+    return afaart;
+  }
+  
+  private Long getSelectedAfaartId() throws ApplicationException
+  {
+    try
+    {
+      Buchungsart buchungsArt = (Buchungsart) getAfaart().getValue();
+      if (null == buchungsArt)
+        return null;
+      Long id = Long.valueOf(buchungsArt.getID());
+      return id;
+    }
+    catch (RemoteException ex)
+    {
+      final String meldung = "Gewählte Buchungsart kann nicht ermittelt werden";
+      Logger.error(meldung, ex);
+      throw new ApplicationException(meldung, ex);
+    }
+  }
+  
+  private LabelInput getMessage() throws RemoteException
+  {
+    if (message != null)
+    {
+      return message;
+    }
+    DBService service = Einstellungen.getDBService();
+    String sql = "SELECT DISTINCT konto.id from konto "
+        + "WHERE (anlagenkonto = TRUE) ";
+    boolean exist = (boolean) service.execute(sql,
+        new Object[] { }, new ResultSetExtractor()
+    {
+      @Override
+      public Object extract(ResultSet rs)
+          throws RemoteException, SQLException
+      {
+        if (rs.next())
+        {
+          return true;
+        }
+        return false;
+      }
+    });
+    if (!exist)
+      message = new LabelInput(" *Beim ersten Anlagenkonto bitte JVerein neu starten um die Änderungen anzuwenden");
+    else
+      message = new LabelInput("");
+    message.setColor(Color.ERROR);
+    return message;
+  }
+  
+  public IntegerNullInput getNutzungsdauer() throws RemoteException
+  {
+    if (nutzungsdauer != null)
+    {
+      return nutzungsdauer;
+    }
+    nutzungsdauer = new IntegerNullInput();
+    return nutzungsdauer;
+  }
+  
+  public class AnlagenartListener implements Listener
+  {
+
+    AnlagenartListener()
+    {
+    }
+
+    @Override
+    public void handleEvent(Event event)
+    {
+      if (event.type != SWT.Selection && event.type != SWT.FocusOut)
+      {
+        return;
+      }
+      try
+      {
+        Buchungsart ba = (Buchungsart) getAnlagenart().getValue();
+        if (ba != null)
+        {
+          if (getAnlagenklasse().getValue() == null)
+            getAnlagenklasse().setValue(ba.getBuchungsklasse());
+        }
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler", e);
+      }
+    }
+  }
+  
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/AnlagenkontoNeuDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/AnlagenkontoNeuDialog.java
@@ -27,6 +27,8 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.KontoControl;
+import de.jost_net.JVerein.gui.control.BuchungsControl;
+import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenart;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
@@ -163,6 +165,8 @@ public class AnlagenkontoNeuDialog extends AbstractDialog<Konto>
       konto.setNutzungsdauer((Integer)getNutzungsdauer().getValue());
       konto.setKommentar(buchung.getKommentar());
       konto.store();
+      BuchungsControl bcontrol = new BuchungsControl(null, Kontenart.ANLAGEKONTO);
+      bcontrol.getSettings().setAttribute("anlagenkonto.kontoid", konto.getID());
     }
     catch (RemoteException e)
     {
@@ -201,7 +205,8 @@ public class AnlagenkontoNeuDialog extends AbstractDialog<Konto>
       return anlagenart;
     }
     anlagenart = new BuchungsartInput().getBuchungsartInput( anlagenart,
-        buchung.getBuchungsart(), buchungsarttyp.ANLAGENART);
+        buchung.getBuchungsart(), buchungsarttyp.ANLAGENART,
+        Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
     anlagenart.addListener(new AnlagenartListener());
     return anlagenart;
   }
@@ -233,7 +238,9 @@ public class AnlagenkontoNeuDialog extends AbstractDialog<Konto>
     DBIterator<Buchungsklasse> list = Einstellungen.getDBService()
         .createList(Buchungsklasse.class);
     list.setOrder(control.getBuchungartSortOrder());
-    Buchungsklasse bk = buchung.getBuchungsart().getBuchungsklasse();
+    Buchungsklasse bk = buchung.getBuchungsklasse();
+    if (bk == null)
+        bk = buchung.getBuchungsart().getBuchungsklasse();
     if (bk != null)
     {
       anlagenklasse = new SelectInput(list != null ? 
@@ -274,7 +281,8 @@ public class AnlagenkontoNeuDialog extends AbstractDialog<Konto>
       return afaart;
     }
     afaart = new BuchungsartInput().getBuchungsartInput( afaart,
-        null, buchungsarttyp.AFAART);
+        null, buchungsarttyp.AFAART,
+        Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
     return afaart;
   }
   

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.menu;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.gui.action.AnlagenkontoNeuAction;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungDeleteAction;
@@ -55,8 +56,12 @@ public class BuchungMenu extends ContextMenu
     addItem(new SingleBuchungItem("Duplizieren", new BuchungDuplizierenAction(),
         "edit-copy.png"));
     if (geldkonto)
+    {
       addItem(new SingleGegenBuchungItem("Gegenbuchung", new BuchungGegenbuchungAction(),
           "edit-copy.png"));
+      addItem(new SingleGegenBuchungItem("Neues Anlagenkonto", new AnlagenkontoNeuAction(),
+          "document-new.png"));
+    }
     addItem(new SplitBuchungItem("Splitbuchung", new SplitBuchungAction(),
         "edit-copy.png"));
     addItem(new AufloesenItem("Auflösen", new SplitbuchungBulkAufloesenAction(),

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -59,13 +59,16 @@ public class BuchungMenu extends ContextMenu
     {
       addItem(new SingleGegenBuchungItem("Gegenbuchung", new BuchungGegenbuchungAction(),
           "edit-copy.png"));
-      addItem(new SingleGegenBuchungItem("Neues Anlagenkonto", new AnlagenkontoNeuAction(),
-          "document-new.png"));
     }
     addItem(new SplitBuchungItem("Splitbuchung", new SplitBuchungAction(),
         "edit-copy.png"));
     addItem(new AufloesenItem("Auflösen", new SplitbuchungBulkAufloesenAction(),
         "unlocked.png"));
+    if (geldkonto)
+    {
+      addItem(new SingleGegenBuchungItem("Neues Anlagenkonto", new AnlagenkontoNeuAction(),
+          "document-new.png"));
+    }
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(control), "view-refresh.png"));
     if (geldkonto)


### PR DESCRIPTION
Man kann jetzt ein Anlagenkonto direkt aus dem Kontextmenü einer Umbuchung erzeugen.
![Bildschirmfoto_20241013_104835](https://github.com/user-attachments/assets/a45d6f63-2534-4f13-8e07-697716ffa48a)

Es öffnet sich ein Dialog zur Eingabe der nötigen Daten um das Konto anzulegen. Buchungsklasse und Buchungsart des Kontos werden mit den Werten aus der Buchung vorbelegt. Beim Ersten Anlagenkonto erscheint die Meldung im Dialog, dass JVerein neu gestartet werden muss.
![Bildschirmfoto_20241013_110055](https://github.com/user-attachments/assets/5c2df130-2645-4764-8642-05533ad9e7b6)

Mit Übernehmen wird das Konto, der Anfangsbestand und die Gegenbuchung ausomatisch erzeugt. Es erscheint der View des neuen Konto um weitere Angaben machen zu können z.B. Auto-Anlagenwert wenn nötig oder Ändern des Afa Mode.