### PR TITLE
Fix Buchungsart Steuer Long statt Int

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -468,7 +468,7 @@ public class BuchungsartControl extends AbstractControl
       b.setSteuersatz(steuersatzValue);
       if (steuer_buchungsart.getValue() instanceof Buchungsart) 
       {
-        b.setSteuerBuchungsart(Integer.parseInt(((Buchungsart) steuer_buchungsart.getValue()).getID()));
+        b.setSteuerBuchungsart(Long.parseLong(((Buchungsart) steuer_buchungsart.getValue()).getID()));
       }
       else
       {

--- a/src/de/jost_net/JVerein/io/KontenrahmenImportXML.java
+++ b/src/de/jost_net/JVerein/io/KontenrahmenImportXML.java
@@ -128,7 +128,7 @@ public class KontenrahmenImportXML implements Importer
             .createList(Buchungsart.class);
         stbuait.addFilter("nummer = ?", mapst.get(id));
         Buchungsart stbua = stbuait.next();
-        bua.setSteuerBuchungsart(Integer.parseInt(stbua.getID()));
+        bua.setSteuerBuchungsart(Long.parseLong(stbua.getID()));
         bua.store();
       }
     }

--- a/src/de/jost_net/JVerein/io/KontenrahmenImportXMLv2.java
+++ b/src/de/jost_net/JVerein/io/KontenrahmenImportXMLv2.java
@@ -143,7 +143,7 @@ public class KontenrahmenImportXMLv2 implements Importer
           .createList(Buchungsart.class);
       stbuait.addFilter("nummer = ?", mapst.get(id));
       Buchungsart stbua = stbuait.next();
-      bua.setSteuerBuchungsart(Integer.parseInt(stbua.getID()));
+      bua.setSteuerBuchungsart(Long.parseLong(stbua.getID()));
       bua.store();
     }
   }

--- a/src/de/jost_net/JVerein/rmi/Buchungsart.java
+++ b/src/de/jost_net/JVerein/rmi/Buchungsart.java
@@ -50,7 +50,7 @@ public interface Buchungsart extends DBObject
 
   public Buchungsart getSteuerBuchungsart() throws RemoteException;
 
-  public void setSteuerBuchungsart(Integer steuer_buchungsart) throws RemoteException;
+  public void setSteuerBuchungsart(Long steuer_buchungsart) throws RemoteException;
   
   public int getStatus() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -207,7 +207,7 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   @Override
   public Buchungsart getSteuerBuchungsart() throws RemoteException
   {
-    Integer id = (Integer) getAttribute("steuer_buchungsart");
+    Long id = (Long) getAttribute("steuer_buchungsart");
     if (id == null) {
       return null;
     }
@@ -220,7 +220,7 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   }
 
   @Override
-  public void setSteuerBuchungsart(Integer steuer_buchungsart) throws RemoteException
+  public void setSteuerBuchungsart(Long steuer_buchungsart) throws RemoteException
   {
     setAttribute("steuer_buchungsart", steuer_buchungsart);
   }


### PR DESCRIPTION
Den Fehler bei der Buchungsart SteuerBuchungsart hatte ich falsch behoben, es muss Long sein und nicht Integer