### PR TITLE
Rechnungen Löschen in DB Bereinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -522,6 +522,7 @@ public class MitgliedskontoControl extends DruckMailControl
     if (mitgliedskontoList == null)
     {
       mitgliedskontoList = new SollbuchungListTablePart(mitgliedskonten, action);
+      mitgliedskontoList.addColumn("Nr", "id-int");
       mitgliedskontoList.addColumn("Datum", "datum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       mitgliedskontoList.addColumn("Abrechnungslauf", "abrechnungslauf");

--- a/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
+++ b/src/de/jost_net/JVerein/gui/view/DbBereinigenView.java
@@ -35,6 +35,13 @@ public class DbBereinigenView extends AbstractView
 
     final DbBereinigenControl control = new DbBereinigenControl(this);
 
+    LabelGroup grouprechnungen = new LabelGroup(getParent(), "Rechnungen");
+    ColumnLayout rcl = new ColumnLayout(grouprechnungen.getComposite(), 2);
+    SimpleContainer rleft = new SimpleContainer(rcl.getComposite());
+    rleft.addLabelPair("Löschen", control.getRechnungenLoeschen());
+    SimpleContainer rright = new SimpleContainer(rcl.getComposite());
+    rright.addLabelPair("Rechnungsdatum älter als", control.getDatumAuswahlRechnungen());
+    
     LabelGroup groupspendenbescheinigungen = new LabelGroup(getParent(), "Spendenbescheinigungen");
     ColumnLayout scl = new ColumnLayout(groupspendenbescheinigungen.getComposite(), 2);
     SimpleContainer sleft = new SimpleContainer(scl.getComposite());

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -80,7 +80,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
       if (this.getSpendenbescheinigung() != null)
       {
         throw new ApplicationException(
-            "Buchung kann nicht gelöscht werden weil sie zu eine "
+            "Buchung kann nicht gelöscht werden weil sie zu einer "
                 + "Spendenbescheinigung gehört");
       }
     }


### PR DESCRIPTION
Ich habe das Löschen von Rechnungen in das DB Bereinigen aufgenommen, auch wenn es wohl erst in 10/8 Jahren relevant wird.

Beim Löschen von Sollbuchungen habe ich einen deleteCheck() in MitgliedskontoImpl eingebaut, dass man sie nicht löschen kann wenn sie einer Rechnung zugeordent ist. Das ist sowie bei Buchungen wenn sie einer Spendenbescheinigung zugeordnet sind.

Im Sollbuchungen Liste View habe ich die Spalte Nr aufegnommen damit man die Sollbuchung bei Fehlermeldungen finden kann.