### PR TITLE
Check bei Setzen der Buchungsart

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungBuchungsartZuordnungAction.java
@@ -72,7 +72,7 @@ public class BuchungBuchungsartZuordnungAction implements Action
       {
         return;
       }
-      
+
       BuchungsartZuordnungDialog baz = new BuchungsartZuordnungDialog(
           BuchungsartZuordnungDialog.POSITION_MOUSE);
       baz.open();
@@ -104,7 +104,7 @@ public class BuchungBuchungsartZuordnungAction implements Action
             {
               buchung.setBuchungsartId(Long.valueOf(ba.getID()));
               if (bk != null)
-               buchung.setBuchungsklasseId(Long.valueOf(bk.getID()));
+                buchung.setBuchungsklasseId(Long.valueOf(bk.getID()));
               else
                 buchung.setBuchungsklasseId(null);
               buchung.store();
@@ -136,7 +136,8 @@ public class BuchungBuchungsartZuordnungAction implements Action
     catch (Exception e)
     {
       Logger.error("Fehler", e);
-      GUI.getStatusBar().setErrorText("Fehler bei der Zuordnung der Buchungsart");
+      GUI.getStatusBar().setErrorText("Fehler bei der Zuordnung der Buchungsart: " 
+          + e.getLocalizedMessage());
     }
   }
 }

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -97,7 +97,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
           "Buchung kann nicht gelöscht werden. Siehe system log");
     }
   }
-  
+
   @Override
   protected void insertCheck() throws ApplicationException
   {
@@ -134,7 +134,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     cal2.add(Calendar.YEAR, 10);
     if (cal1.after(cal2))
     {
-     throw new ApplicationException("Buchungsdatum liegt mehr als 10 Jahre in der Zukunft");
+      throw new ApplicationException("Buchungsdatum liegt mehr als 10 Jahre in der Zukunft");
     }
     cal2.add(Calendar.YEAR, -20);
     if (cal1.before(cal2))
@@ -167,6 +167,22 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     if (!getSpeicherung() && getBuchungsart() == null)
     {
       throw new ApplicationException("Buchungsart fehlt bei Splitbuchung!");
+    }
+
+    if (getSpendenbescheinigung() != null)
+    {
+      if (getBuchungsart() == null)
+      {
+        throw new ApplicationException(
+            "Buchungsart kann nicht gelöscht werden da "
+            + "eine Spendenbescheinigung zugeordnet ist!");
+      }
+      if (getBuchungsart() != null && !getBuchungsart().getSpende())
+      {
+        throw new ApplicationException(
+            "Buchungsart kann nicht in eine Buchungsart ohne der Eigenschaft Spende "
+            + "geändert werden da eine Spendenbescheinigung zugeordnet ist!");
+      }
     }
   }
 
@@ -313,7 +329,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("betrag", null);
   }
-  
+
   @Override
   public String getZweck() throws RemoteException
   {
@@ -391,7 +407,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("buchungsart", buchungsartId);
   }
-  
+
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
@@ -410,7 +426,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     return (Long) super.getAttribute("buchungsklasse");
   }
-  
+
   @Override
   public void setBuchungsklasseId(Long buchungsklasseId) throws RemoteException
   {
@@ -441,7 +457,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("abrechnungslauf", Long.valueOf(abrechnungslauf.getID()));
   }
-  
+
   @Override
   public Jahresabschluss getAbschluss() throws RemoteException
   { 
@@ -563,7 +579,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     setAttribute("spendenbescheinigung", spendenbescheinigung);
   }
-  
+
   @Override
   public int getDependencyId() throws RemoteException
   {
@@ -601,7 +617,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     }
     map.put(BuchungVar.ABRECHNUNGSLAUF.getName(),
         (this.getAbrechnungslauf() != null
-            ? this.getAbrechnungslauf().getDatum()
+        ? this.getAbrechnungslauf().getDatum()
             : ""));
     map.put(BuchungVar.ART.getName(),
         StringTool.toNotNullString(this.getArt()));
@@ -658,8 +674,8 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
         this.getKonto() != null ? this.getKonto().getNummer() : "");
     map.put(BuchungVar.MITGLIEDSKONTO.getName(),
         this.getMitgliedskonto() != null
-            ? Adressaufbereitung
-                .getNameVorname(this.getMitgliedskonto().getMitglied())
+        ? Adressaufbereitung
+            .getNameVorname(this.getMitgliedskonto().getMitglied())
             : "");
     map.put(BuchungVar.NAME.getName(), this.getName());
     map.put(BuchungVar.ZWECK1.getName(),
@@ -685,16 +701,16 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
 
     if ("buchungsart".equals(fieldName))
       return getBuchungsart();
-    
+
     if ("buchungsklasse".equals(fieldName))
       return getBuchungsklasse();
 
     if ("konto".equals(fieldName))
       return getKonto();
-    
+
     if ("mitgliedskonto".equals(fieldName))
-        return getMitgliedskonto();
-    
+      return getMitgliedskonto();
+
     if ("document".equals(fieldName))
     {
       DBIterator<BuchungDokument> list = Einstellungen.getDBService()
@@ -798,7 +814,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   {
     return delete;
   }
-  
+
   @Override
   public void delete() throws RemoteException, ApplicationException
   {
@@ -814,13 +830,13 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     }
     super.delete();
   }
-  
+
   @Override
   public void store() throws RemoteException, ApplicationException
   {
     store(true);
   }
-  
+
   @Override
   public void store(boolean check) throws RemoteException, ApplicationException
   {
@@ -839,5 +855,5 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     // können. In diesem Fall wird mit check false gespeichert.
     super.store();
   }
-  
+
 }


### PR DESCRIPTION
In #474 habe ich geändert, dass man eine Buchung nicht mehr editieren kann wenn sie einer Spendenbescheinigung zugeordnet ist.

Der Dialog zum Setzen der Buchungsart ist aber noch aktiv. Ich habe jetzt einen Check beim Speichern der Buchung eingebaut, das man bei gesetzter Spendenbescheinigung die Buchungsart nicht löschen kann und auch nur in eine Buchungsart mit Spende wechseln kann.