### PR TITLE
Unterschrift nur bei Geldspenden

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -672,8 +672,7 @@ public class SpendenbescheinigungPrintAction implements Action
             + "(Ort, Datum und Unterschrift des Zuwendungsempfängers)",
             8);
 
-    if (Einstellungen.getEinstellung().getUnterschriftdrucken() &&
-        Einstellungen.getEinstellung().getUnterschrift() != null)
+    if (unterschriftDrucken)
     {
       rpt.addLight("\nDie maschinelle Erstellung der Zuwendungsbestätigung wurde dem "
           + "zuständigen Finanzamt " + Einstellungen.getEinstellung().getFinanzamt()

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -644,8 +644,15 @@ public class SpendenbescheinigungPrintAction implements Action
           8);
     }
 
-    if (Einstellungen.getEinstellung().getUnterschriftdrucken() &&
-        Einstellungen.getEinstellung().getUnterschrift() != null)
+    boolean unterschriftDrucken = false;
+    if (Einstellungen.getEinstellung().getUnterschriftdrucken()
+        && Einstellungen.getEinstellung().getUnterschrift() != null
+        && spb.isEchteGeldspende())
+    {
+      unterschriftDrucken = true;
+    }
+
+    if (unterschriftDrucken)
     {
       rpt.add("\n", 8);
       rpt.add(Einstellungen.getEinstellung().getUnterschrift(), 400, 55, 0);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1219,6 +1219,7 @@ public class BuchungsControl extends AbstractControl
     }
     settings.setAttribute(settingsprefix + "suchtext", (String) getSuchtext().getValue());
     settings.setAttribute(settingsprefix + "suchbetrag", (String) getSuchBetrag().getValue());
+    settings.setAttribute(settingsprefix + "mitglied", (String) getMitglied().getValue());
 
     query = new BuchungQuery(dv, db, k, b, p, (String) getSuchtext().getValue(),
         (String) getSuchBetrag().getValue(), m.getValue(),

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1219,7 +1219,6 @@ public class BuchungsControl extends AbstractControl
     }
     settings.setAttribute(settingsprefix + "suchtext", (String) getSuchtext().getValue());
     settings.setAttribute(settingsprefix + "suchbetrag", (String) getSuchBetrag().getValue());
-    settings.setAttribute(settingsprefix + "mitglied", (String) getMitglied().getValue());
 
     query = new BuchungQuery(dv, db, k, b, p, (String) getSuchtext().getValue(),
         (String) getSuchBetrag().getValue(), m.getValue(),

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -36,6 +36,7 @@ import de.jost_net.JVerein.gui.dialogs.ZusatzfelderAuswahlDialog;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
+import de.jost_net.JVerein.keys.SuchSpendenart;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Adresstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
@@ -147,6 +148,8 @@ public class FilterControl extends AbstractControl
   protected SelectInput abrechnungslaufausw = null;
   
   protected IntegerNullInput integerausw = null;
+  
+  protected SelectInput suchspendenart = null;
   
   public enum Mitgliedstyp {
     MITGLIED,
@@ -1049,6 +1052,26 @@ public class FilterControl extends AbstractControl
     return integerausw != null;
   }
   
+  public SelectInput getSuchSpendenart()
+  {
+    if (suchspendenart != null)
+    {
+      return suchspendenart;
+    }
+    SuchSpendenart defaultwert = SuchSpendenart
+        .getByKey(settings.getInt(settingsprefix + "suchspendenart.key", 1));
+    suchspendenart = new SelectInput(SuchSpendenart.values(), defaultwert);
+    suchspendenart.setName("Spendenart");
+    suchspendenart.addListener(new FilterListener());
+    return suchspendenart;
+  }
+  
+  public boolean isSuchSpendenartAktiv()
+  {
+    return suchspendenart != null;
+  }
+  
+  
   /**
    * Buttons
    */
@@ -1167,6 +1190,8 @@ public class FilterControl extends AbstractControl
           suchtext.setValue("");
         if (integerausw != null)
           integerausw.setValue(null);
+        if (suchspendenart != null)
+          suchspendenart.setValue(SuchSpendenart.ALLE);
         refresh();
       }
     }, null, false, "eraser.png");
