### PR TITLE
Statistik Jahrgänge auch ohne Geburtsdatum Pflicht

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/StatistikJahrgaengeView.java
+++ b/src/de/jost_net/JVerein/gui/view/StatistikJahrgaengeView.java
@@ -16,7 +16,6 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
-import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.StatistikJahrgaengeExportAction;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
@@ -25,8 +24,6 @@ import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
-import de.willuhn.jameica.messaging.StatusBarMessage;
-import de.willuhn.jameica.system.Application;
 
 public class StatistikJahrgaengeView extends AbstractView
 {
@@ -46,14 +43,7 @@ public class StatistikJahrgaengeView extends AbstractView
         DokumentationUtil.STATISTIKJAHRGAENGE, false, "question-circle.png");
     Button btnStart = new Button("Start", new StatistikJahrgaengeExportAction(),
         control.getJubeljahr(), true, "walking.png");
-    if (!Einstellungen.getEinstellung().getGeburtsdatumPflicht())
-    {
-      btnStart.setEnabled(false);
-      Application.getMessagingFactory().sendMessage(new StatusBarMessage(
-          "Einstellungen->Anzeige->Geburtsdatum: keine Pflicht. Die Statistik kann nicht erstellt werden.",
-          StatusBarMessage.TYPE_ERROR));
 
-    }
     buttons.addButton(btnStart);
 
     buttons.paint(getParent());

--- a/src/de/jost_net/JVerein/io/StatistikJahrgaengeExport.java
+++ b/src/de/jost_net/JVerein/io/StatistikJahrgaengeExport.java
@@ -112,7 +112,7 @@ public abstract class StatistikJahrgaengeExport implements Exporter
     MitgliedUtils.setMitgliedJuristischePerson(mitglj);
     while (mitglj.hasNext())
     {
-      String jg = "juristische Personen";
+      String jg = "Juristische Personen";
       StatistikJahrgang dsbj = statistik.get(jg);
       if (dsbj == null)
       {
@@ -122,6 +122,38 @@ public abstract class StatistikJahrgaengeExport implements Exporter
       dsbj.incrementGesamt();
       dsbj.incrementOhne();
       mitglj.next();
+    }
+    /*
+     * Teil 3: Ohne Geburtsdatum
+     */
+    DBIterator<Mitglied> mitglo = Einstellungen.getDBService()
+        .createList(Mitglied.class);
+    MitgliedUtils.setNurAktive(mitglo, stichtag);
+    MitgliedUtils.setMitglied(mitglo);
+    mitglo.addFilter("geburtsdatum is null");
+    while (mitglo.hasNext())
+    {
+      Mitglied m = (Mitglied) mitglo.next();
+      String jg = "Ohne Datum";
+      StatistikJahrgang dsbj = statistik.get(jg);
+      if (dsbj == null)
+      {
+        dsbj = new StatistikJahrgang();
+        statistik.put(jg, dsbj);
+      }
+      dsbj.incrementGesamt();
+      if (m.getGeschlecht().equals(GeschlechtInput.MAENNLICH))
+      {
+        dsbj.incrementMaennlich();
+      }
+      if (m.getGeschlecht().equals(GeschlechtInput.WEIBLICH))
+      {
+        dsbj.incrementWeiblich();
+      }
+      if (m.getGeschlecht().equals(GeschlechtInput.OHNEANGABE))
+      {
+        dsbj.incrementOhne();
+      }
     }
 
     open();


### PR DESCRIPTION
Implementiert #381.

In einer Zeile werden alle ohne Geburstdatum ausgegeben.

![Bildschirmfoto_20241018_124950](https://github.com/user-attachments/assets/9bbed0e0-0487-4d04-bb9a-1481fa136a01)
