### PR TITLE
Leistungsdatum

### DIFF
--- a/src/de/jost_net/JVerein/Queries/BuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/BuchungQuery.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.HashMap;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.io.Suchbetrag;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -31,6 +32,7 @@ import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.logging.Logger;
 
 public class BuchungQuery
 {
@@ -58,6 +60,8 @@ public class BuchungQuery
   
   private HashMap<String, String> sortValues = new HashMap<String, String>();
 
+  private final BuchungsControl.Datumsart datumsart;
+
   private void SortHashMap() {
 	  sortValues.put("ORDER_ID","order by id");
 	  sortValues.put("ORDER_DATUM","order by datum");
@@ -78,7 +82,8 @@ public class BuchungQuery
 
   public BuchungQuery(Date datumvon, Date datumbis, Konto konto,
       Buchungsart buchungsart, Projekt projekt, String text, String betrag,
-      Boolean hasMitglied, String mitglied, boolean geldkonto)
+      Boolean hasMitglied, String mitglied, boolean geldkonto,
+      BuchungsControl.Datumsart datumsart)
   {
     this.datumvon = datumvon;
     this.datumbis = datumbis;
@@ -90,6 +95,7 @@ public class BuchungQuery
     this.hasMitglied = hasMitglied;
     this.geldkonto = geldkonto;
     this.mitglied = mitglied;
+    this.datumsart = datumsart;
   }
   
   public String getOrder(String value) {
@@ -168,9 +174,21 @@ public class BuchungQuery
       it.addFilter("(lower(mitglied.name) like ? or lower(mitglied.vorname) like ?)",
           new Object[] { mitgliedsuche, mitgliedsuche });
     }
-    
-    it.addFilter("buchung.datum >= ? ", datumvon);
-    it.addFilter("buchung.datum <= ? ", datumbis);
+
+    switch (datumsart)
+    {
+      case BUCHUNGSDATUM:
+        it.addFilter("buchung.datum >= ? ", datumvon);
+        it.addFilter("buchung.datum <= ? ", datumbis);
+        break;
+      case LEISTUNGSDATUM:
+        it.addFilter("buchung.leistungsdatum >= ? ", datumvon);
+        it.addFilter("buchung.leistungsdatum <= ? ", datumbis);
+        break;
+      default:
+        Logger.error("Fehler beim Filtern!");
+        break;
+    }
 
     if (konto != null)
     {

--- a/src/de/jost_net/JVerein/gui/action/BuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungNeuAction.java
@@ -54,6 +54,7 @@ public class BuchungNeuAction implements Action
           buch.setBuchungsartId(konto.getAfaartId());
         }
         buch.setDatum(new Date());
+        buch.setLeistungsdatum(new Date());
         buch.setKonto(konto);
       }
       else
@@ -72,6 +73,7 @@ public class BuchungNeuAction implements Action
                 buch.setBuchungsartId(k.getAfaartId());
               }
               buch.setDatum(new Date());
+              buch.setLeistungsdatum(new Date());
               buch.setKonto(k);
             }
           }

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.dialogs.SollbuchungAuswahlDialog;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Einstellung;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
@@ -97,7 +98,7 @@ public class BuchungSollbuchungZuordnungAction implements Action
           }
 
           mk.setBetrag(betrag);
-          mk.setDatum(b[0].getDatum());
+          mk.setDatum(b[0].getLeistungsdatum());
           mk.setMitglied(m);
           mk.setZahlungsweg(Zahlungsweg.ÜBERWEISUNG);
           mk.setZweck1(b[0].getZweck());
@@ -107,12 +108,22 @@ public class BuchungSollbuchungZuordnungAction implements Action
         for (Buchung buchung : b)
         {
           buchung.setMitgliedskonto(mk);
+          Einstellung einstellung = Einstellungen.getEinstellung();
           if (mk != null)
           {
             if (buchung.getBuchungsartId() == null)
+            {
               buchung.setBuchungsartId(mk.getBuchungsartId());
+            }
             if (buchung.getBuchungsklasseId() == null)
+            {
               buchung.setBuchungsklasseId(mk.getBuchungsklasseId());
+            }
+            if (einstellung.getWirtschaftsplanung() && buchung.getLeistungsdatum()
+                .equals(buchung.getDatum()))
+            {
+              buchung.setLeistungsdatum(mk.getDatum());
+            }
           }
           buchung.store();
         }

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -307,6 +307,8 @@ public class EinstellungControl extends AbstractControl
   
   private CheckboxInput freiebuchungsklasse;
 
