### PR TITLE
Spendenbescheinigung verschluesseln

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -67,13 +67,13 @@ import de.willuhn.util.ApplicationException;
  */
 public class SpendenbescheinigungPrintAction implements Action
 {
-  
+
   private Adressblatt adressblatt = Adressblatt.OHNE_ADRESSBLATT;
 
   private String fileName = null;
-  
+
   private String text = null;
-  
+
   private boolean open = false;
 
   private de.willuhn.jameica.system.Settings settings;
@@ -109,7 +109,7 @@ public class SpendenbescheinigungPrintAction implements Action
     this.text = text;
     this.open = open;
   }
-  
+
   /**
    * Konstruktor. Über den Parameter kann festgelegt werden, ob das Standard-
    * oder das individuelle Dokument aufbereitet werden soll.
@@ -275,7 +275,7 @@ public class SpendenbescheinigungPrintAction implements Action
         }
       }
       String erfolg = (spbArr.length > 1) ? "Die Spendenbescheinigungen wurden erstellt und unter " + path + " gespeichert."
-                                          : "Die Spendenbescheinigung wurde erstellt und unter " + path + " gespeichert.";
+          : "Die Spendenbescheinigung wurde erstellt und unter " + path + " gespeichert.";
       GUI.getStatusBar().setSuccessText(erfolg);
       if (file != null && spbArr.length == 1 && open)
         FileViewer.show(file);
@@ -301,7 +301,7 @@ public class SpendenbescheinigungPrintAction implements Action
    */
   private void generiereSpendenbescheinigungStandardAb2014(
       Spendenbescheinigung spb, String fileName, Adressblatt adressblatt)
-      throws IOException, DocumentException
+          throws IOException, DocumentException
   {
     final File file = new File(fileName);
     FileOutputStream fos = new FileOutputStream(file);
@@ -310,7 +310,7 @@ public class SpendenbescheinigungPrintAction implements Action
     map = new AllgemeineMap().getMap(map);
     boolean isSammelbestaetigung = spb.isSammelbestaetigung();
     Reporter rpt = new Reporter(fos, 80, 50, 50, 50);
-    
+
     // Aussteller, kein Header
     rpt.addHeaderColumn("", Element.ALIGN_CENTER, 100, BaseColor.LIGHT_GRAY);
     rpt.createHeader();
@@ -333,7 +333,7 @@ public class SpendenbescheinigungPrintAction implements Action
         "im Sinne des § 10b des Einkommenssteuergesetzes an eine der in § 5 Abs. 1 Nr. 9 des "
             + "Körperschaftssteuergesetzes bezeichneten Körperschaften, Personenvereinigungen "
             + "oder Vermögensmassen\n",  8);
-    
+
     // Name und Anschrift, kein Header
     rpt.addHeaderColumn("", Element.ALIGN_CENTER, 100, BaseColor.LIGHT_GRAY);
     rpt.createHeader();
@@ -433,7 +433,7 @@ public class SpendenbescheinigungPrintAction implements Action
         p.add(new Chunk((char) 113, FontFactory.getFont(FontFactory.ZAPFDINGBATS, 8))); // box leer
       p.add("     Der Zuwendende hat trotz Aufforderung keine Angaben zur Herkunft der Sachzuwendung gemacht.\n");
       rpt.add(p);
-      
+
       p = new Paragraph();
       p.setFont(Reporter.getFreeSans(8));
       p.setAlignment(Element.ALIGN_JUSTIFIED);
@@ -518,14 +518,14 @@ public class SpendenbescheinigungPrintAction implements Action
       p.add(new Chunk((char) 113, FontFactory.getFont(FontFactory.ZAPFDINGBATS, 8))); // box leer
       p.add(txt);
       rpt.add(p);
-      
+
       txt = "     Die Einhaltung der satzungsgemäßen Voraussetzungen nach den §§ 51, 59, 60 und 61 "
           + "AO wurde vom Finanzamt "
           + Einstellungen.getEinstellung().getFinanzamt() + ", StNr. "
           + Einstellungen.getEinstellung().getSteuernummer()
           + ", mit Bescheid vom "
           + new JVDateFormatTTMMJJJJ()
