### PR TITLE
Menüeinträge Struktur vereinheitlicht

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/FormularMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/FormularMenu.java
@@ -24,7 +24,6 @@ import de.jost_net.JVerein.gui.control.FormularControl;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
-import de.willuhn.jameica.gui.parts.ContextMenuItem;
 
 /**
  * Kontext-Menu zu den Formularen.
@@ -43,7 +42,6 @@ public class FormularMenu extends ContextMenu
         "edit-copy.png"));
     addItem(new CheckedSingleContextMenuItem("Duplizieren",
         new FormularDuplizierenAction(control), "edit-copy.png"));
-    addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedContextMenuItem("Löschen", new FormularDeleteAction(),
         "user-trash-full.png"));
   }

--- a/src/de/jost_net/JVerein/gui/menu/LehrgangMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/LehrgangMenu.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
+import de.willuhn.jameica.gui.parts.ContextMenuItem;
 
 /**
  * Kontext-Menu zu den Lehrgängen
@@ -36,9 +37,10 @@ public class LehrgangMenu extends ContextMenu
   {
     addItem(new CheckedSingleContextMenuItem("Bearbeiten", new LehrgangAction(null),
         "text-x-generic.png"));
-    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
-        new MitgliedDetailAction(), "user-friends.png"));
     addItem(new CheckedContextMenuItem("Löschen", new LehrgangDeleteAction(),
         "user-trash-full.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
+        new MitgliedDetailAction(), "user-friends.png"));
   }
 }

--- a/src/de/jost_net/JVerein/gui/menu/WiedervorlageMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/WiedervorlageMenu.java
@@ -28,6 +28,7 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
 import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
 import de.willuhn.jameica.gui.parts.ContextMenu;
+import de.willuhn.jameica.gui.parts.ContextMenuItem;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.logging.Logger;
 
@@ -44,14 +45,15 @@ public class WiedervorlageMenu extends ContextMenu
   {
     addItem(new CheckedSingleContextMenuItem("Bearbeiten", new WiedervorlageAction(null),
         "text-x-generic.png"));
-    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
-        new MitgliedDetailAction(), "user-friends.png"));
     addItem(new WiedervorlageNichtErledigtItem("Erledigung setzen",
         new WiedervorlageErledigungAction(table), "check.png"));
     addItem(new WiedervorlageErledigtItem("Erledigung löschen",
         new WiedervorlageErledigungDeleteAction(table), "user-trash-full.png"));
     addItem(new CheckedContextMenuItem("Löschen",
         new WiedervorlageDeleteAction(), "user-trash-full.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
+        new MitgliedDetailAction(), "user-friends.png"));
   }
   
   private static class WiedervorlageErledigtItem extends CheckedSingleContextMenuItem

--- a/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
@@ -48,19 +48,19 @@ public class ZusatzbetraegeMenu extends ContextMenu
   {
     addItem(new CheckedSingleContextMenuItem("Bearbeiten", new ZusatzbetraegeAction(null),
         "text-x-generic.png"));
-    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
-        new MitgliedDetailAction(), "user-friends.png"));
     addItem(new ZusatzbetragWiederholtItem("Vorheriges Fälligkeitsdatum",
         new ZusatzbetraegeVorherigeFaelligkeitAction(table),
         "office-calendar.png"));
     addItem(new ZusatzbetragWiederholtItem("Nächstes Fälligkeitsdatum",
         new ZusatzbetraegeNaechsteFaelligkeitAction(table),
         "office-calendar.png"));
-    addItem(ContextMenuItem.SEPARATOR);
     addItem(new ZusatzbetragEinmaligItem("Erneut ausführen",
         new ZusatzbetraegeResetAction(table), "view-refresh.png"));
     addItem(new CheckedContextMenuItem("Löschen",
         new ZusatzbetraegeDeleteAction(), "user-trash-full.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
+        new MitgliedDetailAction(), "user-friends.png"));
   }
   
   private static class ZusatzbetragEinmaligItem extends CheckedSingleContextMenuItem


### PR DESCRIPTION
Neu  /   Alt
![Bildschirmfoto_20241027_172132](https://github.com/user-attachments/assets/03ed017f-20f7-478d-bd34-9916a9a8fd33)![Bildschirmfoto_20241027_172419](https://github.com/user-attachments/assets/6a023052-fc9b-4d49-a116-7c788d3e8fd0)
![Bildschirmfoto_20241027_172219](https://github.com/user-attachments/assets/c2f18717-5e2a-4cee-bb2b-233b8a9ab146)![Bildschirmfoto_20241027_172442](https://github.com/user-attachments/assets/257b15e0-8831-4713-a0ee-9a03c27169e8)
![Bildschirmfoto_20241027_172247](https://github.com/user-attachments/assets/ac9bda55-bc16-4306-9eaf-5c18876d6cd0)![Bildschirmfoto_20241027_172458](https://github.com/user-attachments/assets/f101ad20-7998-496e-9204-9bd52c33c207)
![Bildschirmfoto_20241027_172312](https://github.com/user-attachments/assets/55dcd234-749b-46fd-bdcb-1755e8dbd231)![Bildschirmfoto_20241027_172520](https://github.com/user-attachments/assets/3e5adb89-7368-46c8-a3b4-c63230460051)

Das Menü für Arbeitseinsätze habe ich im entsprechenden PR schon gemacht:
![Bildschirmfoto_20241027_173331](https://github.com/user-attachments/assets/0e9bbac4-c752-4dde-a350-6789cc86d5ff)

Das Ganze passt zur Idee im ersten Teil die Bearbeitungs und Löschen Funktion und nach dem Seperator weitere Aktionen die keine Bearbeitung des Eintrags machen.
Als Beispiel dient auch das neue Menü für Mitglied aus dem Eigenschaften Feature:
![Bildschirmfoto_20241027_173356](https://github.com/user-attachments/assets/ebc2929b-8096-484a-a404-29f3df19b1ae)

