### PR TITLE
Buchungsart übernehmen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/AnlagenkontoNeuAction.java
@@ -65,7 +65,7 @@ public class AnlagenkontoNeuAction implements Action
         bu.setZweck(buchung.getZweck());
         bu.setDatum(buchung.getDatum());
         if (buchung.getBuchungsart() != null)
-          bu.setBuchungsart(buchung.getBuchungsartId());
+          bu.setBuchungsartId(buchung.getBuchungsartId());
         if (buchung.getProjekt() != null)
           bu.setProjektID(buchung.getProjektID());
         bu.setKommentar(buchung.getKommentar());

--- a/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
@@ -85,7 +85,7 @@ public class BuchungBuchungsartZuordnungAction implements Action
         {
           for (Buchung buchung : b)
           {
-            buchung.setBuchungsart(null);
+            buchung.setBuchungsartId(null);
             buchung.setBuchungsklasseId(null);
             buchung.store();
           }
@@ -102,7 +102,7 @@ public class BuchungBuchungsartZuordnungAction implements Action
             }
             else
             {
-              buchung.setBuchungsart(Long.valueOf(ba.getID()));
+              buchung.setBuchungsartId(Long.valueOf(ba.getID()));
               if (bk != null)
                buchung.setBuchungsklasseId(Long.valueOf(bk.getID()));
               else

--- a/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDuplizierenAction.java
@@ -47,7 +47,7 @@ public class BuchungDuplizierenAction implements Action
       bu.setArt(b.getArt());
       bu.setKommentar(b.getKommentar());
       if (b.getBuchungsart() != null)
-        bu.setBuchungsart(b.getBuchungsartId());
+        bu.setBuchungsartId(b.getBuchungsartId());
       if (b.getBuchungsklasse() != null)
         bu.setBuchungsklasseId(b.getBuchungsklasseId());
       if (b.getProjekt() != null)

--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -67,7 +67,7 @@ public class BuchungGegenbuchungAction implements Action
         bu.setZweck(b.getZweck());
         bu.setDatum(b.getDatum());
         if (b.getBuchungsart() != null)
-          bu.setBuchungsart(b.getBuchungsartId());
+          bu.setBuchungsartId(b.getBuchungsartId());
         if (b.getBuchungsklasse() != null)
           bu.setBuchungsklasseId(b.getBuchungsklasseId());
         if (b.getProjekt() != null)

--- a/src/de/jost_net/JVerein/gui/action/BuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungNeuAction.java
@@ -51,7 +51,7 @@ public class BuchungNeuAction implements Action
       {
         if (konto.getAnlagenkonto())
         {
-          buch.setBuchungsart(konto.getAfaartId());
+          buch.setBuchungsartId(konto.getAfaartId());
         }
         buch.setDatum(new Date());
         buch.setKonto(konto);
@@ -69,7 +69,7 @@ public class BuchungNeuAction implements Action
             {
               if (k.getAnlagenkonto())
               {
-                buch.setBuchungsart(k.getAfaartId());
+                buch.setBuchungsartId(k.getAfaartId());
               }
               buch.setDatum(new Date());
               buch.setKonto(k);

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -107,6 +107,13 @@ public class BuchungSollbuchungZuordnungAction implements Action
         for (Buchung buchung : b)
         {
           buchung.setMitgliedskonto(mk);
+          if (mk != null)
+          {
+            if (buchung.getBuchungsart() == null)
+              buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
+            if (buchung.getBuchungsklasseId() == null)
+              buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
+          }
           buchung.store();
         }
         control.getBuchungsList();

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -109,8 +109,8 @@ public class BuchungSollbuchungZuordnungAction implements Action
           buchung.setMitgliedskonto(mk);
           if (mk != null)
           {
-            if (buchung.getBuchungsart() == null && mk.getBuchungsart() != null)
-              buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
+            if (buchung.getBuchungsartId() == null)
+              buchung.setBuchungsartId(mk.getBuchungsartId());
             if (buchung.getBuchungsklasseId() == null)
               buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
           }

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -109,7 +109,7 @@ public class BuchungSollbuchungZuordnungAction implements Action
           buchung.setMitgliedskonto(mk);
           if (mk != null)
           {
-            if (buchung.getBuchungsart() == null)
+            if (buchung.getBuchungsart() == null && mk.getBuchungsart() != null)
               buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
             if (buchung.getBuchungsklasseId() == null)
               buchung.setBuchungsklasseId(mk.getBuchungsklasseId());

--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
@@ -48,7 +48,7 @@ public class SplitbuchungNeuAction implements Action
       buch.setSplitId(Long.valueOf(master.getID()));
       buch.setUmsatzid(master.getUmsatzid());
       buch.setZweck(master.getZweck());
-      buch.setBuchungsart(Long.parseLong(master.getBuchungsart().getID()));
+      buch.setBuchungsartId(master.getBuchungsartId());
       buch.setSpeicherung(false);
       buch.setSplitTyp(SplitbuchungTyp.SPLIT);
       buch.setBetrag(SplitbuchungsContainer.getSumme(SplitbuchungTyp.HAUPT).doubleValue() - SplitbuchungsContainer.getSumme(SplitbuchungTyp.SPLIT).doubleValue());

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -254,7 +254,7 @@ public class BuchungsControl extends AbstractControl
 
   public void fillBuchung(Buchung b) throws ApplicationException, RemoteException
   { 
-    b.setBuchungsart(getSelectedBuchungsArtId());
+    b.setBuchungsartId(getSelectedBuchungsArtId());
     b.setBuchungsklasseId(getSelectedBuchungsKlasseId());
     b.setProjektID(getSelectedProjektId());
     b.setKonto(getSelectedKonto());
@@ -700,7 +700,7 @@ public class BuchungsControl extends AbstractControl
               b.setAuszugsnummer(master.getAuszugsnummer());
               b.setBetrag(ssub.getBetrag() * -1);
               b.setBlattnummer(master.getBlattnummer());
-              b.setBuchungsart(master.getBuchungsartId());
+              b.setBuchungsartId(master.getBuchungsartId());
               b.setBuchungsklasseId(master.getBuchungsklasseId());
               b.setDatum(su.getAusfuehrungsdatum());
               b.setKonto(master.getKonto());
@@ -986,7 +986,7 @@ public class BuchungsControl extends AbstractControl
               break;
           }
           
-          b_steuer.setBuchungsart(Long.valueOf(b_art.getSteuerBuchungsart().getID()));
+          b_steuer.setBuchungsartId(Long.valueOf(b_art.getSteuerBuchungsart().getID()));
           b_steuer.setBetrag(steuer.doubleValue());
           b_steuer.setZweck(b.getZweck() + zweck_postfix);          
           b_steuer.setSplitId(b.getSplitId());

--- a/src/de/jost_net/JVerein/gui/control/QIFBuchungsImportControl.java
+++ b/src/de/jost_net/JVerein/gui/control/QIFBuchungsImportControl.java
@@ -790,7 +790,7 @@ public class QIFBuchungsImportControl extends AbstractControl
       Buchung buchung = BuchungNoCheck.getNewInstanze();
       buchung.setArt(importPos.getBeleg());
       buchung.setBetrag(importPos.getBetrag().doubleValue());
-      buchung.setBuchungsart(importPos.getBuchungsartId());
+      buchung.setBuchungsartId(importPos.getBuchungsartId());
       buchung.setDatum(importPos.getDatum());
       buchung.setKommentar("Importiert von externen Programm");
       buchung.setKonto(konto);

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
@@ -38,11 +38,8 @@ import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
-import de.willuhn.jameica.system.Application;
-import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
-import de.willuhn.util.ProgressMonitor;
 
 /**
  * Ein Dialog, der die automatisch ermittelten Zuordnungen zwischen Buchung
@@ -107,7 +104,7 @@ public class BuchungenSollbuchungZuordnungVorschauDialog extends AbstractDialog<
     b.addButton("Zuordnen", new Action()
     {
       @Override
-      public void handleAction(Object context)
+      public void handleAction(Object context) throws ApplicationException
       {
         persistAssignment();
       }
@@ -124,58 +121,34 @@ public class BuchungenSollbuchungZuordnungVorschauDialog extends AbstractDialog<
     b.paint(parent);
   }
 
-  protected void persistAssignment()
+  protected void persistAssignment() throws ApplicationException
   {
-
-    BackgroundTask t = new BackgroundTask()
+    try
     {
-
-      @Override
-      public void run(ProgressMonitor monitor) throws ApplicationException
+      for(BookingMemberAccountEntry dao : assignedBooking)
       {
-
-        try
+        Mitgliedskonto mk = dao.getMitgliedskonto();
+        Buchung buchung = dao.getBuchung();
+        buchung.setMitgliedskonto(dao.getMitgliedskonto());
+        if (mk != null)
         {
-          for(BookingMemberAccountEntry dao : assignedBooking)
-          {
-            Mitgliedskonto mk = dao.getMitgliedskonto();
-            Buchung buchung = dao.getBuchung();
-            buchung.setMitgliedskonto(dao.getMitgliedskonto());
-            if (mk != null)
-            {
-              if (buchung.getBuchungsart() == null)
-                buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
-              if (buchung.getBuchungsklasseId() == null)
-                buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
-            }
-            buchung.store();
-          }
-
-          //Darstellung aktualisieren
-          new BuchungsListeAction().handleAction(this);
-
-          GUI.getStatusBar().setSuccessText("Die Zuordnung wurde erfolgreich durchgeführt");
+          if (buchung.getBuchungsart() == null && mk.getBuchungsart() != null)
+            buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
+          if (buchung.getBuchungsklasseId() == null)
+            buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
         }
-        catch (RemoteException e) {
-          Logger.error("error while assignment", e);
-          throw new ApplicationException("Fehler bei der Durchführung der Zuordnung", e);
-        }
-      }
-      
-      @Override
-      public void interrupt()
-      {
-        //
+        buchung.store();
       }
 
-      @Override
-      public boolean isInterrupted()
-      {
-        return false;
-      }
-    };
+      //Darstellung aktualisieren
+      new BuchungsListeAction().handleAction(this);
 
-    Application.getController().start(t);
+      GUI.getStatusBar().setSuccessText("Die Zuordnung wurde erfolgreich durchgeführt");
+    }
+    catch (RemoteException e) {
+      Logger.error("error while assignment", e);
+      throw new ApplicationException("Fehler bei der Durchführung der Zuordnung", e);
+    }
 
     close();
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
@@ -26,6 +26,8 @@ import org.eclipse.swt.widgets.Composite;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BuchungsListeAction;
 import de.jost_net.JVerein.gui.dialogs.BuchungenSollbuchungZuordnungDialog.BookingMemberAccountEntry;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -136,8 +138,17 @@ public class BuchungenSollbuchungZuordnungVorschauDialog extends AbstractDialog<
         {
           for(BookingMemberAccountEntry dao : assignedBooking)
           {
-            dao.getBuchung().setMitgliedskonto(dao.getMitgliedskonto());
-            dao.getBuchung().store();
+            Mitgliedskonto mk = dao.getMitgliedskonto();
+            Buchung buchung = dao.getBuchung();
+            buchung.setMitgliedskonto(dao.getMitgliedskonto());
+            if (mk != null)
+            {
+              if (buchung.getBuchungsart() == null)
+                buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
+              if (buchung.getBuchungsklasseId() == null)
+                buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
+            }
+            buchung.store();
           }
 
           //Darstellung aktualisieren

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
@@ -132,8 +132,8 @@ public class BuchungenSollbuchungZuordnungVorschauDialog extends AbstractDialog<
         buchung.setMitgliedskonto(dao.getMitgliedskonto());
         if (mk != null)
         {
-          if (buchung.getBuchungsart() == null && mk.getBuchungsart() != null)
-            buchung.setBuchungsart(Long.valueOf(mk.getBuchungsart().getID()));
+          if (buchung.getBuchungsartId() == null)
+            buchung.setBuchungsartId(mk.getBuchungsartId());
           if (buchung.getBuchungsklasseId() == null)
             buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
         }

--- a/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
+++ b/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
@@ -132,8 +132,7 @@ public class SollbuchungAuswahlInput
             buchungen[0].setZweck(konto.getZweck1());
             buchungen[0].setBetrag(konto.getBetrag());
             buchungen[0].setDatum(new Date());
-            buchungen[0]
-                .setBuchungsart(Long.valueOf(konto.getBuchungsart().getID()));
+            buchungen[0].setBuchungsartId(konto.getBuchungsartId());
             buchungen[0].setBuchungsklasseId(konto.getBuchungsklasseId());
           }
         }

--- a/src/de/jost_net/JVerein/gui/util/AfaUtil.java
+++ b/src/de/jost_net/JVerein/gui/util/AfaUtil.java
@@ -205,7 +205,7 @@ public class AfaUtil
     buchung.setName(Einstellungen.getEinstellung().getName());
     buchung.setDatum(afaBuchungDatum);
     buchung.setBetrag(-betrag);
-    buchung.setBuchungsart(konto.getAfaartId());
+    buchung.setBuchungsartId(konto.getAfaartId());
     buchung.setAbschluss(abschluss);
     if (abschluss == null)
       buchung.store(true);
@@ -308,7 +308,7 @@ public class AfaUtil
     buchung.setName(Einstellungen.getEinstellung().getName());
     buchung.setZweck(zweck);
     buchung.setDatum(afaBuchungDatum);
-    buchung.setBuchungsart(konto.getAfaartId());
+    buchung.setBuchungsartId(konto.getAfaartId());
     buchung.setBetrag(-betrag);
     buchung.setAbschluss(abschluss);
     if (abschluss == null)

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -865,7 +865,7 @@ public class AbrechnungSEPA
       }
       if (buchungsart != null)
       {
-        buchung.setBuchungsart(Long.valueOf(buchungsart.getID()));
+        buchung.setBuchungsartId(Long.valueOf(buchungsart.getID()));
       }
       buchung.setBuchungsklasseId(buchungsklasseId);
       buchung.store();

--- a/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
+++ b/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
@@ -174,7 +174,7 @@ public class CSVBuchungsImport implements Importer
                   .format("Buchungsart %d existiert nicht in JVerein!", bart));
             }
             Buchungsart b1 = (Buchungsart) bit.next();
-            bu.setBuchungsart(Long.valueOf(b1.getID()));
+            bu.setBuchungsartId(Long.valueOf(b1.getID()));
           }
           catch (SQLException e)
           {

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -289,7 +289,7 @@ public class SplitbuchungsContainer
     buch.setAuszugsnummer(b.getAuszugsnummer());
     buch.setBetrag(b.getBetrag() * -1);
     buch.setBlattnummer(b.getBlattnummer());
-    buch.setBuchungsart(b.getBuchungsartId());
+    buch.setBuchungsartId(b.getBuchungsartId());
     buch.setBuchungsklasseId(b.getBuchungsklasseId());
     buch.setDatum(b.getDatum());
     buch.setKommentar(b.getKommentar());
@@ -311,7 +311,7 @@ public class SplitbuchungsContainer
     buch.setAuszugsnummer(master.getAuszugsnummer());
     buch.setBetrag(origin.getBetrag());
     buch.setBlattnummer(master.getBlattnummer());
-    buch.setBuchungsart(origin.getBuchungsartId());
+    buch.setBuchungsartId(origin.getBuchungsartId());
     buch.setBuchungsklasseId(origin.getBuchungsklasseId());
     buch.setDatum(master.getDatum());
     buch.setKommentar(origin.getKommentar());

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -79,7 +79,7 @@ public interface Buchung extends DBObject
 
   public Long getBuchungsartId() throws RemoteException;
 
-  public void setBuchungsart(Long buchungsart) throws RemoteException;
+  public void setBuchungsartId(Long buchungsart) throws RemoteException;
   
   public Buchungsklasse getBuchungsklasse() throws RemoteException;
   

--- a/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
+++ b/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
@@ -67,6 +67,10 @@ public interface Mitgliedskonto extends DBObject
   public Buchungsart getBuchungsart() throws RemoteException;
 
   public void setBuchungsart(Buchungsart buchungsart) throws RemoteException;
+  
+  public Long getBuchungsartId() throws RemoteException;
+
+  public void setBuchungsartId(Long buchungsartId) throws RemoteException;
 
   public Buchungsklasse getBuchungsklasse() throws RemoteException;
   

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -383,13 +383,13 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Long getBuchungsartId() throws RemoteException
   {
-    return Long.parseLong(getBuchungsart().getID());
+    return (Long) super.getAttribute("buchungsart");
   }
 
   @Override
-  public void setBuchungsart(Long buchungsart) throws RemoteException
+  public void setBuchungsartId(Long buchungsartId) throws RemoteException
   {
-    setAttribute("buchungsart", buchungsart);
+    setAttribute("buchungsart", buchungsartId);
   }
   
   @Override

--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -103,10 +103,6 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
   @Override
   protected Class<?> getForeignObject(String arg0)
   {
-    if ("buchungsart".equals(arg0))
-    {
-      return Buchungsart.class;
-    }
     return null;
   }
 
@@ -158,7 +154,14 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
   @Override
   public Buchungsart getBuchungsart() throws RemoteException
   {
-    return (Buchungsart) getAttribute("buchungsart");
+    Long l = (Long) super.getAttribute("buchungsart");
+    if (l == null)
+    {
+      return null; // Keine Buchungsart zugeordnet
+    }
+
+    Cache cache = Cache.get(Buchungsart.class, true);
+    return (Buchungsart) cache.get(l);
   }
 
   @Override
@@ -168,6 +171,18 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
       setAttribute("buchungsart", Long.valueOf(buchungsart.getID()));
     else
       setAttribute("buchungsart", null);
+  }
+  
+  @Override
+  public Long getBuchungsartId() throws RemoteException
+  {
+    return (Long) super.getAttribute("buchungsart");
+  }
+  
+  @Override
+  public void setBuchungsartId(Long buchungsartId) throws RemoteException
+  {
+    setAttribute("buchungsart", buchungsartId);
   }
   
   @Override


### PR DESCRIPTION
Dies implementiert #462. Es werden bei der Zuweisung einer Sollbuchung zur Buchung automatisch die Buchungsart und Buchungsaklasse in der Buchung gesetzt wenn sie noch null sind.

Ich habe die Änderung für den Sollbuchung Zuordnung Dialog (Aufruf aus dem Buchung Menü) implementiert und für die automatische Zuordnung.

Die automatische Zuordnung konnte ich aber nicht testen. In der Entwicklungsumgebung kommt es beim Zuordnen Button im zweiten Dialog zur Meldung:  "Es wird bereits eine Hintergrund-Aufgabe ausgeführt".
Dies liegt daran, dass der BuchungenSollbuchungZuordnungVorschauDialog in der Task des BuchungenSollbuchungZuordnungDialog aufgerufen wird. Beim Drücken des Buttons wird dann die zweite Hintergrund Task gestartet was zum Fehler führt. 

Das ganze passiert aber auch auf dem Main Branch ohne meine Änderung. Warum das außerhalb von Eclipse in den Standard Produktionen nicht auftritt weiß ich nicht. Evtl. ist da der BuchungenSollbuchungZuordnungVorschauDialog schneller geschlossen und die erste Task beendet bevor die zweite los läuft.

Schön ist aber eine solche Race Condition nicht. Kann man irgendwie den BuchungenSollbuchungZuordnungVorschauDialog aus der ersten Task starten ohne auf dessen Ende zu warten?