@@ -1553,6 +1578,12 @@ public class FilterControl extends AbstractControl
       {
         settings.setAttribute(settingsprefix + "intergerauswahl", "");
       }
+    }
+    
+    if (suchspendenart != null )
+    {
+      SuchSpendenart ss = (SuchSpendenart) suchspendenart.getValue();
+      settings.setAttribute(settingsprefix + "suchspendenart.key", ss.getKey());
     }
   }
   

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -1075,7 +1075,7 @@ public class FilterControl extends AbstractControl
     suchspendenart.addListener(new FilterListener());
     return suchspendenart;
   }
-  
+
   public boolean isSuchSpendenartAktiv()
   {
     return suchspendenart != null;

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungAutoNeuControl.java
@@ -58,7 +58,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
   private TreePart spbTree;
 
   private SelectInput formularEinzelGeld;
-  
+
   private SelectInput formularEinzelSonstig;
 
   private SelectInput formularSammelGeld;
@@ -80,12 +80,8 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
     }
     Calendar cal = Calendar.getInstance();
     jahr = new SelectInput(
-            new Object[] {
-                    cal.get(Calendar.YEAR),
-                    cal.get(Calendar.YEAR) - 1,
-                    cal.get(Calendar.YEAR) - 2,
-                    cal.get(Calendar.YEAR) - 3
-                },
+        new Object[] { cal.get(Calendar.YEAR), cal.get(Calendar.YEAR) - 1,
+            cal.get(Calendar.YEAR) - 2, cal.get(Calendar.YEAR) - 3 },
         cal.get(Calendar.YEAR));
     jahr.addListener(new Listener()
     {
@@ -115,7 +111,8 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       return formularEinzelGeld;
     }
     String tmp = settings.getString("formular.einzel", "");
-    formularEinzelGeld = getFormularInput(tmp, FormularArt.SPENDENBESCHEINIGUNG);
+    formularEinzelGeld = getFormularInput(tmp,
+        FormularArt.SPENDENBESCHEINIGUNG);
     formularEinzelGeld.setPleaseChoose("Standard");
     return formularEinzelGeld;
   }
@@ -127,7 +124,8 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       return formularEinzelSonstig;
     }
     String tmp = settings.getString("formular.einzel.sonstig", "");
-    formularEinzelSonstig = getFormularInput(tmp, FormularArt.SPENDENBESCHEINIGUNG);
+    formularEinzelSonstig = getFormularInput(tmp,
+        FormularArt.SPENDENBESCHEINIGUNG);
     formularEinzelSonstig.setPleaseChoose("Standard");
     return formularEinzelSonstig;
   }
@@ -139,36 +137,40 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       return formularSammelGeld;
     }
     String tmp = settings.getString("formular.sammel", "");
-    formularSammelGeld = getFormularInput(tmp, FormularArt.SAMMELSPENDENBESCHEINIGUNG);
+    formularSammelGeld = getFormularInput(tmp,
+        FormularArt.SAMMELSPENDENBESCHEINIGUNG);
     formularSammelGeld.setPleaseChoose("Standard");
     return formularSammelGeld;
   }
-  
-  public SelectInput getFormularSammelbestaetigungSonstig() throws RemoteException
+
+  public SelectInput getFormularSammelbestaetigungSonstig()
+      throws RemoteException
   {
     if (formularSammelSonstig != null)
     {
       return formularSammelSonstig;
     }
     String tmp = settings.getString("formular.sammel.sonstig", "");
-    formularSammelSonstig = getFormularInput(tmp, FormularArt.SAMMELSPENDENBESCHEINIGUNG);
+    formularSammelSonstig = getFormularInput(tmp,
+        FormularArt.SAMMELSPENDENBESCHEINIGUNG);
     formularSammelSonstig.setPleaseChoose("Standard");
     return formularSammelSonstig;
   }
