### PR TITLE
Splittyp löschen bei Splittbuchung auflösen

### DIFF
--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -158,6 +158,7 @@ public class SplitbuchungsContainer
       if (b.getSplitTyp() == SplitbuchungTyp.HAUPT)
       {
         b.setSplitId(null);
+        b.setSplitTyp(null);
         b.store();
       }
       else


### PR DESCRIPTION
Beim Auflösen einer Splitbuchung muss der Splittyp gelöscht werden. Sonst wird später die Buchung mit H versehen weil es einmal eine Haupbuchung war.