### PR TITLE
Fix SteuerBuchungsart setzen

### DIFF
--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -207,7 +207,7 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   @Override
   public Buchungsart getSteuerBuchungsart() throws RemoteException
   {
-    Long id = (Long) getAttribute("steuer_buchungsart");
+    Integer id = (Integer) getAttribute("steuer_buchungsart");
     if (id == null) {
       return null;
     }


### PR DESCRIPTION
Beim Speichern der Buchungsart mit Steuerbuchungsart kam es zu Exception wegen eines falschen Typs