### PR TITLE
Spalte S bei Buchung H,G,S statt nur S

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1233,12 +1233,13 @@ public class BuchungsControl extends AbstractControl
       {
         buchungsList.addColumn("D", "document");
       }
-      buchungsList.addColumn("S", "splitid", new Formatter()
+      buchungsList.addColumn("S", "splittyp", new Formatter()
       {
         @Override
         public String format(Object o)
         {
-          return (o != null ? "S" : " ");
+          Integer typ = (Integer) o;
+          return SplitbuchungTyp.get(typ).substring(0, 1);
         }
       });
       buchungsList.addColumn("Konto", "konto", new Formatter()


### PR DESCRIPTION
Um in der Buchungsliste bei Splitbuchungen besser sehen zu können was die Hauptbuchung, Gegenbuchung oder eine Splitbuchung ist zeige ich das durch H, G oder S an.

![Bildschirmfoto_20241031_140036](https://github.com/user-attachments/assets/80953234-e96b-41c9-92b0-957daaa8153e)