-              .format(Einstellungen.getEinstellung().getBescheiddatum())
+          .format(Einstellungen.getEinstellung().getBescheiddatum())
           + " nach § 60a AO gesondert festgestellt. Wir fördern nach unserer Satzung "
           + Einstellungen.getEinstellung().getBeguenstigterzweck() + ".";
       p = new Paragraph();
@@ -548,13 +548,13 @@ public class SpendenbescheinigungPrintAction implements Action
           + ", StNr. " + Einstellungen.getEinstellung().getSteuernummer()
           + ", vom "
           + new JVDateFormatTTMMJJJJ()
-              .format(Einstellungen.getEinstellung().getBescheiddatum())
+          .format(Einstellungen.getEinstellung().getBescheiddatum())
           + " für den letzten Veranlagungszeitraum "
           + new JVDateFormatJJJJ()
-              .format(Einstellungen.getEinstellung().getVeranlagungVon())
+          .format(Einstellungen.getEinstellung().getVeranlagungVon())
           + " bis "
           + new JVDateFormatJJJJ()
-              .format(Einstellungen.getEinstellung().getVeranlagungBis())
+          .format(Einstellungen.getEinstellung().getVeranlagungBis())
           + " nach § 5 Abs. 1 Nr. 9 des Körperschaftsteuergesetzes von der Körperschaftsteuer und nach "
           + "§ 3 Nr. 6 des Gewerbesteuergesetzes von der Gewerbesteuer befreit.\n ";
       Paragraph p = new Paragraph();
@@ -582,9 +582,9 @@ public class SpendenbescheinigungPrintAction implements Action
       p.add(new Chunk((char) 113, FontFactory.getFont(FontFactory.ZAPFDINGBATS, 8))); // box leer
       p.add(txt);
       rpt.add(p);
-      
+
     }
-    
+
     // Rahmen über Unterschrift
     PdfPCell cell = new PdfPCell();
     Paragraph p = new Paragraph();
@@ -607,7 +607,7 @@ public class SpendenbescheinigungPrintAction implements Action
           "Nur für steuerbegünstigte Einrichtungen, bei denen die Mitgliedsbeiträge "
               + "steuerlich nicht abziehbar sind:\n"));
       cell.addElement(p);
-      
+
       p = new Paragraph();
       p.setFont(Reporter.getFreeSans(8));
       p.setAlignment(Element.ALIGN_JUSTIFIED);
@@ -657,13 +657,21 @@ public class SpendenbescheinigungPrintAction implements Action
     rpt.add(
         "\n" + Einstellungen.getEinstellung().getOrt() + ", "
             + new JVDateFormatTTMMJJJJ().format(spb.getBescheinigungsdatum()),
-        9);
-    
+            9);
+
     rpt.addLight(
-          "..............................................................................."
-        + "...............................................................................\n"
-        + "(Ort, Datum und Unterschrift des Zuwendungsempfängers)",
-        8);
+        "..............................................................................."
+            + "...............................................................................\n"
+            + "(Ort, Datum und Unterschrift des Zuwendungsempfängers)",
+            8);
+
+    if (Einstellungen.getEinstellung().getUnterschriftdrucken() &&
+        Einstellungen.getEinstellung().getUnterschrift() != null)
+    {
+      rpt.addLight("\nDie maschinelle Erstellung der Zuwendungsbestätigung wurde dem "
+          + "zuständigen Finanzamt " + Einstellungen.getEinstellung().getFinanzamt()
+          + " angezeigt.", 8);
+    }
 
     rpt.add("\nHinweis:", 8);
     rpt.addLight(
@@ -677,7 +685,7 @@ public class SpendenbescheinigungPrintAction implements Action
             + "bzw. das Datum der Feststellung der Einhaltung der satzungsmäßigen Voraussetzungen "
             + "nach § 60a Abs. 1 AO länger als 3 Jahre seit Ausstellung des Bescheides zurückliegt "
             + "(§ 63 Abs. 5 AO).",
-        7);
+            7);
 
     /* Es sind mehrere Spenden für diese Spendenbescheinigung vorhanden */
     if (isSammelbestaetigung)
@@ -748,14 +756,14 @@ public class SpendenbescheinigungPrintAction implements Action
 
       rpt.closeTable();      
     }
-    
+
     if (adressblatt != Adressblatt.OHNE_ADRESSBLATT)
     {
       // Neue Seite für Anschrift in Fenster in querem Brief
       // oder für Anschreiben
       rpt.newPage();
     }
