### PR TITLE
Zahlungsgrund laengeres Feld erlauben

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -206,7 +206,7 @@ public class AbrechnungSEPAControl extends AbstractControl
     }
     String zgrund = settings.getString("zahlungsgrund", "bitte eingeben");
 
-    zahlungsgrund = new TextInput(zgrund, 50);
+    zahlungsgrund = new TextInput(zgrund, 140);
     return zahlungsgrund;
   }
 

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -475,7 +475,12 @@ public class AbrechnungSEPA
         zahler.setFaelligkeit(param.faelligkeit);
         if (primaer && m.getZahlungsweg() != Zahlungsweg.VOLLZAHLER)
         {
-          zahler.setVerwendungszweck(getVerwendungszweck2(mZahler) + " " + vzweck);
+          String verwendungszweck = getVerwendungszweck2(mZahler) + " " + vzweck;
+          if (verwendungszweck.length() >= 140)
+          {
+            verwendungszweck = verwendungszweck.substring(0, 136) + "...";
+          }
+          zahler.setVerwendungszweck(verwendungszweck);
         }
         else
         {


### PR DESCRIPTION
Zahlungsgrund bei Abrechnungslauf 140 statt nur 50 Zeichen erlauben. So können auch die Variablennamen eingegeben werden. Wenn der gesamte Verwendungszweck zu lang wird, wird er bei der Abrechnung gekürzt.