### PR TITLE
Disable Vollzahler auch wenn Beitragsgruppe null ist

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1344,18 +1344,16 @@ public class MitgliedControl extends FilterControl
     });
 
     if (getBeitragsgruppe(true) != null
-        && getBeitragsgruppe(true).getValue() != null)
+        && getBeitragsgruppe(true).getValue() != null
+        && ((Beitragsgruppe) getBeitragsgruppe(true).getValue()).getBeitragsArt() 
+             == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
     {
-      Beitragsgruppe bg2 = (Beitragsgruppe) getBeitragsgruppe(true).getValue();
-      if (bg2.getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
-      {
-        zahler.setEnabled(true);
-      }
-      else
-      {
-        zahler.setPreselected(getMitglied());
-        zahler.setEnabled(false);
-      }
+      zahler.setEnabled(true);
+    }
+    else
+    {
+      zahler.setPreselected(getMitglied());
+      zahler.setEnabled(false);
     }
     return zahler;
   }


### PR DESCRIPTION
Im Mitglied Detail View war Vollzahler auswählbar wenn keine Beitragsgruppe ausgewählt war. Es sollte aber nur bei Familienmitglieder sein.