### PR TITLE
Fix zu Nicht-Mitglied umwandeln

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -150,10 +150,11 @@ public class MitgliedMenu extends ContextMenu
             m.setEingabedatum();
             m.setBeitragsgruppe(null);
             m.setExterneMitgliedsnummer(null);
-            m.setIndividuellerBeitrag(0.0d);
+            m.setIndividuellerBeitrag(null);
             m.setEintritt("");
             m.setAustritt("");
             m.setKuendigung("");
+            m.setZahlerID(null);
             DBService service = Einstellungen.getDBService();
             // Sekundäre Beitragsgruppen löschen
             DBIterator<SekundaereBeitragsgruppe> sit = service


### PR DESCRIPTION
Beim Umwandeln eines Mitglieds zu Nicht-Mitgliedgab es zwei Fehler.

Der Individuelle Beitrag muss jetzt null sein statt 0 wegen der Änderung die wir diesbezüglich gemacht haben.

ZahlerId muss man löschen weil sonst das Nicht-Mitglied im Familienveband View weiter als Familienmitglied angezeigt wird. Das wäre nur anders wenn wir das in Zukunft erlauben würden.