+  private CheckboxInput wirtschaftsplanung;
+
   private CheckboxInput summenAnlagenkonto;
 
 
@@ -822,6 +824,19 @@ public class EinstellungControl extends AbstractControl
     freiebuchungsklasse = new CheckboxInput(Einstellungen.getEinstellung().getBuchungsklasseInBuchung());
     freiebuchungsklasse.setName("Keine feste Zuordnung von Buchungsklasse zu Buchungsart z.B. SKR 42");
     return freiebuchungsklasse;
+  }
+
+  public CheckboxInput getWirtschaftsplanung() throws RemoteException
+  {
+    if (wirtschaftsplanung != null)
+    {
+      return wirtschaftsplanung;
+    }
+    wirtschaftsplanung = new CheckboxInput(
+        Einstellungen.getEinstellung().getWirtschaftsplanung());
+    wirtschaftsplanung.setName(
+        "Zusätzliches Leistungsdatum aktivieren"); //TODO: Text zu Wirtschaftsplanung ändern, sobald implementiert.
+    return wirtschaftsplanung;
   }
 
   public CheckboxInput getExterneMitgliedsnummer() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.parts;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.rmi.Einstellung;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
@@ -55,8 +56,10 @@ public class BuchungPart implements Part
   @Override
   public void paint(Composite parent) throws RemoteException
   {
-    String title = (control.getBuchung().getSpeicherung() ? "Buchung"
-        : "Splitbuchung");
+    Einstellung einstellung = Einstellungen.getEinstellung();
+    String title = (control.getBuchung().getSpeicherung() ?
+        "Buchung" :
+        "Splitbuchung");
     GUI.getView().setTitle(title);
 
     ScrolledContainer scrolled = new ScrolledContainer(parent, 1);
@@ -76,7 +79,14 @@ public class BuchungPart implements Part
     DateInput date = control.getDatum();
     grKontoauszug.addLabelPair("Datum", date);
     if (!control.getBuchung().getSpeicherung())
+    {
       date.setEnabled(false);
+    }
+    if (einstellung.getWirtschaftsplanung())
+    {
+      DateInput leistungsdatum = control.getLeistunsgdatum();
+      grKontoauszug.addLabelPair("Leistungsdatum", leistungsdatum);
+    }
     grKontoauszug.addLabelPair("Art", control.getArt());
     grKontoauszug.addLabelPair("Sollbuchung", control.getMitgliedskonto());
     grKontoauszug.addLabelPair("Kommentar", control.getKommentar());

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -16,7 +16,8 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
-
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.rmi.Einstellung;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.TabFolder;
@@ -48,8 +49,10 @@ public class BuchungslisteView extends AbstractView
   public void bind() throws Exception
   {
     GUI.getView().setTitle("Buchungen");
-    
-    final BuchungsControl control = new BuchungsControl(this, Kontenart.GELDKONTO);
+    Einstellung einstellung = Einstellungen.getEinstellung();
+
+    final BuchungsControl control = new BuchungsControl(this,
+        Kontenart.GELDKONTO);
 
     LabelGroup group = new LabelGroup(getParent(), "Konto");
     group.addLabelPair("Konto", control.getSuchKonto());
@@ -67,7 +70,12 @@ public class BuchungslisteView extends AbstractView
     left.addLabelPair("Buchungsart", control.getSuchBuchungsart());
     left.addLabelPair("Projekt", control.getSuchProjekt());
     left.addLabelPair("Betrag", control.getSuchBetrag());
-    left.addLabelPair("Mitglied zugeordnet?", control.getSuchMitgliedZugeordnet());
+    left.addLabelPair("Mitglied zugeordnet?",
+        control.getSuchMitgliedZugeordnet());
+    if (einstellung.getWirtschaftsplanung())
+    {
+      right.addLabelPair("Datumsart", control.getDatumsart());
+    }
     right.addLabelPair("Von Datum", control.getVondatum());
     right.addLabelPair("Bis Datum", control.getBisdatum());
     right.addLabelPair("Enthaltener Text", control.getSuchtext());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -49,6 +49,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     cont.addInput(control.getKontonummerInBuchungsliste());
     cont.addInput(control.getOptiert());
     cont.addInput(control.getFreieBuchungsklasse());
+    cont.addInput(control.getWirtschaftsplanung());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -67,6 +67,10 @@ public interface Buchung extends DBObject
 
   public void setDatum(Date datum) throws RemoteException;
 
+  Date getLeistungsdatum() throws RemoteException;
+
+  void setLeistungsdatum(Date leistungsdatum) throws RemoteException;
+
   public String getArt() throws RemoteException;
 
   public void setArt(String art) throws RemoteException;

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -598,7 +598,12 @@ public interface Einstellung extends DBObject, IBankverbindung
   
   public Boolean getBuchungsklasseInBuchung() throws RemoteException;
 
-  public void setBuchungsklasseInBuchung(Boolean bkinbuchung) throws RemoteException;
+  public void setBuchungsklasseInBuchung(Boolean bkinbuchung)
+      throws RemoteException;
+
+  Boolean getWirtschaftsplanung() throws RemoteException;
+
+  void setWirtschaftsplanung(Boolean wirtschaftsplanung) throws RemoteException;
 
   public Boolean getSummenAnlagenkonto() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -356,7 +356,24 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
 
   public void setDatum(String datum) throws RemoteException
   {
-    setAttribute("datum", toDate(datum));
+    setDatum(toDate(datum));
+  }
+
+  @Override
+  public Date getLeistungsdatum() throws RemoteException
+  {
+    return (Date) getAttribute("leistungsdatum");
+  }
+
+  @Override
+  public void setLeistungsdatum(Date leistungsdatum) throws RemoteException
+  {
+    setAttribute("leistungsdatum", leistungsdatum);
+  }
+
+  public void setLeistungsdatum(String datum) throws RemoteException
+  {
+    setLeistungsdatum(toDate(datum));
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0452.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0452.java
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0452 extends AbstractDDLUpdate
+{
+  public Update0452(String driver, ProgressMonitor monitor,
+      Connection connection)
+  {
+    super(driver, monitor, connection);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung",
+        new Column("wirtschaftsplanung", COLTYPE.BOOLEAN, 0, null, false,
+            false)));
+
+    execute(addColumn("buchung",
+        new Column("leistungsdatum", COLTYPE.DATE, 0, null, false, false)));
+
+    execute("UPDATE buchung SET leistungsdatum = datum");
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2099,6 +2099,19 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     setAttribute("bkinbuchung", bkinbuchung);
   }
 
+  @Override
+  public Boolean getWirtschaftsplanung() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("wirtschaftsplanung"));
+  }
+
+  @Override
+  public void setWirtschaftsplanung(Boolean wirtschaftsplanung)
+      throws RemoteException
+  {
+    setAttribute("wirtschaftsplanung", wirtschaftsplanung);
+  }
+
   public Boolean getSummenAnlagenkonto() throws RemoteException
   {
     return Util.getBoolean(getAttribute("summenanlagenkonto"));


### PR DESCRIPTION
Closes #472 

In Vorbereitung für #434 habe ich ein zusätzliches Leistungsdatum eingeführt. Dieses Feature kann über die Einstellungen aktiviert werden. 
Standardmäßig ist das Leistungsdatum identisch zum Buchungsdatum und wird auch immer geändert, wenn man das Buchungsdatum ändert. Erst sobald ein abweichender Wert gesetzt wird, wird das Leistungsdatum nicht mehr mit verändert.
Weißt man eine Sollbuchung zu, wird ebenfalls das Leistungsdatum geändert, sofern es nicht vorher schon manuell oder durch eine Sollbuchung geändert wurde.
Ebenfalls neu ist, dass das Datum einer neuen Sollbuchung automatisch auf das Leistungsdatum der Buchung gesetzt wird.
So dass standardmäßig Leistungsdatum und Sollbuchung konsistent sind, sofern der User sich nicht aktiv dafür entscheidet hier abweichende Werte zu setzen.

Da standardmäßig Datum und Leistungsdatum gekoppelt sind, können die Felder im Hintergrund beim Zugriff auf die Daten synonym verwendet werden, was teilweise eine Aufteilung in Ausführungspfade (abhängig davon ob die Einstellung gesetzt ist) umgeht.