### PR TITLE
Prüfen ob Mandatsdatum in der Zukunft liegt

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -191,6 +191,10 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte Datum des Mandat eingeben");
       }
+      else if (getMandatDatum().after(new Date()))
+      {
+        throw new ApplicationException("Datum des Mandat liegt in der Zukunft!");
+      }
     }
     if (getIban() != null && getIban().length() != 0)
     {


### PR DESCRIPTION
Das Feature prüft ob das Mandatsdatum für Basislastschrift in der Zukunft liegt.