### PR TITLE
Istbuchungen bearbeiten in Mitgliedskonto

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstbuchungEditAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedskontoIstbuchungEditAction.java
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
+import de.jost_net.JVerein.gui.view.BuchungView;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.util.ApplicationException;
+
+public class MitgliedskontoIstbuchungEditAction implements Action
+{
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (context == null || !(context instanceof MitgliedskontoNode))
+    {
+      throw new ApplicationException("Keine Istbuchung ausgewählt");
+    }
+  	
+    MitgliedskontoNode mkn = null;
+    Buchung bu = null;
+
+    if (context != null && (context instanceof MitgliedskontoNode))
+    {
+      mkn = (MitgliedskontoNode) context;
+      try
+      {
+        bu = (Buchung) Einstellungen.getDBService().createObject(Buchung.class,
+            mkn.getID());
+        GUI.startView(BuchungView.class.getName(), bu);
+      }
+      catch (RemoteException e)
+      {
+        throw new ApplicationException("Fehler beim Editieren der Istbuchung");
+      }
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -40,10 +40,13 @@ import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
 import de.jost_net.JVerein.gui.parts.SollbuchungListTablePart;
+import de.jost_net.JVerein.gui.view.BuchungView;
+import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
 import de.jost_net.JVerein.io.Kontoauszug;
 import de.jost_net.JVerein.io.Mahnungsausgabe;
 import de.jost_net.JVerein.io.Rechnungsausgabe;
 import de.jost_net.JVerein.keys.Zahlungsweg;
+import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitglied;
@@ -436,7 +439,40 @@ public class MitgliedskontoControl extends DruckMailControl
   public Part getMitgliedskontoTree(Mitglied mitglied) throws RemoteException
   {
     mitgliedskontoTree = new TreePart(new MitgliedskontoNode(mitglied),
-        (Action) null)
+        new Action()
+    {
+
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        if (context == null || !(context instanceof MitgliedskontoNode))
+        {
+          return;
+        }
+        try
+        {
+          MitgliedskontoNode mkn = (MitgliedskontoNode) context;
+          if (mkn.getType() == MitgliedskontoNode.IST)
+          {
+            Buchung bu = (Buchung) Einstellungen.getDBService().createObject(
+                Buchung.class, mkn.getID());
+            GUI.startView(BuchungView.class.getName(), bu);
+          }
+          if (mkn.getType() == MitgliedskontoNode.SOLL)
+          {
+            Mitgliedskonto mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
+                Mitgliedskonto.class, mkn.getID());
+            GUI.startView(new SollbuchungDetailView(MitgliedskontoNode.SOLL), mk);
+          }
+        }
+        catch (RemoteException e)
+        {
+          Logger.error(e.getMessage());
+          throw new ApplicationException("Fehler beim Editieren der Buchung");
+        }
+      }
+    })
+
     {
 
       @SuppressWarnings("unchecked")

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungEditAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungLoeschenAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoSollbuchungNeuAction;
+import de.jost_net.JVerein.gui.action.MitgliedskontoIstbuchungEditAction;
 import de.jost_net.JVerein.gui.action.MitgliedskontoIstbuchungLoesenAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
@@ -46,12 +47,14 @@ public class MitgliedskontoMenu extends ContextMenu
   public MitgliedskontoMenu()
   {
     addItem(new MitgliedItem("Neue Sollbuchung",
-        new MitgliedskontoSollbuchungNeuAction(), "list-add.png"));
-    addItem(ContextMenuItem.SEPARATOR);
+        new MitgliedskontoSollbuchungNeuAction(), "document-new.png"));
     addItem(new SollItem("Sollbuchung bearbeiten",
         new MitgliedskontoSollbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
         new MitgliedskontoSollbuchungLoeschenAction(), "user-trash-full.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    addItem(new SollMitIstItem("Istbuchung bearbeiten",
+        new MitgliedskontoIstbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollMitIstItem("Istbuchung von Sollbuchung lösen",
         new MitgliedskontoIstbuchungLoesenAction(), "unlocked.png"));
     addItem(ContextMenuItem.SEPARATOR);


### PR DESCRIPTION
Im Mitgliedskonto kann man jetzt auch Istbuchungen bearbeiten über einen Menü Eintrag. 
![Bildschirmfoto_20241016_172721](https://github.com/user-attachments/assets/807e7317-b27e-4ece-9946-09e96d447534)

Sonstige Änderungen:
- Icon für neue Sollbuchung auf sonst übliches Icon geändert
- Doppelklick auf Sollbuchung oder Istbuchung löst ebenfalls die Edit Action aus. Implementiert #382 