-  
-  private SelectInput getFormularInput(String formular, FormularArt art) throws RemoteException
+
+  private SelectInput getFormularInput(String formular, FormularArt art)
+      throws RemoteException
   {
     DBIterator<Formular> it = Einstellungen.getDBService()
         .createList(Formular.class);
-    it.addFilter("art = ?",
-        new Object[] { art.getKey() });
+    it.addFilter("art = ?", new Object[] { art.getKey() });
     ArrayList<Formular> list = new ArrayList<>();
     Formular preset = null;
     while (it.hasNext())
     {
       Formular f = (Formular) it.next();
       list.add(f);
-      if (formular != null && !formular.isEmpty() && f.getID().equalsIgnoreCase(formular) )
+      if (formular != null && !formular.isEmpty()
+          && f.getID().equalsIgnoreCase(formular))
         preset = f;
     }
     return new SelectInput(list, preset);
@@ -192,7 +194,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       {
         try
         {
-          if (formularEinzelGeld != null )
+          if (formularEinzelGeld != null)
           {
             Formular aa = (Formular) getFormularGeld().getValue();
             if (aa != null)
@@ -200,7 +202,7 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
             else
               settings.setAttribute("formular.einzel", "");
           }
-          if (formularEinzelSonstig != null )
+          if (formularEinzelSonstig != null)
           {
             Formular aa = (Formular) getFormularSonstig().getValue();
             if (aa != null)
@@ -208,29 +210,31 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
             else
               settings.setAttribute("formular.einzel.sonstig", "");
           }
-          if (formularSammelGeld != null )
+          if (formularSammelGeld != null)
           {
-            Formular aa = (Formular) getFormularSammelbestaetigungGeld().getValue();
+            Formular aa = (Formular) getFormularSammelbestaetigungGeld()
+                .getValue();
             if (aa != null)
               settings.setAttribute("formular.sammel", aa.getID());
             else
               settings.setAttribute("formular.sammel", "");
-          }       
-          if (formularSammelSonstig != null )
+          }
+          if (formularSammelSonstig != null)
           {
-            Formular aa = (Formular) getFormularSammelbestaetigungSonstig().getValue();
+            Formular aa = (Formular) getFormularSammelbestaetigungSonstig()
+                .getValue();
             if (aa != null)
               settings.setAttribute("formular.sammel.sonstig", aa.getID());
             else
               settings.setAttribute("formular.sammel.sonstig", "");
-          } 
-          
+          }
+
           @SuppressWarnings("rawtypes")
           List items = spbTree.getItems();
-          
-          //Baum Spendenbescheinigungen enthält keine Einträge
+
+          // Baum Spendenbescheinigungen enthält keine Einträge
           if (items == null)
-        	  return;
+            return;
 
           SpendenbescheinigungNode spn = (SpendenbescheinigungNode) items
               .get(0);
@@ -294,11 +298,11 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
                     .setFormular((Formular) getFormularSonstig().getValue());
               }
             }
-            //Spendenbescheinigungen erfolgreich erstellt
+            // Spendenbescheinigungen erfolgreich erstellt
             spbescheinigung.store();
             spbTree.removeAll();
             GUI.getStatusBar()
-            .setSuccessText("Spendenbescheinigung(en) erstellt");
+                .setSuccessText("Spendenbescheinigung(en) erstellt");
           }
         }
         catch (RemoteException e)
