### PR TITLE
PleaseChoose für Spendenbescheinigung Formular

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -115,6 +115,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     it.addFilter("art = ?",
         new Object[] { FormularArt.SPENDENBESCHEINIGUNG.getKey() });
     formularEinzel = new SelectInput(it != null ? PseudoIterator.asList(it) : null, null);
+    formularEinzel.setPleaseChoose("Bitte auswählen");
     return formularEinzel;
   }
 
@@ -129,6 +130,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     it.addFilter("art = ?",
         new Object[] { FormularArt.SAMMELSPENDENBESCHEINIGUNG.getKey() });
     formularSammel = new SelectInput(it != null ? PseudoIterator.asList(it) : null, null);
+    formularSammel.setPleaseChoose("Bitte auswählen");
     return formularSammel;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -318,6 +318,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     {
       formular = new FormularInput(FormularArt.SPENDENBESCHEINIGUNG, def);
     }
+    formular.setPleaseChoose("Bitte auswählen");
     return formular;
   }
 


### PR DESCRIPTION
Wenn man keine Formulare für Spendenbescheinigungen hat werden sie ohne Formular generiert.
Hat man Formulare muss man immer eines auswählen. Öffnet man eine Spendenbescheinigung welche noch ohne Formular erzeugt wurde wird das erste gefundene Formular angezeigt obwohl die Spendenbescheinigung kein Formular gespeichert hat.
Mit "Bitte auswählen" wird jetzt angezeigt, dass die Bescheinmigung kein Formular hat. Damit kann man das Formular auch entfernen. Bei der automatischen Generierung kann man jetzt auch angeben, dass kein Formular hinterlegt werden soll.