### PR TITLE
Kleine Korrekturen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -87,10 +87,8 @@ public class DruckMailControl extends FilterControl
     {
       return ausgabeart;
     }
-    String art = settings.getString(settingsprefix + "ausgabeart", "DRUCK");
-    if (art.equals("EMAIL"))
-      art = "MAIL";
-    ausgabeart = new SelectInput(Ausgabeart.values(), Ausgabeart.valueOf(art));
+    ausgabeart = new SelectInput(Ausgabeart.values(),
+        Ausgabeart.getByKey(settings.getInt(settingsprefix + "ausgabeart.key", 1)));
     ausgabeart.setName("Ausgabe");
     return ausgabeart;
   }
@@ -191,7 +189,7 @@ public class DruckMailControl extends FilterControl
     if (ausgabeart != null )
     {
       Ausgabeart aa = (Ausgabeart) getAusgabeart().getValue();
-      settings.setAttribute(settingsprefix + "ausgabeart", aa.toString());
+      settings.setAttribute(settingsprefix + "ausgabeart.key", aa.getKey());
     }
     if (art != null)
     {
@@ -216,7 +214,7 @@ public class DruckMailControl extends FilterControl
     }
     if (pdfModus != null)
     {
-      String pdfMode = (String) getPdfModus().getValue();;
+      String pdfMode = (String) getPdfModus().getValue();
       settings.setAttribute(settingsprefix + "pdfModus", pdfMode);
     }
     if (mailbetreff != null)

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -48,7 +48,7 @@ public class SpendenbescheinigungMenu extends ContextMenu
     addItem(new CheckedContextMenuItem("PDF (Individuell, Mit Adressblatt)",
         new SpendenbescheinigungPrintAction(false, true), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem("E-Mail an Spender",
+    addItem(new CheckedContextMenuItem("Mail an Spender",
         new SpendenbescheinigungEmailAction(), "envelope-open.png"));
     addItem(new CheckedContextMenuItem("Spendenbescheinigungen versenden",
         new SpendenbescheinigungSendAction(), "envelope-open.png"));

--- a/src/de/jost_net/JVerein/keys/Ausgabeart.java
+++ b/src/de/jost_net/JVerein/keys/Ausgabeart.java
@@ -18,5 +18,45 @@ package de.jost_net.JVerein.keys;
 
 public enum Ausgabeart
 {
-  DRUCK, MAIL;
+
+  DRUCK(1, "Druck"),
+  MAIL(2, "Mail");
+
+  private final String text;
+
+  private final int key;
+  
+  Ausgabeart(int key, String text)
+  {
+    this.key = key;
+    this.text = text;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public String getText()
+  {
+    return text;
+  }
+
+  public static Ausgabeart getByKey(int key)
+  {
+    for (Ausgabeart art : Ausgabeart.values())
+    {
+      if (art.getKey() == key)
+      {
+        return art;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return getText();
+  }
 }


### PR DESCRIPTION
Im Spendenbescheinigung Menü habe ich E-Mail zu Mail geändert weil wir sonst auch immer Mail verwenden.
![Bildschirmfoto_20241015_103431](https://github.com/user-attachments/assets/0aa35894-6ae2-4f66-9e08-170bfc3f0e9c)

Den Enum für DRUCK/MAIL habe ich in ein Key/Value Paar geändert. Damit kann man den Text am GUI unabhängig vom Key definieren. Bei der Ausgabe wird Druck/Mail verwendet. Alles in Großbuchstaben passt nicht zum Rest.
![Bildschirmfoto_20241015_103503](https://github.com/user-attachments/assets/1810da79-c259-45aa-8f05-11be7f97a941)