-    
+
     if (adressblatt == Adressblatt.MIT_ADRESSE ||
         adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
     {
@@ -764,7 +772,7 @@ public class SpendenbescheinigungPrintAction implements Action
       rpt.addUnderline(getAussteller(),8);
       rpt.addLight((String) map.get(SpendenbescheinigungVar.EMPFAENGER.getName()),10);
     }
-    
+
     if (adressblatt == Adressblatt.MIT_ANSCHREIBEN ||
         adressblatt == Adressblatt.MIT_ADRESSE_ANSCHREIBEN)
     {
@@ -790,7 +798,7 @@ public class SpendenbescheinigungPrintAction implements Action
         rpt.addLight(text, 10);
       }
     }
-    
+
     rpt.close();
     fos.close();
   }

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -1967,6 +1967,8 @@ public class EinstellungControl extends AbstractControl
       return unterschriftdrucken;
     }
     unterschriftdrucken = new CheckboxInput(Einstellungen.getEinstellung().getUnterschriftdrucken());
+    unterschriftdrucken.setName(" *Die maschinelle Erstellung einer Zuwendungsbestätigung muss "
+        + "dem zuständigen Finanzamt angezeigt werden");
     return unterschriftdrucken;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -1967,8 +1967,8 @@ public class EinstellungControl extends AbstractControl
       return unterschriftdrucken;
     }
     unterschriftdrucken = new CheckboxInput(Einstellungen.getEinstellung().getUnterschriftdrucken());
-    unterschriftdrucken.setName(" *Die maschinelle Erstellung einer Zuwendungsbestätigung muss "
-        + "dem zuständigen Finanzamt angezeigt werden");
+    unterschriftdrucken.setName(" *Die maschinelle Erstellung von Zuwendungsbestätigungen muss "
+        + "vorab dem zuständigen Finanzamt angezeigt worden sein.");
     return unterschriftdrucken;
   }
 

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -113,6 +113,8 @@ public class FormularAufbereitung
       fos = new FileOutputStream(f);
 
       writer = PdfWriter.getInstance(doc, fos);
+      writer.setEncryption(null, null, 
+          PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
       doc.open();
 
     }

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -114,7 +114,7 @@ public class FormularAufbereitung
 
       writer = PdfWriter.getInstance(doc, fos);
       writer.setEncryption(null, null, 
-          PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
+          PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS, PdfWriter.ENCRYPTION_AES_256);
       doc.open();
 
     }

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -115,7 +115,7 @@ public class Reporter
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     hyph = new HyphenationAuto("de", "DE", 2, 2);
     PdfWriter.getInstance(rpt, out).setEncryption(null, null, 
-        PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
+        PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS, PdfWriter.ENCRYPTION_AES_256);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);
     rpt.addAuthor(plugin.getManifest().getName() + " - Version "
@@ -134,7 +134,7 @@ public class Reporter
     hyph = new HyphenationAuto("de", "DE", 2, 2);
     PdfWriter writer = PdfWriter.getInstance(rpt, out);
     writer.setEncryption(null, null, 
-        PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
+        PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS, PdfWriter.ENCRYPTION_AES_256);
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -114,7 +114,8 @@ public class Reporter
     rpt = new Document();
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     hyph = new HyphenationAuto("de", "DE", 2, 2);
-    PdfWriter.getInstance(rpt, out);
+    PdfWriter.getInstance(rpt, out).setEncryption(null, null, 
+        PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);
     rpt.addAuthor(plugin.getManifest().getName() + " - Version "
@@ -132,6 +133,8 @@ public class Reporter
     rpt = new Document();
     hyph = new HyphenationAuto("de", "DE", 2, 2);
     PdfWriter writer = PdfWriter.getInstance(rpt, out);
+    writer.setEncryption(null, null, 
+        PdfWriter.ALLOW_PRINTING, PdfWriter.ENCRYPTION_AES_256);
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);


### PR DESCRIPTION
Mit dieser Änderung wird:
- bei drucken einer Unterschrift, bei der Ausgabe Standard, auch ein Satz auf der ersten Seite eingefügt, dass die maschinelle Erstellung dem Finanzamt angezeigt wurde
- wird das PDF verschlüsselt (schreibgeschützt) generiert