### PR TITLE
Fix statistik jahrgaenge

### DIFF
--- a/src/de/jost_net/JVerein/io/StatistikJahrgaengeExport.java
+++ b/src/de/jost_net/JVerein/io/StatistikJahrgaengeExport.java
@@ -130,6 +130,7 @@ public abstract class StatistikJahrgaengeExport implements Exporter
         .createList(Mitglied.class);
     MitgliedUtils.setNurAktive(mitglo, stichtag);
     MitgliedUtils.setMitglied(mitglo);
+    MitgliedUtils.setMitgliedNatuerlichePerson(mitglo);
     mitglo.addFilter("geburtsdatum is null");
     while (mitglo.hasNext())
     {

--- a/src/de/jost_net/JVerein/server/MitgliedUtils.java
+++ b/src/de/jost_net/JVerein/server/MitgliedUtils.java
@@ -58,7 +58,7 @@ public class MitgliedUtils
   public static void setMitgliedJuristischePerson(DBIterator<Mitglied> it)
       throws RemoteException
   {
-    it.addFilter("personenart = 'j'");
+    it.addFilter("personenart = 'j' or personenart = 'J'");
   }
 
 }

--- a/src/de/jost_net/JVerein/server/MitgliedUtils.java
+++ b/src/de/jost_net/JVerein/server/MitgliedUtils.java
@@ -52,7 +52,7 @@ public class MitgliedUtils
   public static void setMitgliedNatuerlichePerson(DBIterator<Mitglied> it)
       throws RemoteException
   {
-    it.addFilter("personenart = 'n'");
+    it.addFilter("personenart = 'n' or personenart = 'N'");
   }
 
   public static void setMitgliedJuristischePerson(DBIterator<Mitglied> it)


### PR DESCRIPTION
Ich hatte in #385 noch einen Fehler weil der Filter auf natürliche Person gefehlt hat.

Dann gab es aber auch noch einen alten Fehler. Der Filter auf juristische Person funktionierte nicht mehr. Mit der Umstellung auf Großschreibung in der Vergangenheit wird juristische Person in Groß "J" in der DB gespeichert, früher in klein "j". Bei der Abfrage muss man jetzt auf beides prüfen.

Dann habe ich jetzt noch gesehen, dass der MitgliederImport bei natürliche Persion ein großes "N" setzt.
Vorsichtshalber habe ich darum auch die Abfrage für natürliche Person geändert.

Ich weiß nicht ob wir beim MitgliederImport ein kleines "n" setzen sollen?