### PR TITLE
Filter auf Betrag vorzeichenlos

### DIFF
--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -254,6 +254,9 @@ public class BuchungQuery
           case KLEINERGLEICH:
             it.addFilter("buchung.betrag <= ?", suchbetrag.getBetrag());
             break;
+          case BETRAG:
+            it.addFilter("buchung.betrag = ? OR buchung.betrag = -?", suchbetrag.getBetrag());
+            break;
           default:
             break;
         }

--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -255,7 +255,7 @@ public class BuchungQuery
             it.addFilter("buchung.betrag <= ?", suchbetrag.getBetrag());
             break;
           case BETRAG:
-            it.addFilter("buchung.betrag = ? OR buchung.betrag = ?", suchbetrag.getBetrag(), suchbetrag.getBetrag().negate());
+            it.addFilter("(buchung.betrag = ? OR buchung.betrag = ?)", suchbetrag.getBetrag(), suchbetrag.getBetrag().negate());
             break;
           default:
             break;

--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -255,7 +255,7 @@ public class BuchungQuery
             it.addFilter("buchung.betrag <= ?", suchbetrag.getBetrag());
             break;
           case BETRAG:
-            it.addFilter("buchung.betrag = ? OR buchung.betrag = -?", suchbetrag.getBetrag());
+            it.addFilter("buchung.betrag = ? OR buchung.betrag = ?", suchbetrag.getBetrag(), suchbetrag.getBetrag().negate());
             break;
           default:
             break;

--- a/src/de/jost_net/JVerein/io/Suchbetrag.java
+++ b/src/de/jost_net/JVerein/io/Suchbetrag.java
@@ -32,7 +32,7 @@ public class Suchbetrag
     KEINE, GLEICH, GRÖSSER, GRÖSSERGLEICH, KLEINER, KLEINERGLEICH, BEREICH, UNGÜLTIG, BETRAG
   }
 
-  private Suchstrategie sustrat = Suchstrategie.KEINE;
+  private Suchstrategie suchstrategie = Suchstrategie.KEINE;
 
   private BigDecimal betrag;
 
@@ -45,7 +45,7 @@ public class Suchbetrag
   {
     if (suchbetrag == null || suchbetrag.length() == 0)
     {
-      sustrat = Suchstrategie.KEINE;
+      suchstrategie = Suchstrategie.KEINE;
       return;
     }
 
@@ -76,37 +76,37 @@ public class Suchbetrag
     }
     if (liste.get(0).equals(">"))
     {
-      sustrat = Suchstrategie.GRÖSSER;
+      suchstrategie = Suchstrategie.GRÖSSER;
       liste.remove(0);
     }
     else if (liste.get(0).equals(">="))
     {
-      sustrat = Suchstrategie.GRÖSSERGLEICH;
+      suchstrategie = Suchstrategie.GRÖSSERGLEICH;
       liste.remove(0);
     }
     else if (liste.get(0).equals("<"))
     {
-      sustrat = Suchstrategie.KLEINER;
+      suchstrategie = Suchstrategie.KLEINER;
       liste.remove(0);
     }
     else if (liste.get(0).equals("<="))
     {
-      sustrat = Suchstrategie.KLEINERGLEICH;
+      suchstrategie = Suchstrategie.KLEINERGLEICH;
       liste.remove(0);
     }
     else if (liste.get(0).equals("="))
     {
-      sustrat = Suchstrategie.GLEICH;
+      suchstrategie = Suchstrategie.GLEICH;
       liste.remove(0);
     }
     else if (liste.get(0).equals("|"))
     {
-      sustrat = Suchstrategie.BETRAG;
+      suchstrategie = Suchstrategie.BETRAG;
       liste.remove(0);
     }
     else if (liste.size() > 1 && liste.get(1).equals(".."))
     {
-      sustrat = Suchstrategie.BEREICH;
+      suchstrategie = Suchstrategie.BEREICH;
       liste.remove(1);
     }
     else if (liste.size() > 1 && !liste.get(1).equals(".."))
@@ -115,7 +115,7 @@ public class Suchbetrag
     }
     else if (liste.size() == 1)
     {
-      sustrat = Suchstrategie.GLEICH; // Nur Betrag angegeben.
+      suchstrategie = Suchstrategie.GLEICH; // Nur Betrag angegeben.
     }
 
     // jetzt muss ein Decimalwert kommen
@@ -124,21 +124,21 @@ public class Suchbetrag
       NumberFormat nf = NumberFormat.getInstance(Locale.GERMAN);
       betrag = new BigDecimal(nf.parse(liste.get(0)).toString());
 
-      if (sustrat == Suchstrategie.BEREICH)
+      if (suchstrategie == Suchstrategie.BEREICH)
       {
         betrag2 = new BigDecimal(nf.parse(liste.get(1)).toString());
       }
     }
     catch (ParseException e)
     {
-      sustrat = Suchstrategie.UNGÜLTIG;
+      suchstrategie = Suchstrategie.UNGÜLTIG;
       throw new Exception("Wert ungültig");
     }
   }
 
   public Suchstrategie getSuchstrategie()
   {
-    return sustrat;
+    return suchstrategie;
   }
 
   public BigDecimal getBetrag()

--- a/src/de/jost_net/JVerein/io/Suchbetrag.java
+++ b/src/de/jost_net/JVerein/io/Suchbetrag.java
@@ -99,6 +99,11 @@ public class Suchbetrag
       sustrat = Suchstrategie.GLEICH;
       liste.remove(0);
     }
+    else if (liste.get(0).equals("|"))
+    {
+      sustrat = Suchstrategie.BETRAG;
+      liste.remove(0);
+    }
     else if (liste.size() > 1 && liste.get(1).equals(".."))
     {
       sustrat = Suchstrategie.BEREICH;

--- a/src/de/jost_net/JVerein/io/Suchbetrag.java
+++ b/src/de/jost_net/JVerein/io/Suchbetrag.java
@@ -51,7 +51,7 @@ public class Suchbetrag
 
     // Suchstring in Einzelteile zerlegen
     ArrayList<String> liste = new ArrayList<>();
-    StringTokenizer tok = new StringTokenizer(suchbetrag, "<>=.", true);
+    StringTokenizer tok = new StringTokenizer(suchbetrag, "<>=.|", true);
     while (tok.hasMoreTokens())
     {
       liste.add(tok.nextToken().trim());

--- a/src/de/jost_net/JVerein/io/Suchbetrag.java
+++ b/src/de/jost_net/JVerein/io/Suchbetrag.java
@@ -29,7 +29,7 @@ public class Suchbetrag
 
   public enum Suchstrategie
   {
-    KEINE, GLEICH, GRÖSSER, GRÖSSERGLEICH, KLEINER, KLEINERGLEICH, BEREICH, UNGÜLTIG
+    KEINE, GLEICH, GRÖSSER, GRÖSSERGLEICH, KLEINER, KLEINERGLEICH, BEREICH, UNGÜLTIG, BETRAG
   }
 
   private Suchstrategie sustrat = Suchstrategie.KEINE;


### PR DESCRIPTION
Wie in #194 gewünscht wurde eine Funktionalität implementiert, dass nach dem Betrag (absolute) des Betrags gesucht werden kann.

Mithilfe von "|" als Prefix vor dem Betrag kann somit vorzeichenlos gefiltert werden. Eine Kombination mit anderen Prefixen ist bislang nicht implementiert oder vorgesehen.
Bsp.:
![image](https://github.com/user-attachments/assets/369c44fd-d4d0-4f32-86ba-0f251b28aab2)
