### PR TITLE
Standard  Fornular Auswahl in Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -106,19 +106,6 @@ public class DruckMailControl extends FilterControl
     return ausgabesortierung;
   }
   
-  public SelectInput getArt()
-  {
-    if (art != null)
-    {
-      return art;
-    }
-    art = new SelectInput( 
-        new String[] { "Standard", "Individuell" },
-        settings.getString(settingsprefix + "art", "Standard"));
-    art.setName("Ausgabeart");
-    return art;
-  }
-  
   public SelectInput getAdressblatt()
   {
     if (adressblatt != null)
@@ -190,11 +177,6 @@ public class DruckMailControl extends FilterControl
     {
       Ausgabeart aa = (Ausgabeart) getAusgabeart().getValue();
       settings.setAttribute(settingsprefix + "ausgabeart.key", aa.getKey());
-    }
-    if (art != null)
-    {
-      String ar = (String) getArt().getValue();
-      settings.setAttribute(settingsprefix + "art", ar);
     }
     if (adressblatt != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -17,6 +17,7 @@
 package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -46,7 +47,6 @@ import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.util.SWTUtil;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
-import de.willuhn.datasource.pseudo.PseudoIterator;
 
 public class SpendenbescheinigungAutoNeuControl extends AbstractControl
 {
@@ -110,11 +110,22 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     {
       return formularEinzel;
     }
+    String tmp = settings.getString("formular.einzel", "");
     DBIterator<Formular> it = Einstellungen.getDBService()
         .createList(Formular.class);
     it.addFilter("art = ?",
         new Object[] { FormularArt.SPENDENBESCHEINIGUNG.getKey() });
-    formularEinzel = new SelectInput(it != null ? PseudoIterator.asList(it) : null, null);
+    ArrayList<Formular> list = new ArrayList<>();
+    Formular preset = null;
+    while (it.hasNext())
+    {
+      Formular f = (Formular) it.next();
+      list.add(f);
+      if (tmp != null && !tmp.isEmpty() && f.getID().equalsIgnoreCase(tmp) )
+        preset = f;
+    }
+    formularEinzel = new SelectInput(list, preset);
+    formularEinzel.setPleaseChoose("Standard");
     return formularEinzel;
   }
 
@@ -124,11 +135,22 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     {
       return formularSammel;
     }
+    String tmp = settings.getString("formular.sammel", "");
     DBIterator<Formular> it = Einstellungen.getDBService()
         .createList(Formular.class);
     it.addFilter("art = ?",
         new Object[] { FormularArt.SAMMELSPENDENBESCHEINIGUNG.getKey() });
-    formularSammel = new SelectInput(it != null ? PseudoIterator.asList(it) : null, null);
+    ArrayList<Formular> list = new ArrayList<>();
+    Formular preset = null;
+    while (it.hasNext())
+    {
+      Formular f = (Formular) it.next();
+      list.add(f);
+      if (tmp != null && !tmp.isEmpty() && f.getID().equalsIgnoreCase(tmp) )
+        preset = f;
+    }
+    formularSammel = new SelectInput(list, preset);
+    formularSammel.setPleaseChoose("Standard");
     return formularSammel;
   }
 
@@ -150,6 +172,23 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       {
         try
         {
+          if (formularEinzel != null )
+          {
+            Formular aa = (Formular) getFormular().getValue();
+            if (aa != null)
+              settings.setAttribute("formular.einzel", aa.getID());
+            else
+              settings.setAttribute("formular.einzel", "");
+          }
+          if (formularSammel != null )
+          {
+            Formular aa = (Formular) getFormularSammelbestaetigung().getValue();
+            if (aa != null)
+              settings.setAttribute("formular.sammel", aa.getID());
+            else
+              settings.setAttribute("formular.sammel", "");
+          }          
+          
           @SuppressWarnings("rawtypes")
           List items = spbTree.getItems();
           

--- a/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SpendenbescheinigungMenu.java
@@ -40,14 +40,8 @@ public class SpendenbescheinigungMenu extends ContextMenu
   {
     addItem(new CheckedSingleContextMenuItem("Bearbeiten",
         new SpendenbescheinigungAction(0), "text-x-generic.png"));
-    addItem(new CheckedContextMenuItem("PDF (Standard)",
-        new SpendenbescheinigungPrintAction(true, Adressblatt.OHNE_ADRESSBLATT), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("PDF (Standard, Mit Adresse)",
-        new SpendenbescheinigungPrintAction(true, Adressblatt.MIT_ADRESSE), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("PDF (Individuell)",
-        new SpendenbescheinigungPrintAction(false, Adressblatt.OHNE_ADRESSBLATT), "file-pdf.png"));
-    addItem(new CheckedContextMenuItem("PDF (Individuell, Mit Adresse)",
-        new SpendenbescheinigungPrintAction(false, Adressblatt.MIT_ADRESSE), "file-pdf.png"));
+    addItem(new CheckedContextMenuItem("PDF",
+        new SpendenbescheinigungPrintAction(Adressblatt.OHNE_ADRESSBLATT, true), "file-pdf.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedContextMenuItem("Druck und Mail",
         new SpendenbescheinigungSendAction(), "document-print.png"));

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -70,7 +70,6 @@ public class SpendenbescheinigungMailView extends AbstractView
     SimpleContainer cont2 = new SimpleContainer(getParent(), false);
     cont2.addHeadline("Parameter");
     cont2.addInput(control.getAusgabeart());
-    cont2.addInput(control.getArt());
     cont2.addInput(control.getAdressblatt());
     
     SimpleContainer cont = new SimpleContainer(getParent(), true);

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
@@ -18,7 +18,6 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
-import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -101,10 +100,7 @@ public class SpendenbescheinigungView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
-    buttons.addButton(control.getPDFStandardButton(Adressblatt.OHNE_ADRESSBLATT));
-    buttons.addButton(control.getPDFStandardButton(Adressblatt.MIT_ADRESSE));
-    buttons.addButton(control.getPDFIndividuellButton(Adressblatt.OHNE_ADRESSBLATT));
-    buttons.addButton(control.getPDFIndividuellButton(Adressblatt.MIT_ADRESSE));
+    buttons.addButton(control.getDruckUndMailButton());
     buttons.addButton("Speichern", new Action()
     {
 


### PR DESCRIPTION
Es ist hier folgendes implementiert wie in #345 besprochen:
- Im Menü den Text von "Bitte auswählen" nach "Standard" geändert.
-  Im View "Spendenbescheinigungen automatisch erzeugen" speichere ich die ausgewählten Formulare in den Settings. Dann muss man sie nicht jedesmal neu setzen.
-  Im Menü gibt es nur noch den Eintrag "PDF".
- Die Buttons in der Spendenbescheinigung entfernt und ein neuer Button "Druck und Mail" wie im Menü kommt dazu.
- Im Druck/Mail View verschwindet dann die Ausgabeart.
- Beim drucken wird entweder das Formular aus der Spendenbescheinigung verwendet oder wenn keines in der Spendenbescheinigung gesetzt ist dann wird Standard gedruckt.
- Die Standard Formate von vor 2014 habe ich im Code löschen. Es erscheint eine Fehlermeldung wenn doch noch eine Spendenbescheinigung im Standard Format gerduckt werden soll die über 10 Jahre alt ist.
- Wird nur eine Spendenbescheinigung gedruckt wird sie auch gleich angezeigt.
