### PR TITLE
Fix Exception in Sollbuchung Liste View

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -414,6 +414,10 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
     {
       return getBuchungsklasse();
     }
+    if (fieldName.equals("buchungsart"))
+    {
+      return getBuchungsart();
+    }
     return super.getAttribute(fieldName);
   }
 }


### PR DESCRIPTION
Zum Sollbuchung Liste View wurde kürlich die Buchungsart als Spalte hinzugefügt. Da kam es zu einer Exception beim Zugriff weil sie als Long geliefert wurde. Der Formatter erwartet die Klasse.