### PR TITLE
Fix Buchung Filter

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1219,6 +1219,7 @@ public class BuchungsControl extends AbstractControl
     }
     settings.setAttribute(settingsprefix + "suchtext", (String) getSuchtext().getValue());
     settings.setAttribute(settingsprefix + "suchbetrag", (String) getSuchBetrag().getValue());
+    settings.setAttribute(settingsprefix + "mitglied", (String) getMitglied().getValue());
 
     query = new BuchungQuery(dv, db, k, b, p, (String) getSuchtext().getValue(),
         (String) getSuchBetrag().getValue(), m.getValue(),


### PR DESCRIPTION
Beim Filter für Buchungen wurde das Feld "Mitglied Name" nicht in den Settings gespeichert.