@@ -321,15 +325,16 @@ public class SpendenbescheinigungAutoNeuControl extends AbstractControl
       @Override
       public void format(TreeItem item)
       {
-        SpendenbescheinigungNode spbn = (SpendenbescheinigungNode) item.getData();
+        SpendenbescheinigungNode spbn = (SpendenbescheinigungNode) item
+            .getData();
         try
         {
-         if (spbn.getNodeType()  == SpendenbescheinigungNode.ROOT)
-           item.setImage(SWTUtil.getImage("file-invoice.png"));
-         if (spbn.getNodeType()  == SpendenbescheinigungNode.MITGLIED)
-           item.setImage(SWTUtil.getImage("user.png"));
-         if (spbn.getNodeType()  == SpendenbescheinigungNode.BUCHUNG)
-           item.setImage(SWTUtil.getImage("euro-sign.png"));
+          if (spbn.getNodeType() == SpendenbescheinigungNode.ROOT)
+            item.setImage(SWTUtil.getImage("file-invoice.png"));
+          if (spbn.getNodeType() == SpendenbescheinigungNode.MITGLIED)
+            item.setImage(SWTUtil.getImage("user.png"));
+          if (spbn.getNodeType() == SpendenbescheinigungNode.BUCHUNG)
+            item.setImage(SWTUtil.getImage("euro-sign.png"));
         }
         catch (Exception e)
         {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -594,7 +594,8 @@ public class SpendenbescheinigungControl extends DruckMailControl
   }
 
   @SuppressWarnings("unchecked")
-  private ArrayList<Spendenbescheinigung> getSpendenbescheinigungen() throws RemoteException
+  private ArrayList<Spendenbescheinigung> getSpendenbescheinigungen()
+      throws RemoteException
   {
     SuchSpendenart suchSpendenart = SuchSpendenart.ALLE;
     if (isSuchSpendenartAktiv())
@@ -610,8 +611,8 @@ public class SpendenbescheinigungControl extends DruckMailControl
     // auch dabei ist dürfen wir die Splittbuchung nicht nehmen
     if (suchSpendenart == SuchSpendenart.GELDSPENDE_ECHT)
     {
-      ArrayList<Long> erstattungsIds = 
-          querySpendenbescheinigungen(SuchSpendenart.ERSTATTUNGSVERZICHT);
+      ArrayList<Long> erstattungsIds = querySpendenbescheinigungen(
+          SuchSpendenart.ERSTATTUNGSVERZICHT);
       for (Long id : queryIds)
       {
         if (!erstattungsIds.contains(id))
@@ -622,22 +623,24 @@ public class SpendenbescheinigungControl extends DruckMailControl
     }
     else
     {
-      ids= queryIds;
+      ids = queryIds;
     }
 
-    if(ids.size() == 0)
+    if (ids.size() == 0)
       return new ArrayList<Spendenbescheinigung>();
 
-    DBIterator<Spendenbescheinigung> list = Einstellungen.getDBService().
-        createList(Spendenbescheinigung.class);
+    DBIterator<Spendenbescheinigung> list = Einstellungen.getDBService()
+        .createList(Spendenbescheinigung.class);
     list.addFilter("id in (" + StringUtils.join(ids, ",") + ")");
-    ArrayList<Spendenbescheinigung> spendenbescheinigungen = list != null ? 
-        (ArrayList<Spendenbescheinigung>) PseudoIterator.asList(list) : null;
+    ArrayList<Spendenbescheinigung> spendenbescheinigungen = list != null
+        ? (ArrayList<Spendenbescheinigung>) PseudoIterator.asList(list)
+        : null;
     return spendenbescheinigungen;
   }
-  
+
   @SuppressWarnings("unchecked")
-  private ArrayList<Long> querySpendenbescheinigungen(SuchSpendenart suchSpendenart) throws RemoteException
+  private ArrayList<Long> querySpendenbescheinigungen(
+      SuchSpendenart suchSpendenart) throws RemoteException
   {
     final DBService service = Einstellungen.getDBService();
     ArrayList<Object> bedingungen = new ArrayList<>();
@@ -737,7 +740,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
     sql += " ORDER BY bescheinigungsdatum desc ";
-    
+
     ResultSetExtractor rs = new ResultSetExtractor()
     {
       @Override
@@ -752,10 +755,9 @@ public class SpendenbescheinigungControl extends DruckMailControl
       }
     };
 
-    return (ArrayList<Long>) service.execute(sql, bedingungen.toArray(),
-        rs);
+    return (ArrayList<Long>) service.execute(sql, bedingungen.toArray(), rs);
   }
-  
+
   private void addCondition(String condition)
   {
     if (and)
@@ -769,7 +771,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     and = true;
     sql += condition;
   }
-  
+
   // Mail/Drucken View
   @Override
   public String getInfoText(Object spbArray)

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -632,6 +632,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     DBIterator<Spendenbescheinigung> list = Einstellungen.getDBService()
         .createList(Spendenbescheinigung.class);
     list.addFilter("id in (" + StringUtils.join(ids, ",") + ")");
+    list.setOrder(" ORDER BY bescheinigungsdatum desc ");
     ArrayList<Spendenbescheinigung> spendenbescheinigungen = list != null
         ? (ArrayList<Spendenbescheinigung>) PseudoIterator.asList(list)
         : null;
@@ -739,7 +740,6 @@ public class SpendenbescheinigungControl extends DruckMailControl
       Date d = (Date) getEingabedatumbis().getValue();
       bedingungen.add(new java.sql.Date(d.getTime()));
     }
