### PR TITLE
Neu Button im Sollbuchungen Liste View

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -44,6 +44,7 @@ public class SollbuchungDetailView extends AbstractView
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
     LabelGroup grBuchung = new LabelGroup(getParent(),
         (typ == MitgliedskontoNode.SOLL ? "Soll" : "Ist") + "buchung");
+    grBuchung.addLabelPair("Mitglied", control.getMitglied());
     grBuchung.addLabelPair("Datum", control.getDatum());
     grBuchung.addLabelPair("Verwendungszweck 1", control.getZweck1());
     grBuchung.addLabelPair("Zahlungsweg", control.getZahlungsweg());

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -69,6 +69,8 @@ public class SollbuchungListeView extends AbstractView
     buttons.addButton(new Button("Export",
         new MitgliedskontoExportAction(EXPORT_TYP.MITGLIEDSKONTO, null),
         control, false, "document-save.png"));
+    buttons.addButton("Neu", new MitgliedskontoSollbuchungEditAction(), 
+        control, false, "document-new.png");
     buttons.paint(this.getParent());
   }
 }


### PR DESCRIPTION
Man kann jetzt auch Sollbuchungen aus dem Sollbuchungen Liste View erzeugen.
Die meisten anderen Views haben das ja auch. Über das Mitgliedskonto im Mitglied View ist das etwas umständlich.

Ich habe ein Input Feld für das Mitglied in den Sollbuchung Detail View eingebaut. Wird Editieren aufgerufen so wird nur das Mitglied angezeigt und es ist nicht ändernbar.
Bei einer neuen Sollbuchung kann man aus der Liste das Mitglied auswählen. Ich habe die Implementierung der Liste aus dem Lesefeld-Definitionen übernommen. Das könnte man in Zukunft verbessern z.B. durch Suchen wie bei Buchungsarten.