### PR TITLE
Arbeitseinsatz View

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/ArbeitseinsaetzeListeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/ArbeitseinsaetzeListeAction.java
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.ArbeitseinsatzListeView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+
+public class ArbeitseinsaetzeListeAction implements Action
+{
+  @Override
+  public void handleAction(Object context)
+  {
+    GUI.startView(ArbeitseinsatzListeView.class.getName(), null);
+  }
+}

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -37,28 +37,36 @@ import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Element;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.ArbeitseinsatzAction;
 import de.jost_net.JVerein.gui.input.ArbeitseinsatzUeberpruefungInput;
+import de.jost_net.JVerein.gui.menu.ArbeitseinsatzMenu;
 import de.jost_net.JVerein.gui.parts.ArbeitseinsatzPart;
 import de.jost_net.JVerein.gui.parts.ArbeitseinsatzUeberpruefungList;
 import de.jost_net.JVerein.io.ArbeitseinsatzZeile;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.util.Dateiname;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.GenericIterator;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.Settings;
@@ -66,11 +74,9 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class ArbeitseinsatzControl extends AbstractControl
+public class ArbeitseinsatzControl extends FilterControl
 {
   private ArbeitseinsatzPart part = null;
-
-  private Settings settings = null;
 
   private Arbeitseinsatz aeins = null;
 
@@ -79,6 +85,8 @@ public class ArbeitseinsatzControl extends AbstractControl
   private SelectInput suchjahr = null;
 
   private ArbeitseinsatzUeberpruefungInput auswertungschluessel = null;
+  
+  private TablePart arbeitseinsatzList;
 
   public ArbeitseinsatzControl(AbstractView view)
   {
@@ -103,7 +111,7 @@ public class ArbeitseinsatzControl extends AbstractControl
     {
       return part;
     }
-    part = new ArbeitseinsatzPart(getArbeitseinsatz());
+    part = new ArbeitseinsatzPart(getArbeitseinsatz(), true);
     return part;
   }
 
@@ -124,6 +132,18 @@ public class ArbeitseinsatzControl extends AbstractControl
     try
     {
       Arbeitseinsatz ae = getArbeitseinsatz();
+      if (ae.isNewObject())
+      {
+        if (getPart().getMitglied().getValue() != null)
+        {
+          Mitglied m = (Mitglied) getPart().getMitglied().getValue();
+          ae.setMitglied(Integer.parseInt(m.getID()));
+        }
+        else
+        {
+          throw new ApplicationException("Bitte Mitglied eingeben");
+        }
+      }
       ae.setDatum((Date) part.getDatum().getValue());
       ae.setStunden((Double) part.getStunden().getValue());
       ae.setBemerkung((String) part.getBemerkung().getValue());
@@ -175,7 +195,7 @@ public class ArbeitseinsatzControl extends AbstractControl
 
   public Button getPDFAusgabeButton()
   {
-    Button b = new Button("PDF-Ausgabe", new Action()
+    Button b = new Button("PDF", new Action()
     {
 
       @Override
@@ -198,7 +218,7 @@ public class ArbeitseinsatzControl extends AbstractControl
 
   public Button getCSVAusgabeButton()
   {
-    Button b = new Button("CSV-Ausgabe", new Action()
+    Button b = new Button("CSV", new Action()
     {
 
       @Override
@@ -534,7 +554,7 @@ public class ArbeitseinsatzControl extends AbstractControl
     return arbeitseinsatzueberpruefungList.getArbeitseinsatzUeberpruefungList();
   }
   
-  private void refresh()
+  private void refreshList()
   {
     try
     {
@@ -556,8 +576,106 @@ public class ArbeitseinsatzControl extends AbstractControl
       {
         return;
       }
-      refresh();
+      refreshList();
     }
+  }
+  
+  public Part getArbeitseinsatzTable() throws RemoteException
+  {
+    if (arbeitseinsatzList != null)
+    {
+      return arbeitseinsatzList;
+    }
+    
+    DBIterator<Arbeitseinsatz> arbeitseinsaetze = getArbeitseinsaetzeIt();
+    arbeitseinsatzList = new TablePart(arbeitseinsaetze,
+        new ArbeitseinsatzAction(null));
+    arbeitseinsatzList.setRememberColWidths(true);
+    arbeitseinsatzList.setRememberOrder(true);
+    arbeitseinsatzList.setContextMenu(new ArbeitseinsatzMenu());
+
+    arbeitseinsatzList.addColumn("Name", "mitglied", new Formatter()
+    {
+
+      @Override
+      public String format(Object o)
+      {
+        Mitglied m = (Mitglied) o;
+        if (m == null)
+          return null;
+        String name = null;
+        try
+        {
+          name = Adressaufbereitung.getNameVorname(m);
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+        return name;
+      }
+    });
+    arbeitseinsatzList.addColumn("Datum", "datum",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    arbeitseinsatzList.addColumn("Stunden", "stunden",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    arbeitseinsatzList.addColumn("Bemerkung", "bemerkung");
+    return arbeitseinsatzList;
+  }
+  
+  
+  public void TabRefresh()
+  {
+    try
+    {
+      if (arbeitseinsatzList == null)
+      {
+        return;
+      }
+      arbeitseinsatzList.removeAll();
+      DBIterator<Arbeitseinsatz> arbeitseinsaetze = getArbeitseinsaetzeIt();
+      while (arbeitseinsaetze.hasNext())
+      {
+        arbeitseinsatzList.addItem(arbeitseinsaetze.next());
+      }
+    }
+    catch (RemoteException e1)
+    {
+      Logger.error("Fehler", e1);
+    }
+  }
+  
+  private DBIterator<Arbeitseinsatz> getArbeitseinsaetzeIt() throws RemoteException
+  {
+    DBService service = Einstellungen.getDBService();
+    DBIterator<Arbeitseinsatz> arbeitseinsaetze = service
+        .createList(Arbeitseinsatz.class);
+    arbeitseinsaetze.join("mitglied");
+    arbeitseinsaetze.addFilter("mitglied.id = arbeitseinsatz.mitglied");
+    
+    if (isSuchnameAktiv() && getSuchname().getValue() != null)
+    {
+      String tmpSuchname = (String) getSuchname().getValue();
+      if (tmpSuchname.length() > 0)
+      {
+        String suchName = "%" + tmpSuchname.toLowerCase() + "%";
+        arbeitseinsaetze.addFilter("(lower(name) like ? "
+            + "or lower(vorname) like ?)" , 
+            new Object[] { suchName, suchName });
+      }
+    }
+    if (isDatumvonAktiv() && getDatumvon().getValue() != null)
+    {
+      arbeitseinsaetze.addFilter("datum >= ?",
+          new Object[] { (Date) getDatumvon().getValue() });
+    }
+    if (isDatumbisAktiv() && getDatumbis().getValue() != null)
+    {
+      arbeitseinsaetze.addFilter("datum <= ?",
+          new Object[] { (Date) getDatumbis().getValue() });
+    }
+    arbeitseinsaetze.setOrder("ORDER by datum desc");
+    return arbeitseinsaetze;
   }
   
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/MitgliedArbeitseinsatzZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MitgliedArbeitseinsatzZuordnungDialog.java
@@ -55,7 +55,7 @@ public class MitgliedArbeitseinsatzZuordnungDialog extends
   {
     Arbeitseinsatz aeins = (Arbeitseinsatz) Einstellungen.getDBService()
         .createObject(Arbeitseinsatz.class, null);
-    part = new ArbeitseinsatzPart(aeins);
+    part = new ArbeitseinsatzPart(aeins, false);
     part.paint(parent);
 
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -43,6 +43,7 @@ import de.jost_net.JVerein.gui.action.PreNotificationAction;
 import de.jost_net.JVerein.gui.action.MitgliedstypListAction;
 import de.jost_net.JVerein.gui.action.AnfangsbestandListAction;
 import de.jost_net.JVerein.gui.action.AnlagenlisteAction;
+import de.jost_net.JVerein.gui.action.ArbeitseinsaetzeListeAction;
 import de.jost_net.JVerein.gui.action.ArbeitseinsatzUeberpruefungAction;
 import de.jost_net.JVerein.gui.action.AuswertungAdressenAction;
 import de.jost_net.JVerein.gui.action.AuswertungKursteilnehmerAction;
@@ -186,8 +187,8 @@ public class MyExtension implements Extension
       }
       if (Einstellungen.getEinstellung().getArbeitseinsatz())
       {
-        mitglieder.addChild(new MyItem(mitglieder, "Arbeitseinsätze prüfen",
-            new ArbeitseinsatzUeberpruefungAction(), "screwdriver.png"));
+        mitglieder.addChild(new MyItem(mitglieder, "Arbeitseinsätze",
+            new ArbeitseinsaetzeListeAction(), "screwdriver.png"));
       }
       jverein.addChild(mitglieder);
 
@@ -246,6 +247,11 @@ public class MyExtension implements Extension
           new StatistikMitgliedAction(), "chart-line.png"));
       auswertung.addChild(new MyItem(auswertung, "Statistik Jahrgänge",
           new StatistikJahrgaengeAction(), "chart-line.png"));
+      if (Einstellungen.getEinstellung().getArbeitseinsatz())
+      {
+        auswertung.addChild(new MyItem(mitglieder, "Arbeitseinsätze",
+            new ArbeitseinsatzUeberpruefungAction(), "screwdriver.png"));
+      }
       jverein.addChild(auswertung);
 
       NavigationItem mail = null;

--- a/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzPart.java
@@ -22,11 +22,17 @@ import java.util.Date;
 
 import org.eclipse.swt.widgets.Composite;
 
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
+import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.input.AbstractInput;
 import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.util.LabelGroup;
 
@@ -39,16 +45,26 @@ public class ArbeitseinsatzPart implements Part
   private DecimalInput stunden = null;
 
   private TextInput bemerkung = null;
+  
+  private AbstractInput mitglied;
+  
+  private boolean mitMitglied;
+  
 
-  public ArbeitseinsatzPart(Arbeitseinsatz arbeitseinsatz)
+  public ArbeitseinsatzPart(Arbeitseinsatz arbeitseinsatz, boolean mitMitglied)
   {
     this.arbeitseinsatz = arbeitseinsatz;
+    this.mitMitglied = mitMitglied;
   }
 
   @Override
   public void paint(Composite parent) throws RemoteException
   {
     LabelGroup group = new LabelGroup(parent, "Arbeitseinsatz");
+    if (mitMitglied)
+    {
+      group.addLabelPair("Mitglied", getMitglied());
+    }
     group.addLabelPair("Datum", getDatum());
     group.addLabelPair("Stunden", getStunden());
     group.addLabelPair("Bemerkung", getBemerkung());
@@ -70,6 +86,7 @@ public class ArbeitseinsatzPart implements Part
     this.datum.setTitle("Datum");
     this.datum.setName("Datum");
     this.datum.setText("Datum Arbeitseinsatz wählen");
+    datum.setMandatory(true);
     return datum;
   }
 
@@ -82,6 +99,7 @@ public class ArbeitseinsatzPart implements Part
     stunden = new DecimalInput(arbeitseinsatz.getStunden(), new DecimalFormat(
         "###,###.##"));
     stunden.setName("Stunden");
+    stunden.setMandatory(true);
     return stunden;
   }
 
@@ -94,6 +112,28 @@ public class ArbeitseinsatzPart implements Part
     bemerkung = new TextInput(arbeitseinsatz.getBemerkung(), 50);
     bemerkung.setName("Bemerkung");
     return bemerkung;
+  }
+  
+  public Input getMitglied() throws RemoteException
+  {
+    if (mitglied != null)
+    {
+      return mitglied;
+    }
+
+    if (arbeitseinsatz.getMitglied() != null)
+    {
+      Mitglied[] mitgliedArray = {arbeitseinsatz.getMitglied()};
+      mitglied = new SelectInput(mitgliedArray, arbeitseinsatz.getMitglied());
+      mitglied.setEnabled(false);
+    }
+    else
+    {
+      mitglied = new MitgliedInput().getMitgliedInput(mitglied, null,
+          Einstellungen.getEinstellung().getMitgliedAuswahl());
+    }
+    mitglied.setMandatory(true);
+    return mitglied;
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
@@ -16,54 +16,51 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
-import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Listener;
-
+import de.jost_net.JVerein.gui.action.ArbeitseinsatzAction;
+import de.jost_net.JVerein.gui.action.ArbeitseinsatzUeberpruefungAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.ArbeitseinsatzControl;
-import de.jost_net.JVerein.gui.input.ArbeitseinsatzUeberpruefungInput;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
 
-public class ArbeitseinsatzUeberpruefungView extends AbstractView
+public class ArbeitseinsatzListeView extends AbstractView
 {
-  Button butArbeitseinsaetze = null;
-
-  ArbeitseinsatzUeberpruefungInput aui = null;
 
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Arbeitseinsätze auswerten");
+    GUI.getView().setTitle("Arbeitseinsätze");
 
     final ArbeitseinsatzControl control = new ArbeitseinsatzControl(this);
-    butArbeitseinsaetze = control.getArbeitseinsatzAusgabeButton();
+
     LabelGroup group = new LabelGroup(getParent(), "Filter");
-    group.addLabelPair("Jahr", control.getSuchJahr());
-    aui = control.getAuswertungSchluessel();
-    aui.addListener(new Listener()
-    {
-      @Override
-      public void handleEvent(Event event)
-      {
-        int i = (Integer) aui.getValue();
-        butArbeitseinsaetze
-            .setEnabled(i == ArbeitseinsatzUeberpruefungInput.MINDERLEISTUNG);
-      }
+    ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
 
-    });
-    group.addLabelPair("Auswertung", aui);
+    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    left.addInput(control.getSuchname());
+    
+    SimpleContainer right = new SimpleContainer(cl.getComposite());
+    right.addInput(control.getDatumvon());
+    right.addInput(control.getDatumbis());
+    
+    ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getResetButton());
+    fbuttons.addButton(control.getSuchenButton());
+    group.addButtonArea(fbuttons);
 
-    control.getArbeitseinsatzUeberpruefungList().paint(getParent());
-    ButtonArea buttons2 = new ButtonArea();
-    buttons2.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.ARBEITSEINSATZPRUEFEN, false, "question-circle.png");
-    buttons2.addButton(control.getPDFAusgabeButton());
-    buttons2.addButton(control.getCSVAusgabeButton());
-    buttons2.addButton(butArbeitseinsaetze);
-    buttons2.paint(this.getParent());
+    control.getArbeitseinsatzTable().paint(this.getParent());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.ARBEITSEINSATZ, false, "question-circle.png");
+    buttons.addButton("Auswertung", new ArbeitseinsatzUeberpruefungAction(), 
+        control, false, "screwdriver.png");
+    buttons.addButton("Neu", new ArbeitseinsatzAction(null), 
+        control, false, "document-new.png");
+    buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -135,6 +135,8 @@ public class DokumentationUtil
   public static final String STATISTIKJAHRGAENGE = PRE + FUNKTIONEN + AUSWERTUNGEN
       + "statistik-jahrgange";
   
+  public static final String ARBEITSEINSATZPRUEFEN = PRE + FUNKTIONEN + AUSWERTUNGEN + "arbeitseinsatz";
+  
 
   // Druck und Mail
   public static final String RECHNUNG = PRE + FUNKTIONEN + DRUCKMAIL + "rechnungen";

--- a/src/de/jost_net/JVerein/server/ArbeitseinsatzImpl.java
+++ b/src/de/jost_net/JVerein/server/ArbeitseinsatzImpl.java
@@ -68,7 +68,7 @@ public class ArbeitseinsatzImpl extends AbstractDBObject implements
     {
       if (getStunden() == null)
       {
-        throw new ApplicationException("Keine Stunden angegeben");
+        throw new ApplicationException("Bitte Stunden eingeben");
       }
       if (getStunden() <= 0d)
       {
@@ -79,7 +79,7 @@ public class ArbeitseinsatzImpl extends AbstractDBObject implements
       }
       if (getDatum() == null)
       {
-        throw new ApplicationException("Bitte Datum erfassen");
+        throw new ApplicationException("Bitte Datum eingeben");
       }
     }
     catch (RemoteException e)
@@ -131,12 +131,7 @@ public class ArbeitseinsatzImpl extends AbstractDBObject implements
   @Override
   public Double getStunden() throws RemoteException
   {
-    Double d = (Double) getAttribute("stunden");
-    if (d == null)
-    {
-      return 0d;
-    }
-    return d.doubleValue();
+    return (Double) getAttribute("stunden");
   }
 
   @Override


### PR DESCRIPTION
Ich habe jetzt einen neuen View für Arbeiteinsätze erstellt. Ich denke, der ist allgemein sinnvoll weil man bisher nirgends alle Einsätze gesehen hat. Nur wenn man in die Mitglieder Details geschaut hat.
In dem View kann man wie bei den anderen filtern, neue Einträge erzeugen, Einträge bearbeiten und löschen.

Den Arbeitseinsätze prüfen View habe ich nach Auswertungen verschoben. 
Der neue View hat einen Button um direkt zu den Auswertungen zu wechseln.

![Bildschirmfoto_20241027_131438](https://github.com/user-attachments/assets/745d0e19-97ff-421f-b742-e69c3e381e8d)