-    sql += " ORDER BY bescheinigungsdatum desc ";
 
     ResultSetExtractor rs = new ResultSetExtractor()
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -687,15 +687,14 @@ public class SpendenbescheinigungControl extends DruckMailControl
           bedingungen.add(Spendenart.SACHSPENDE);
           break;
         case ERSTATTUNGSVERZICHT:
-          addCondition("buchung.verzicht IS NOT NULL and buchung.verzicht = 1 ");
+          addCondition("buchung.verzicht = 1");
           break;
         case GELDSPENDE_ECHT:
-          addCondition("buchung.verzicht != 1 AND spendenart != ?");
-          bedingungen.add(Spendenart.SACHSPENDE);
+          addCondition("buchung.verzicht != 1 AND spendenart = ?");
+          bedingungen.add(Spendenart.GELDSPENDE);
           break;
         case SACHSPENDE_ERSTATTUNGSVERZICHT:
-          addCondition("((buchung.verzicht IS NOT NULL and  buchung.verzicht = 1)"
-              + "OR spendenart = ?) ");
+          addCondition("(buchung.verzicht = 1 OR spendenart = ?)");
           bedingungen.add(Spendenart.SACHSPENDE);
           break;
         default:

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
@@ -23,7 +23,9 @@ import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.InfoPanel;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class SpendenbescheinigungAutoNeuView extends AbstractView
 {
@@ -57,12 +59,23 @@ public class SpendenbescheinigungAutoNeuView extends AbstractView
     info.setComment("Siehe Administration->Einstellungen->Spendenbescheinigungen->Mindestbetrag");
     }
     info.paint(getParent());
-    LabelGroup group = new LabelGroup(getParent(), "Jahr");
-    group.addLabelPair("Jahr", control.getJahr());
-    // TODO Unterscheidung Einzel/Sammel-Bestätigung: zwei Felder
-    group.addLabelPair("Formular-Einzelbest.", control.getFormular());
-    group.addLabelPair("Formular-Sammelbest.",
-        control.getFormularSammelbestaetigung());
+    LabelGroup group1 = new LabelGroup(getParent(), "Filter");
+    group1.addLabelPair("Jahr", control.getJahr());
+
+    LabelGroup group2 = new LabelGroup(getParent(), "Formulare");
+    ColumnLayout cl = new ColumnLayout(group2.getComposite(), 2);
+
+    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    left.addLabelPair("Einzelbestätigung für Geldsspende",
+        control.getFormularGeld());
+    left.addLabelPair("Einzelbestätigung für Erstattungsverzicht",
+        control.getFormularSonstig());
+
+    SimpleContainer right = new SimpleContainer(cl.getComposite());
+    right.addLabelPair("Sammelbestätigung für Geldsspende",
+        control.getFormularSammelbestaetigungGeld());
+    right.addLabelPair("Sammelbestätigung für Erstattungsverzicht",
+        control.getFormularSammelbestaetigungSonstig());
 
     control.getSpendenbescheinigungTree().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungAutoNeuView.java
