### PR TITLE
Umbenennungen

### DIFF
--- a/src/com/schlevoigt/JVerein/gui/view/BuchungsTexteKorrigierenView.java
+++ b/src/com/schlevoigt/JVerein/gui/view/BuchungsTexteKorrigierenView.java
@@ -28,7 +28,7 @@ public class BuchungsTexteKorrigierenView extends AbstractView {
 
 	@Override
 	public void bind() throws Exception {
-	    GUI.getView().setTitle("Buchungstexte korrigieren");
+	    GUI.getView().setTitle("Buchungskorrektur");
 
 		final BuchungsTextKorrekturControl control = new BuchungsTextKorrekturControl(this);
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -635,7 +635,7 @@ public class BuchungsartControl extends AbstractControl
 
   public Button getPDFAusgabeButton()
   {
-    Button b = new Button("PDF-Ausgabe", new Action()
+    Button b = new Button("PDF", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -198,7 +198,7 @@ public class MyExtension implements Extension
           new KontoListAction(), "list.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Anfangsbestände",
           new AnfangsbestandListAction(), "euro-sign.png"));
-      buchfuehrung.addChild(new MyItem(buchfuehrung, "Hibiscus-Buchungen",
+      buchfuehrung.addChild(new MyItem(buchfuehrung, "Hibiscus-Buchungen-Import",
           new BuchungsuebernahmeAction(), "hibiscus-icon-64x64.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungen",
           new BuchungsListeAction(), "euro-sign.png"));

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -177,7 +177,7 @@ public class MyExtension implements Extension
       }
       if (Einstellungen.getEinstellung().getWiedervorlage())
       {
-        mitglieder.addChild(new MyItem(mitglieder, "Wiedervorlage",
+        mitglieder.addChild(new MyItem(mitglieder, "Wiedervorlagen",
             new WiedervorlageListeAction(), "office-calendar.png"));
       }
       if (Einstellungen.getEinstellung().getLehrgaenge())
@@ -224,7 +224,7 @@ public class MyExtension implements Extension
       abrechnung = new MyItem(abrechnung, "Abrechnung", null);
       abrechnung.addChild(new MyItem(abrechnung, "Abrechnung",
           new AbrechnungSEPAAction(), "calculator.png"));
-      abrechnung.addChild(new MyItem(abrechnung, "Abrechnungslauf",
+      abrechnung.addChild(new MyItem(abrechnung, "Abrechnungsläufe",
           new AbrechnunslaufListAction(), "calculator.png"));
       abrechnung.addChild(new MyItem(abrechnung, "Lastschriften",
           new LastschriftListAction(), "file-invoice.png"));
@@ -243,9 +243,9 @@ public class MyExtension implements Extension
         auswertung.addChild(new MyItem(auswertung, "Kursteilnehmer",
             new AuswertungKursteilnehmerAction(), "receipt.png"));
       }
-      auswertung.addChild(new MyItem(auswertung, "Statistik",
+      auswertung.addChild(new MyItem(auswertung, "Mitgliederstatistik",
           new StatistikMitgliedAction(), "chart-line.png"));
-      auswertung.addChild(new MyItem(auswertung, "Statistik Jahrgänge",
+      auswertung.addChild(new MyItem(auswertung, "Jahrgangsstatistik",
           new StatistikJahrgaengeAction(), "chart-line.png"));
       if (Einstellungen.getEinstellung().getArbeitseinsatz())
       {
@@ -324,7 +324,7 @@ public class MyExtension implements Extension
       einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Beitragsgruppen",
           new BeitragsgruppeSucheAction(), "clone.png"));
       einstellungenmitglieder
-          .addChild(new MyItem(einstellungenmitglieder, "Eigenschaften-Gruppen",
+          .addChild(new MyItem(einstellungenmitglieder, "Eigenschaftengruppen",
               new EigenschaftGruppeListeAction(), "document-properties.png"));
       einstellungenmitglieder.addChild(new MyItem(einstellungenmitglieder, "Eigenschaften",
           new EigenschaftListeAction(), "document-properties.png"));
@@ -373,14 +373,14 @@ public class MyExtension implements Extension
       einstellungenerweitert.addChild(new MyItem(einstellungenerweitert, "Migration",
           new MitgliedMigrationAction(), "file-import.png"));
       einstellungenerweitert
-      .addChild(new MyItem(einstellungenerweitert, "QIF Datei-Import",
+      .addChild(new MyItem(einstellungenerweitert, "QIF-Datei-Import",
           new QIFBuchungsImportViewAction(), "file-import.png"));
       einstellungenerweitert.addChild(new MyItem(einstellungenerweitert,
-          "Datenbank bereinigen", new DbBereinigenAction(), "placeholder-loading.png"));
+          "Datenbank-Bereinigung", new DbBereinigenAction(), "placeholder-loading.png"));
       einstellungenerweitert.addChild(new MyItem(einstellungenerweitert,
-          "Diagnose-Backup erstellen", new BackupCreateAction(), "document-save.png"));
+          "Diagnose-Backup-Export", new BackupCreateAction(), "document-save.png"));
       einstellungenerweitert.addChild(
-          new MyItem(einstellungenerweitert, "Diagnose-Backup importieren",
+          new MyItem(einstellungenerweitert, "Diagnose-Backup-Import",
               new BackupRestoreAction(), "file-import.png"));
       administration.addChild(einstellungenerweitert);
       jverein.addChild(administration);

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzUeberpruefungView.java
@@ -37,7 +37,7 @@ public class ArbeitseinsatzUeberpruefungView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Arbeitseinsätze auswerten");
+    GUI.getView().setTitle("Auswertung Arbeitseinsätze");
 
     final ArbeitseinsatzControl control = new ArbeitseinsatzControl(this);
     butArbeitseinsaetze = control.getArbeitseinsatzAusgabeButton();

--- a/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungMitgliedView.java
@@ -41,7 +41,7 @@ public class AuswertungMitgliedView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Auswertung Mitgliedsdaten");
+    GUI.getView().setTitle("Auswertung Mitglieder");
 
     LabelGroup group = new LabelGroup(getParent(), "Filter");
 

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -42,7 +42,7 @@ public class AuswertungNichtMitgliedView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Auswertung Nicht-Mitgliederdaten");
+    GUI.getView().setTitle("Auswertung Nicht-Mitglieder");
 
     LabelGroup group = new LabelGroup(getParent(), "Filter");
 

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -30,7 +30,7 @@ public class BuchungsklasseSaldoView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Buchungsklassen-Saldo");
+    GUI.getView().setTitle("Buchungsklassensaldo");
 
     final BuchungsklasseSaldoControl control = new BuchungsklasseSaldoControl(
         this);

--- a/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
@@ -30,7 +30,7 @@ public class BuchungsuebernahmeView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Hibiscus-Buchungen übernehmen");
+    GUI.getView().setTitle("Hibiscus-Buchungen");
 
     final BuchungsuebernahmeControl control = new BuchungsuebernahmeControl(
         this);

--- a/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsuebernahmeView.java
@@ -30,7 +30,7 @@ public class BuchungsuebernahmeView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Hibiscus-Buchungen");
+    GUI.getView().setTitle("Hibiscus-Buchungen-Import");
 
     final BuchungsuebernahmeControl control = new BuchungsuebernahmeControl(
         this);
@@ -40,14 +40,14 @@ public class BuchungsuebernahmeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGSUEBERNAHME, false, "question-circle.png");
-    buttons.addButton("Übernahme", new Action()
+    buttons.addButton("Import", new Action()
     {
       @Override
       public void handleAction(Object context)
       {
         new Buchungsuebernahme();
       }
-    }, null, true, "document-save.png");
+    }, null, true, "file-import.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
+++ b/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
@@ -31,7 +31,7 @@ public class DbBereinigenView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Datenbank bereinigen");
+    GUI.getView().setTitle("Datenbank-Bereinigung");
 
     final DbBereinigenControl control = new DbBereinigenControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
@@ -29,7 +29,7 @@ public class EigenschaftGruppeListeView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Eigenschaften Gruppen");
+    GUI.getView().setTitle("Eigenschaftengruppen");
 
     EigenschaftGruppeControl control = new EigenschaftGruppeControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
@@ -33,7 +33,7 @@ public class EinstellungenMitgliedAnsichtView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Einstellungen Mitglied Ansicht");
+    GUI.getView().setTitle("Einstellungen Mitglieder Ansicht");
 
     final EinstellungControl control = new EinstellungControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
@@ -29,7 +29,7 @@ public class EinstellungenMitgliederSpaltenView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Einstellungen Trefferliste Mitglieder");
+    GUI.getView().setTitle("Einstellungen Mitglieder Spalten");
 
     final EinstellungControl control = new EinstellungControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -30,7 +30,7 @@ public class EinstellungenRechnungenView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Einstellungen");
+    GUI.getView().setTitle("Einstellungen Rechnungen");
 
     final EinstellungControl control = new EinstellungControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/JubilaeenView.java
+++ b/src/de/jost_net/JVerein/gui/view/JubilaeenView.java
@@ -40,7 +40,7 @@ public class JubilaeenView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.JUBILAEEN, false, "question-circle.png");
-    buttons.addButton("Start", new JubilaeumsExportAction(), control, true,
+    buttons.addButton("Starten", new JubilaeumsExportAction(), control, true,
         "walking.png");
     buttons.paint(getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/KontensaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontensaldoView.java
@@ -31,7 +31,7 @@ public class KontensaldoView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Konten-Saldo");
+    GUI.getView().setTitle("Kontensaldo");
 
     final KontensaldoControl control = new KontensaldoControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
@@ -34,7 +34,7 @@ public class KontoauszugView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Kontoauszug");
+    GUI.getView().setTitle("Kontoauszüge");
 
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
     control.init("kontoauszug.", null, null);

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
@@ -38,7 +38,7 @@ public class KursteilnehmerSucheView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Suche Kursteilnehmer");
+    GUI.getView().setTitle("Kursteilnehmer");
 
     final KursteilnehmerControl control = new KursteilnehmerControl(this);
 

--- a/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
@@ -102,7 +102,7 @@ public class LesefeldDetailView extends AbstractView implements Listener
       updateScriptResult();
 
     ButtonArea buttonArea = new ButtonArea();
-    Button button = new Button("Aktualisieren (F5)", new Action()
+    Button button = new Button("Aktualisieren", new Action()
     {
 
       @Override
@@ -112,7 +112,7 @@ public class LesefeldDetailView extends AbstractView implements Listener
       }
     }, null, false, "view-refresh.png");
     buttonArea.addButton(button);
-    button = new Button("Variablen anzeigen (F6)",
+    button = new Button("Variablen anzeigen",
         new OpenInsertVariableDialogAction(), null, false, "bookmark.png");
     buttonArea.addButton(button);
     button = new Button("Speichern", new SaveLesefeldAction(), null,
@@ -218,14 +218,14 @@ public class LesefeldDetailView extends AbstractView implements Listener
   public void handleEvent(Event event)
   {
     // aktualisiere Script-Ausgabe, wenn F5 gedrückt wird.
-    if (event.keyCode == org.eclipse.swt.SWT.F5)
+    /*if (event.keyCode == org.eclipse.swt.SWT.F5)
     {
       updateScriptResult();
     }
     else if (event.keyCode == org.eclipse.swt.SWT.F6)
     {
       new OpenInsertVariableDialogAction().handleAction(null);
-    }
+    }*/
   }
 
   private final class SaveLesefeldAction implements Action

--- a/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldDetailView.java
@@ -217,15 +217,6 @@ public class LesefeldDetailView extends AbstractView implements Listener
   @Override
   public void handleEvent(Event event)
   {
-    // aktualisiere Script-Ausgabe, wenn F5 gedrückt wird.
-    /*if (event.keyCode == org.eclipse.swt.SWT.F5)
-    {
-      updateScriptResult();
-    }
-    else if (event.keyCode == org.eclipse.swt.SWT.F6)
-    {
-      new OpenInsertVariableDialogAction().handleAction(null);
-    }*/
   }
 
   private final class SaveLesefeldAction implements Action

--- a/src/de/jost_net/JVerein/gui/view/LesefeldUebersichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldUebersichtView.java
@@ -27,7 +27,7 @@ public class LesefeldUebersichtView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Lesefeld-Definitionen");
+    GUI.getView().setTitle("Lesefelder");
 
     LesefeldUebersichtPart lesefeldEinstellungPart = new LesefeldUebersichtPart(
         (Mitglied) getCurrentObject());

--- a/src/de/jost_net/JVerein/gui/view/MigrationView.java
+++ b/src/de/jost_net/JVerein/gui/view/MigrationView.java
@@ -187,7 +187,7 @@ public class MigrationView extends AbstractView
   public void bind() throws Exception
   {
 
-    GUI.getView().setTitle("Daten-Import");
+    GUI.getView().setTitle("Migration");
 
     final Composite parent = this.getParent();
     parent.setLayout(new GridLayout(2, false));

--- a/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
@@ -42,7 +42,7 @@ public class MitgliederSucheView extends AbstractMitgliedSucheView
   @Override
   public String getTitle()
   {
-    return "Mitglieder suchen";
+    return "Mitglieder";
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
@@ -41,7 +41,7 @@ public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
   @Override
   public String getTitle()
   {
-    return "Nicht-Mitglieder suchen";
+    return "Nicht-Mitglieder";
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/PreNotificationView.java
+++ b/src/de/jost_net/JVerein/gui/view/PreNotificationView.java
@@ -45,7 +45,7 @@ public class PreNotificationView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("SEPA Pre-Notification");
+    GUI.getView().setTitle("Pre-Notification");
 
     final PreNotificationControl control = new PreNotificationControl(this);
     control.init("prenotification." , null, null);

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -31,7 +31,7 @@ public class ProjektSaldoView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Projekt-Saldo");
+    GUI.getView().setTitle("Projektsaldo");
 
     final ProjektSaldoControl control = new ProjektSaldoControl(this);
     

--- a/src/de/jost_net/JVerein/gui/view/QIFBuchungsImportView.java
+++ b/src/de/jost_net/JVerein/gui/view/QIFBuchungsImportView.java
@@ -44,7 +44,7 @@ public class QIFBuchungsImportView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Importiere QIF Buchungen");
+    GUI.getView().setTitle("QIF-Datei-Import");
 
     QIFBuchungsImportControl control = new QIFBuchungsImportControl(this);
     LabelGroup group = new LabelGroup(getParent(), "Konto Kopfdaten");
@@ -77,7 +77,7 @@ public class QIFBuchungsImportView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.QIFIMPORT, false, "question-circle.png");
-    buttons.addButton("Datei einlesen", new QIFDateiEinlesenAction(), null,
+    buttons.addButton("Import", new QIFDateiEinlesenAction(), null,
         false, "file-import.png");
     buttons.addButton("Import löschen",
         control.getAktuellenImportLoeschenAction(), null, false,

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -33,7 +33,7 @@ public class SpendenbescheinigungMailView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Spendenbescheinigung");
+    GUI.getView().setTitle("Spendenbescheinigungen");
 
     final SpendenbescheinigungControl control = new SpendenbescheinigungControl(this);
     control.init("spenden." , null, null);

--- a/src/de/jost_net/JVerein/gui/view/StatistikJahrgaengeView.java
+++ b/src/de/jost_net/JVerein/gui/view/StatistikJahrgaengeView.java
@@ -31,7 +31,7 @@ public class StatistikJahrgaengeView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Statistik Jahrgänge");
+    GUI.getView().setTitle("Jahrgangsstatistik");
 
     final MitgliedControl control = new MitgliedControl(this);
 
@@ -41,7 +41,7 @@ public class StatistikJahrgaengeView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.STATISTIKJAHRGAENGE, false, "question-circle.png");
-    Button btnStart = new Button("Start", new StatistikJahrgaengeExportAction(),
+    Button btnStart = new Button("Starten", new StatistikJahrgaengeExportAction(),
         control.getJubeljahr(), true, "walking.png");
 
     buttons.addButton(btnStart);

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetraegelisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetraegelisteView.java
@@ -43,7 +43,7 @@ public class ZusatzbetraegelisteView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ZUSATZBETRAEGE, false, "question-circle.png");
-    buttons.addButton("Importieren",
+    buttons.addButton("Import",
         new ZusatzbetraegeImportAction(),null,false, "file-import.png");
     buttons.addButton(control.getPDFAusgabeButton());
     buttons.addButton("Neu", new ZusatzbetraegeAction(null), 


### PR DESCRIPTION
In Anregung durch #443 habe ich einige Namen im Navigationsbaum umbenannt.
Zusätzlich habe ich dann die Titel in den zugehörigen Views entsprechend angepasst.
Bei einigen Buttons habe ich die Namen an sonst übliche Namen angepasst.

Im Lesefelder Detail View habe ich das F5 und F6 auskommentiert. Das ist der einzige View der F Tasten unterstützt. Das passt nicht zum Rest des Systems. Wenn wir das machen sollten wir es für alle Views einführen.
