### PR TITLE
Icons update und Text umbenannt

### DIFF
--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -319,10 +319,10 @@ public class MyExtension implements Extension
           new BeitragsgruppeSucheAction(), "clone.png"));
       einstellungenmitglieder
           .addChild(new MyItem(einstellungenmitglieder, "Eigenschaften-Gruppen",
-              new EigenschaftGruppeListeAction(), "ellipsis-v.png"));
+              new EigenschaftGruppeListeAction(), "document-properties.png"));
       einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Eigenschaften",
-          new EigenschaftListeAction(), "ellipsis-v.png"));
-      einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Felddefinitionen",
+          new EigenschaftListeAction(), "document-properties.png"));
+      einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Zusatzfelder",
           new FelddefinitionenAction(), "list.png"));
       if (Einstellungen.getEinstellung().getUseLesefelder())
       {
@@ -340,7 +340,7 @@ public class MyExtension implements Extension
       if (Einstellungen.getEinstellung().getZusatzadressen())
       {
         einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Mitgliedstypen",
-            new MitgliedstypListAction(), "columns.png"));
+            new MitgliedstypListAction(), "user-friends.png"));
       }
       administration.addChild(einstellungenmitglieder);
       
@@ -353,10 +353,10 @@ public class MyExtension implements Extension
           "Buchungsarten", new BuchungsartListAction(), "ellipsis-v.png"));
       einstellungenbuchfuehrung
           .addChild(new MyItem(einstellungenbuchfuehrung, "Kontenrahmen-Export",
-              new KontenrahmenExportAction(), "ellipsis-v.png"));
+              new KontenrahmenExportAction(), "document-save.png"));
       einstellungenbuchfuehrung
           .addChild(new MyItem(einstellungenbuchfuehrung, "Kontenrahmen-Import",
-              new KontenrahmenImportAction(), "ellipsis-v.png"));
+              new KontenrahmenImportAction(), "file-import.png"));
       einstellungenbuchfuehrung.addChild(new MyItem(einstellungenbuchfuehrung,
           "Projekte", new ProjektListAction(), "screwdriver.png"));
       administration.addChild(einstellungenbuchfuehrung);

--- a/src/de/jost_net/JVerein/gui/view/FelddefinitionenUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/FelddefinitionenUebersichtView.java
@@ -29,7 +29,7 @@ public class FelddefinitionenUebersichtView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Felddefinitionen");
+    GUI.getView().setTitle("Zusatzfelder");
 
     FelddefinitionControl control = new FelddefinitionControl(this);
 


### PR DESCRIPTION
Ich habe einige Icons im Navigationsbaum geändert:
- Für Eigenschaften und Eigenschaften-Gruppen das Icon welches auch im Mitglied Menü verwendet wird und im neuen Eigenschaften Dialog auch.
- Bei Mitgliedstypen habe ich das Icon welches bei Formulare benutzt wurde durch das Mitglieder Icon ersetzt
- Bei Kontenrahmen-Export das Export Icon verwendet
- Bei Kontenrahmen-Import das Import Icon verwendet
- Felddefinitionen in Zusatzfelder umbenannt. Sie heißen ja auch im Filter Bereich des Mitglied Suche View so. Auch im Mitglieds Detail View ist der Name des Tab so.

Icons alt:                                           Icons neu:
![Bildschirmfoto_20241024_104143](https://github.com/user-attachments/assets/7905b1ba-3399-4771-b756-52be917384fa) ![Bildschirmfoto_20241024_103315](https://github.com/user-attachments/assets/61ea29c5-9f2c-40e7-86cd-c8372aa317e8)


