### PR TITLE
Abbuchung und Hibiscus-Buchungen-Import entfernt

### DIFF
--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -24,7 +24,6 @@ import com.schlevoigt.JVerein.gui.action.BuchungsTexteKorrigierenAction;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.AboutAction;
-import de.jost_net.JVerein.gui.action.AbrechnungSEPAAction;
 import de.jost_net.JVerein.gui.action.AbrechnunslaufListAction;
 import de.jost_net.JVerein.gui.action.AbschreibungsListeAction;
 import de.jost_net.JVerein.gui.action.AdministrationEinstellungenAbrechnungAction;
@@ -55,7 +54,6 @@ import de.jost_net.JVerein.gui.action.BuchungsListeAction;
 import de.jost_net.JVerein.gui.action.BuchungsartListAction;
 import de.jost_net.JVerein.gui.action.BuchungsklasseListAction;
 import de.jost_net.JVerein.gui.action.BuchungsklasseSaldoAction;
-import de.jost_net.JVerein.gui.action.BuchungsuebernahmeAction;
 import de.jost_net.JVerein.gui.action.DbBereinigenAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.EigenschaftGruppeListeAction;
@@ -198,8 +196,6 @@ public class MyExtension implements Extension
           new KontoListAction(), "list.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Anfangsbestände",
           new AnfangsbestandListAction(), "euro-sign.png"));
-      buchfuehrung.addChild(new MyItem(buchfuehrung, "Hibiscus-Buchungen-Import",
-          new BuchungsuebernahmeAction(), "hibiscus-icon-64x64.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungen",
           new BuchungsListeAction(), "euro-sign.png"));
       if (anlagenkonto)
@@ -222,8 +218,6 @@ public class MyExtension implements Extension
       
       NavigationItem abrechnung = null;
       abrechnung = new MyItem(abrechnung, "Abrechnung", null);
-      abrechnung.addChild(new MyItem(abrechnung, "Abrechnung",
-          new AbrechnungSEPAAction(), "calculator.png"));
       abrechnung.addChild(new MyItem(abrechnung, "Abrechnungsläufe",
           new AbrechnunslaufListAction(), "calculator.png"));
       abrechnung.addChild(new MyItem(abrechnung, "Lastschriften",

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import de.jost_net.JVerein.gui.action.AbrechnungSEPAAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AbrechnungslaufControl;
 import de.willuhn.jameica.gui.AbstractView;
@@ -54,6 +55,8 @@ public class AbrechnungslaufListView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ABRECHNUNGSLAUF, false, "question-circle.png");
+    buttons.addButton("Neu", new AbrechnungSEPAAction(), 
+        null, false, "document-new.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.TabFolder;
 
 import de.jost_net.JVerein.gui.action.BuchungImportAction;
 import de.jost_net.JVerein.gui.action.BuchungNeuAction;
+import de.jost_net.JVerein.gui.action.BuchungsuebernahmeAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenart;
@@ -126,6 +127,8 @@ public class BuchungslisteView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGEN, false, "question-circle.png");
+    buttons.addButton("Hibiscus-Import", new BuchungsuebernahmeAction(), null, false,
+        "file-import.png");
     buttons.addButton("Import", new BuchungImportAction(), null, false,
         "file-import.png");
     buttons.addButton(control.getStartCSVAuswertungButton());


### PR DESCRIPTION
Nach der Diskussion in #443 habe ich jetzt noch Navigationsbaum Einträge entfernt.
- Abrechnung entfernt und als Neu Button im Abrechnungsläufe View integriert
- Hibiscus-Buchungen-Import entfernt und als Button im Buchungen Liste View integriert. Der hat eh nicht in den Baum so richtig gepasst
![Bildschirmfoto_20241114_105805](https://github.com/user-attachments/assets/23169e32-a47b-4280-8cda-8576e34abf70)


 