### PR TITLE
Fix zusatzbetrag

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetraegelisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetraegelisteView.java
@@ -30,7 +30,7 @@ public class ZusatzbetraegelisteView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Liste der Zusatzbeträge");
+    GUI.getView().setTitle("Zusatzbeträge");
 
     final ZusatzbetragControl control = new ZusatzbetragControl(this);
 

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -337,7 +337,7 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
     {
       return false;
     }
-    if (getFaelligkeit().getTime() > datum.getTime())
+    if (getFaelligkeit().getTime() < datum.getTime())
     {
       return false;
     }


### PR DESCRIPTION
Der Filter "Active" in im Zusatzbeiträge View sollte Einträge anzeigen die eine nächste Fälligkeit in der Zukunft haben. Jedenfalls wäre das mein Verständnis.

Dafür war aber die Abfrage falsch und so war meine Liste immer leer.

Dann habe ich auch noch den View Titel angepasst.