### PR TITLE
Fenster SEPA Version

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -29,6 +29,7 @@ import org.kapott.hbci.sepa.SepaVersion;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.dialogs.PainVersionDialog;
 import de.jost_net.JVerein.gui.input.AbbuchungsmodusInput;
 import de.jost_net.JVerein.io.AbrechnungSEPA;
 import de.jost_net.JVerein.io.AbrechnungSEPAParam;
@@ -47,7 +48,6 @@ import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
-import de.willuhn.jameica.hbci.gui.dialogs.PainVersionDialog;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.OperationCanceledException;
@@ -361,7 +361,7 @@ public class AbrechnungSEPAControl extends AbstractControl
       String file = fd.open();
       if (file == null || file.length() == 0)
       {
-        throw new ApplicationException("keine Datei ausgewählt!");
+        throw new ApplicationException("Keine Datei ausgewählt!");
       }
       sepafilercur = new File(file);
       // Wir merken uns noch das Verzeichnis fürs nächste mal
@@ -379,6 +379,10 @@ public class AbrechnungSEPAControl extends AbstractControl
           if (sepaVersion == null)
           {
             return;
+          }
+          if (d.isChecked())
+          {
+            Einstellungen.getEinstellung().setSepaVersion(sepaVersion);
           }
         }
       }

--- a/src/de/jost_net/JVerein/gui/dialogs/PainVersionDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/PainVersionDialog.java
@@ -1,0 +1,167 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.kapott.hbci.sepa.SepaVersion;
+import org.kapott.hbci.sepa.SepaVersion.Type;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.LabelInput;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.Container;
+import de.willuhn.jameica.gui.util.SimpleContainer;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Dialog zum Auswaehlen einer SEPA PAIN-Version.
+ */
+public class PainVersionDialog extends AbstractDialog<SepaVersion>
+{
+  private final static int WINDOW_WIDTH = 400;
+
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  
+  private Type type               = null;
+  private SepaVersion painVersion = null;
+  private Button ok               = null;
+  private boolean isChecked       = true;
+  final CheckboxInput check = this.getCheckbox();
+
+  /**
+   * ct.
+   * @param type der zu exportierende PAIN-Type.
+   */
+  public PainVersionDialog(Type type)
+  {
+    super(PainVersionDialog.POSITION_CENTER);
+    this.setTitle(i18n.tr("SEPA XML-Version"));
+    this.type = type;
+    this.setSize(WINDOW_WIDTH,SWT.DEFAULT);
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#paint(org.eclipse.swt.widgets.Composite)
+   */
+  protected void paint(Composite parent) throws Exception
+  {
+    Container c = new SimpleContainer(parent);
+    c.addText(i18n.tr("Bitte wählen Sie die zu verwendende SEPA XML-Version."),true);
+    
+    final SelectInput version = this.getPainVersionInput();
+    final LabelInput msg      = this.getMessage();
+    
+    c.addInput(version);
+    c.addInput(msg);
+    c.addInput(check);
+    
+    ButtonArea buttons = new ButtonArea();
+    this.ok = new Button(i18n.tr("Übernehmen"),new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        painVersion = (SepaVersion) version.getValue();
+        if (painVersion == null)
+        {
+          msg.setValue(i18n.tr("Bitte wählen Sie eine SEPA XML-Version aus."));
+          return;
+        }
+        close();
+      }
+    },null,true,"ok.png");
+    buttons.addButton(ok);
+    
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        throw new OperationCanceledException();
+      }
+    },null,false,"process-stop.png");
+    
+    c.addButtonArea(buttons);
+    getShell().setMinimumSize(getShell().computeSize(WINDOW_WIDTH,SWT.DEFAULT));
+  }
+  
+  /**
+   * Liefert ein Auswahlfeld mit der zu verwendenden PAIN-Version.
+   * @return Auswahlfeld mit der PAIN-Version.
+   */
+  private SelectInput getPainVersionInput()
+  {
+    List<SepaVersion> list = SepaVersion.getKnownVersions(type);
+    final SelectInput select = new SelectInput(list,SepaVersion.findGreatest(list));
+    select.setAttribute("file");
+    select.setName(i18n.tr("Schema-Version der SEPA XML-Datei"));
+    select.addListener(new Listener() {
+      public void handleEvent(Event event)
+      {
+        if (ok != null)
+          ok.setEnabled(select.getValue() != null);
+      }
+    });
+    return select;
+  }
+  
+  /**
+   * Liefert ein Label fuer Fehlermeldungen.
+   * @return ein Label fuer Fehlermeldungen.
+   */
+  private LabelInput getMessage()
+  {
+    LabelInput label = new LabelInput("");
+    label.setColor(Color.ERROR);
+    label.setName("");
+    return label;
+  }
+  
+  private CheckboxInput getCheckbox()
+  {
+    CheckboxInput checkbox = new CheckboxInput(true);
+    checkbox.setName("Schema-Version in die Einstellungen übernehmen");
+    checkbox.addListener(new Listener() {
+      public void handleEvent(Event event)
+      {
+        isChecked = (boolean) check.getValue();
+      }
+    });
+    return checkbox;
+  }
+  
+  public boolean isChecked()
+  {
+    return isChecked;
+  }
+  
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  protected SepaVersion getData() throws Exception
+  {
+    return this.painVersion;
+  }
+}
+
+

--- a/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
+++ b/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
@@ -46,6 +46,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.LastschriftMap;
 import de.jost_net.JVerein.Variable.VarTools;
+import de.jost_net.JVerein.gui.dialogs.PainVersionDialog;
 import de.jost_net.JVerein.keys.Ct1Ausgabe;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -56,7 +57,6 @@ import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.hbci.gui.action.SepaUeberweisungMerge;
-import de.willuhn.jameica.hbci.gui.dialogs.PainVersionDialog;
 import de.willuhn.jameica.hbci.rmi.AuslandsUeberweisung;
 import de.willuhn.jameica.hbci.rmi.HibiscusAddress;
 import de.willuhn.jameica.system.Application;
@@ -100,6 +100,10 @@ public class Ct1Ueberweisung
       if (sepaVersion == null)
       {
         throw new OperationCanceledException();
+      }
+      if (d.isChecked())
+      {
+        Einstellungen.getEinstellung().setCt1SepaVersion(sepaVersion);
       }
     }
     Properties ls_properties = new Properties();


### PR DESCRIPTION
In Anregung aus #442 habe ich den SEPA Pain Dialog erweitert um eine Checkbox mit der Abfrage ob die SEPA Version in die Einstellungen übernommen werden soll. Das ist per Default selektiert. Damit erschein die Abfrage später nicht mehr. Sie erscheint sowieso nicht wenn man schon etwas in den Einstellungen gesetzt hatte.

Die Änderung ist für Lastschrift und 1ct Überweisung gemacht.

![Bildschirmfoto_20241112_102511](https://github.com/user-attachments/assets/a7695657-71d9-466c-b973-6e71ca14166d)

PS: Ich habe den Dialog aus Hibiskus kopiert um ihn zu erweitern.