@@ -81,7 +81,7 @@ public class SpendenbescheinigungAutoNeuView extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
-            DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+        DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
     buttons.addButton(control.getSpendenbescheinigungErstellenButton());
     buttons.paint(getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -45,6 +45,7 @@ public class SpendenbescheinigungListeView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
     left.addInput(control.getMailauswahl());
+    left.addInput(control.getSuchSpendenart());
 
     SimpleContainer middle = new SimpleContainer(cl.getComposite());
     middle.addLabelPair("Bescheinigungsdatum von", control.getDatumvon());

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -46,6 +46,7 @@ public class SpendenbescheinigungMailView extends AbstractView
       SimpleContainer left = new SimpleContainer(cl.getComposite());
       left.addInput(control.getSuchname());
       left.addInput(control.getMailauswahl());
+      left.addInput(control.getSuchSpendenart());
 
       SimpleContainer middle = new SimpleContainer(cl.getComposite());
       middle.addLabelPair("Bescheinigungsdatum von", control.getDatumvon());

--- a/src/de/jost_net/JVerein/keys/SuchSpendenart.java
+++ b/src/de/jost_net/JVerein/keys/SuchSpendenart.java
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.keys;
+
+/**
+ * Suchspendenart
+ */
+public enum SuchSpendenart
+{
+
+  ALLE(1, "Alle"),
+  GELDSPENDE(2, "Geldspende"),
+  SACHSPENDE(3, "Sachspende"),
+  ERSTATTUNGSVERZICHT(4, "Geldspende mit Erstattungsverzicht"),
+  GELDSPENDE_ECHT(5, "Geldspende ohne Erstattungsverzicht"),
+  SACHSPENDE_ERSTATTUNGSVERZICHT(6, "Sachspende oder Geldspende mit Erstattungsverzicht");
+
+  private final String text;
+
+  private final int key;
+
+  SuchSpendenart(int key, String text)
+  {
+    this.key = key;
+    this.text = text;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public String getText()
+  {
+    return text;
+  }
+
+  public static SuchSpendenart getByKey(int key)
+  {
+    for (SuchSpendenart sb : SuchSpendenart.values())
+    {
+      if (sb.getKey() == key)
+      {
+        return sb;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return getText();
+  }
+}

--- a/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
+++ b/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
@@ -98,6 +98,17 @@ public interface Spendenbescheinigung extends DBObject
   public boolean isSammelbestaetigung() throws RemoteException;
 
   /**
+   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine
+   * echte Geldspende ist. Dies ist der Fall, wenn es sich um eine 
+   * Gelspende handelt bei der bei keiner Buchung das Flag 
+   * Erstattungsverzicht gesetzt ist.
+   * 
+   * @return Flag, ob echte Geldspende
+   * @throws RemoteException
+   */
+  public boolean isEchteGeldspende() throws RemoteException;
+  
+  /**
    * Fügt der Liste der Buchungen eine Buchung hinzu. Der Gesamtbetrag der
    * Spendenbescheinigung wird anhand der Einzelbeträge der Buchungen berechnet.
    * Die Spendenart wird auf "GELDSPENDE" gesetzt.

--- a/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
+++ b/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
@@ -98,10 +98,9 @@ public interface Spendenbescheinigung extends DBObject
   public boolean isSammelbestaetigung() throws RemoteException;
 
   /**
-   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine
-   * echte Geldspende ist. Dies ist der Fall, wenn es sich um eine 
-   * Gelspende handelt bei der bei keiner Buchung das Flag 
-   * Erstattungsverzicht gesetzt ist.
+   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine echte
+   * Geldspende ist. Dies ist der Fall, wenn es sich um eine Gelspende handelt
+   * bei der bei keiner Buchung das Flag Erstattungsverzicht gesetzt ist.
    * 
    * @return Flag, ob echte Geldspende
    * @throws RemoteException

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -427,6 +427,27 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
       return false;
     return getBuchungen().size() > 1;
   }
+  
+  /**
+   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine
+   * echte Geldspende ist. Dies ist der Fall, wenn es sich um eine 
+   * Gelspende handelt bei der bei keiner Buchung das Flag 
+   * Erstattungsverzicht gesetzt ist.
+   * 
+   * @return Flag, ob echte Geldspende
+   * @throws RemoteException
+   */
+  public boolean isEchteGeldspende() throws RemoteException
+  {
+    if (getBuchungen() == null)
+      return false;
+    for (Buchung buchung : getBuchungen())
+    {
+      if (buchung.getVerzicht())
+        return false;
+    }
+    return true;
+  }
 
   /**
    * Fügt der Liste der Buchungen eine Buchung hinzu. Der Gesamtbetrag der

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -429,10 +429,9 @@ public class SpendenbescheinigungImpl extends AbstractDBObject
   }
   
   /**
-   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine
-   * echte Geldspende ist. Dies ist der Fall, wenn es sich um eine 
-   * Gelspende handelt bei der bei keiner Buchung das Flag 
-   * Erstattungsverzicht gesetzt ist.
+   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine echte
+   * Geldspende ist. Dies ist der Fall, wenn es sich um eine Gelspende handelt
+   * bei der bei keiner Buchung das Flag Erstattungsverzicht gesetzt ist.
    * 
    * @return Flag, ob echte Geldspende
    * @throws RemoteException


### PR DESCRIPTION
Dieses Feature implementiert  #440.

Automatisierte Spendenbescheinigung mit gedruckter Unterschrift werden nur noch für echte Geldspenden erzeugt. Bei Sachspenden, Geldspenden mit Erstattungsverzicht  und Sammelbestätigungen in denen mindestens einer Buchnung mit Erstattungsverzicht ist, wird bei der Standard Spendenbescheinigung keine Unterschrift mehr gedruckt.

Zur Unterstützung bei nicht Standard Formularen habe ich den Spendenbescheinigungen Auto View erweitert. Man kann jetzt jeweils ein Formular für echte Geldspenden und solche für Geldspenden mit Erstattungsverzicht eingeben. Bei den ersten kann man eine gedruckte Unterschrift im Formular haben, bei den anderen ist das nicht erlaubt.
![Bildschirmfoto_20241124_184212](https://github.com/user-attachments/assets/b42bc156-7066-4eb8-b6c9-a9985026fb32)

Im Spendenbescheinigung Liste View und Druck/Mail View gibt es das neue Feld Spendenart.
![Bildschirmfoto_20241124_184337](https://github.com/user-attachments/assets/42a15d67-324d-4871-bfee-42011510407e)

Die Optionen sind.
![Bildschirmfoto_20241124_184356](https://github.com/user-attachments/assets/014afbfc-08d0-4e74-8d21-de86b937ebb5)

Alle: zeigt alle an
Geldspende: zeigt alle Geldspendenbescheinigungen an
Sachspende: zeigt alle Sachspenden an
Geldspende mit Erstattungsverzicht: zeigt alle Geldspenden in denen Buchungen mit Erstattungsverzicht sind
Geldspende ohne Erstattungsverzicht: zeigt alle Geldspenden ohne Buchungen mit Erstattungsverzicht
Sachspende oder Geldspende mit Erstattungsverzicht: das Gegentei der vorhergehenden Option

Nur die Option "Geldspende ohne Erstattungsverzicht" kann beim Mailversand benutzt werden weil nur hier die gedruckte Unterschrift eingefügt wird.

Mit der Option "Sachspende oder Geldspende mit Erstattungsverzicht" bekommt man alle die man nicht mailen kann. Diese sind auszudrucken und eigenhändig zu unterschreiben. So lautet momentan die gesetzliche Regelung.
