### PR TITLE
Buchungen mit Spendenbescheinigung nicht editierbar

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
@@ -133,6 +133,10 @@ public class BuchungBuchungsartZuordnungAction implements Action
     {
       throw oce;
     }
+    catch (ApplicationException e)
+    {
+      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
+    }
     catch (Exception e)
     {
       Logger.error("Fehler", e);

--- a/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
@@ -141,7 +141,7 @@ public class BuchungDeleteAction implements Action
         if(spb != null)
         {
           throw new ApplicationException(
-              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordnet.");
         }
         if (bu.getSplitId() == null)
         {

--- a/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungDeleteAction.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -136,6 +137,12 @@ public class BuchungDeleteAction implements Action
               "Buchung wurde bereits am %s von %s abgeschlossen.",
               new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
         }
+        Spendenbescheinigung spb = bu.getSpendenbescheinigung();
+        if(spb != null)
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+        }
         if (bu.getSplitId() == null)
         {
           if (bu.getSpendenbescheinigung() != null)
@@ -176,6 +183,10 @@ public class BuchungDeleteAction implements Action
       {
         GUI.getStatusBar().setErrorText("Keine Buchung gelöscht");
       }
+    }
+    catch (ApplicationException e)
+    {
+      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/action/BuchungKontoauszugZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungKontoauszugZuordnungAction.java
@@ -113,6 +113,10 @@ public class BuchungKontoauszugZuordnungAction implements Action
     {
       throw oce;
     }
+    catch (ApplicationException e)
+    {
+      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
+    }
     catch (Exception e)
     {
       Logger.error("Fehler", e);

--- a/src/de/jost_net/JVerein/gui/action/BuchungProjektZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungProjektZuordnungAction.java
@@ -119,6 +119,10 @@ public class BuchungProjektZuordnungAction implements Action
     {
       throw oce;
     }
+    catch (ApplicationException e)
+    {
+      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
+    }
     catch (Exception e)
     {
       Logger.error("Fehler", e);

--- a/src/de/jost_net/JVerein/gui/action/SplitBuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitBuchungAction.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -72,6 +73,12 @@ public class SplitBuchungAction implements Action
           throw new ApplicationException(String.format(
               "Buchung wurde bereits am %s von %s abgeschlossen.",
               new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
+        }
+        Spendenbescheinigung spb = bu.getSpendenbescheinigung();
+        if(spb != null)
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
         }
         if (bu.getBuchungsart() == null)
         {

--- a/src/de/jost_net/JVerein/gui/action/SplitBuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitBuchungAction.java
@@ -78,7 +78,7 @@ public class SplitBuchungAction implements Action
         if(spb != null)
         {
           throw new ApplicationException(
-              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordnet.");
         }
         if (bu.getBuchungsart() == null)
         {

--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.Messaging.BuchungMessage;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
@@ -156,6 +157,12 @@ public class SplitbuchungBulkAufloesenAction implements Action
           throw new ApplicationException(String.format(
               "Buchung wurde bereits am %s von %s abgeschlossen.",
               new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
+        }
+        Spendenbescheinigung spb = bu.getSpendenbescheinigung();
+        if(spb != null)
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
         }
         splitid = bu.getSplitId();
         if (!geloescht.contains(splitid))

--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungBulkAufloesenAction.java
@@ -162,7 +162,7 @@ public class SplitbuchungBulkAufloesenAction implements Action
         if(spb != null)
         {
           throw new ApplicationException(
-              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordnet.");
         }
         splitid = bu.getSplitId();
         if (!geloescht.contains(splitid))

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -79,6 +79,7 @@ import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.rmi.Projekt;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.util.Dateiname;
 import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.Geschaeftsjahr;
@@ -1785,6 +1786,13 @@ public class BuchungsControl extends AbstractControl
               new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
           return true;
         }
+        Spendenbescheinigung spb = getBuchung().getSpendenbescheinigung();
+        if(spb != null)
+        {
+          GUI.getStatusBar().setErrorText(
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+          return true;
+        }
       }
     }
     catch (RemoteException e)
@@ -1813,6 +1821,13 @@ public class BuchungsControl extends AbstractControl
             GUI.getStatusBar().setErrorText(String.format(
                 "Buchung wurde bereits am %s von %s abgeschlossen.",
                 new JVDateFormatTTMMJJJJ().format(ja.getDatum()), ja.getName()));
+            return true;
+          }
+          Spendenbescheinigung spb = getBuchung().getSpendenbescheinigung();
+          if(spb != null)
+          {
+            GUI.getStatusBar().setErrorText(
+                "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
             return true;
           }
         }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1790,7 +1790,7 @@ public class BuchungsControl extends AbstractControl
         if(spb != null)
         {
           GUI.getStatusBar().setErrorText(
-              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+              "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordnet.");
           return true;
         }
       }
@@ -1827,7 +1827,7 @@ public class BuchungsControl extends AbstractControl
           if(spb != null)
           {
             GUI.getStatusBar().setErrorText(
-                "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordenet.");
+                "Buchung kann nicht bearbeitet werden. Sie ist einer Spendenbescheinigung zugeordnet.");
             return true;
           }
         }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -1261,7 +1261,7 @@ public class MitgliedskontoControl extends DruckMailControl
     if(getMitgliedskonto().getRechnung() != null)
     {
       GUI.getStatusBar().setErrorText(
-          "Solbuchung kann nicht bearbeitet werden. Es wurde bereits eine Rechnung über diese Sollbuchung erstellt.");
+          "Sollbuchung kann nicht bearbeitet werden. Es wurde bereits eine Rechnung über diese Sollbuchung erstellt.");
       return true;
     }
     return false;


### PR DESCRIPTION
So wie man Sollbuchungen nicht mehr editieren kann wenn sie Teil einer Rechnung sind habe ich das analog für Buchungen gemacht wenn sie Teil einer Spendenbescheinigung sind. Auch kann man sie nicht mehr splitten.

Ich habe dazu überall wo der Check auf Jahresabschluss war den Check auf Spendenbescheinigung hinzugefügt.

Die Buchnung Kontextmenüs Buchungsart,  Sollbuchung, Projekt, Kontoauszug zuordnen funktionieren weiterhin. Die sind ja nicht schädlich für die Spendenbescheinigung.

