### PR TITLE
Update Docu Links

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -44,6 +44,8 @@ public class DokumentationUtil
   
   private static final String ADMERWEITERT = "erweitert/";
   
+  private static final String ADMEINSTELLUNG = "einstellungen/";
+  
   
   // Mitglieder
   public static final String ARBEITSEINSATZ = PRE + FUNKTIONEN + MITGLIEDER + "arbeitseinsatz";
@@ -160,7 +162,27 @@ public class DokumentationUtil
   
   
   // Einstellungen
-  public static final String EINSTELLUNGEN = PRE + FUNKTIONEN + ADMIN + "einstellungen";
+  public static final String EINSTELLUNGEN_ABRECHNUNG = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "abrechnung";
+  
+  public static final String EINSTELLUNGEN_ALLGEMEIN = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "allgemein";
+  
+  public static final String EINSTELLUNGEN_ANSICHT = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "ansicht";
+  
+  public static final String EINSTELLUNGEN_ANZEIGE = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "anzeige";
+  
+  public static final String EINSTELLUNGEN_BUCHFUEHRUNG = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "buchfuehrung";
+  
+  public static final String EINSTELLUNGEN_DATEINAMEN = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "dateinamen";
+  
+  public static final String EINSTELLUNGEN_MAIL = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "mail";
+  
+  public static final String EINSTELLUNGEN_RECHNUNGEN = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "rechnungen";
+  
+  public static final String EINSTELLUNGEN_SPALTEN = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "spalten";
+  
+  public static final String EINSTELLUNGEN_SPENDENBESCHEINIGUNGEN = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "spendenbescheinigungen";
+  
+  public static final String EINSTELLUNGEN_STATISTIK = PRE + FUNKTIONEN + ADMIN + ADMEINSTELLUNG + "statistik";
   
   
   // Einstellungen Mitglieder

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAbrechnungView.java
@@ -58,7 +58,7 @@ public class EinstellungenAbrechnungView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_ABRECHNUNG, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAllgemeinView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAllgemeinView.java
@@ -50,7 +50,7 @@ public class EinstellungenAllgemeinView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_ALLGEMEIN, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -92,7 +92,7 @@ public class EinstellungenAnzeigeView extends AbstractView
     cont.addSeparator();
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_ANZEIGE, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -52,7 +52,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_BUCHFUEHRUNG, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenDateinamenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenDateinamenView.java
@@ -44,7 +44,7 @@ public class EinstellungenDateinamenView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_DATEINAMEN, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMailView.java
@@ -67,7 +67,7 @@ public class EinstellungenMailView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_MAIL, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
@@ -114,7 +114,7 @@ public class EinstellungenMitgliedAnsichtView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_ANSICHT, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliederSpaltenView.java
@@ -38,7 +38,7 @@ public class EinstellungenMitgliederSpaltenView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_SPALTEN, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -59,7 +59,7 @@ public class EinstellungenRechnungenView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_RECHNUNGEN, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenSpendenbescheinigungenView.java
@@ -58,7 +58,7 @@ public class EinstellungenSpendenbescheinigungenView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_SPENDENBESCHEINIGUNGEN, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenStatistikView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenStatistikView.java
@@ -44,7 +44,7 @@ public class EinstellungenStatistikView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-        DokumentationUtil.EINSTELLUNGEN, false, "question-circle.png");
+        DokumentationUtil.EINSTELLUNGEN_STATISTIK, false, "question-circle.png");
     buttons.addButton("Speichern", new Action()
     {
 


### PR DESCRIPTION
Bei der Überarbeitung der Online Help habe ich die Seite für die Einstellungen in einzellne Seiten aufgeteilt.

Mit dem PR werden die Help Links auf die neuen Seiten gesetzt.

Ich habe den alten Text noch Online gelassen wegen der aktuellen Version. Allerdings landet man nicht dort, sondern in der Übersicht Seite der Einstellungen. Das ist auch ok weil man dann eben auf das Feld klickt welches man sehen will.