### PR TITLE
Fix 1ct Überweisung für Kursteilnehmer

### DIFF
--- a/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
+++ b/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
@@ -46,6 +46,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.LastschriftMap;
 import de.jost_net.JVerein.Variable.VarTools;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Ct1Ausgabe;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -103,8 +104,16 @@ public class Ct1Ueberweisung
     {
       ls_properties.setProperty(SepaUtil.insertIndex("dst.bic", counter),       StringUtils.trimToEmpty(ls.getBIC()));
       ls_properties.setProperty(SepaUtil.insertIndex("dst.iban", counter),      StringUtils.trimToEmpty(ls.getIBAN()));
-      ls_properties.setProperty(SepaUtil.insertIndex("dst.name", counter),      StringUtils.trimToEmpty(ls.getMitglied()
-          .getKontoinhaber(1).toUpperCase()));
+      if (ls.getMitglied() != null)
+      {
+        ls_properties.setProperty(SepaUtil.insertIndex("dst.name", counter),      StringUtils.trimToEmpty(ls.getMitglied()
+            .getKontoinhaber(1).toUpperCase()));
+      }
+      else if (ls.getKursteilnehmer() != null)
+      {
+        ls_properties.setProperty(SepaUtil.insertIndex("dst.name", counter),      StringUtils.trimToEmpty(
+            Adressaufbereitung.getNameVorname(ls.getKursteilnehmer()).toUpperCase()));
+      }
       ls_properties.setProperty(SepaUtil.insertIndex("btg.value", counter),     (BigDecimal.valueOf(0.01)).toString());
       ls_properties.setProperty(SepaUtil.insertIndex("btg.curr", counter),      HBCIProperties.CURRENCY_DEFAULT_DE);
       ls_properties.setProperty(SepaUtil.insertIndex("usage", counter),         StringUtils.trimToEmpty(eval(ls, verwendungszweck)));


### PR DESCRIPTION
Bei der 1ct Überweisung für Kursteilnehmer kam es zur Exception weil der Code das Mitglied gelesen hat und nicht den Kursteilnehmer. Das Mitglied ist hier in der Lastschrift null.