### PR TITLE
Spendenbescheinigung auch für abgeschlossene Jahre

### DIFF
--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -375,7 +375,7 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
       for (Buchung b : buchungen)
       {
         b.setSpendenbescheinigungId(id);
-        b.store();
+        b.store(false);
       }
     }
   }


### PR DESCRIPTION
Das erstellen von Spendenbescheinigungen für abgeschlossene Jahre war nicht möglich, ich habe den Test entfernt