### PR TITLE
Fix #27. ROW FORMAT bei mariaDB

### DIFF
--- a/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
+++ b/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
@@ -1026,7 +1026,7 @@ public class JVereinUpdateProvider
     sb.append(" rechnungfuerbarzahlung CHAR(5),");
     sb.append(" UNIQUE (id),");
     sb.append(" PRIMARY KEY (id)");
-    sb.append(" )  ENGINE=InnoDB;\n");
+    sb.append(" )  ENGINE=InnoDB ROW_FORMAT=DYNAMIC;\n");
     statements.put(DBSupportMySqlImpl.class.getName(), sb.toString());
 
     execute(conn, statements, 28);


### PR DESCRIPTION
Beim anlegen der DB bei Mariadb und Charset utf8mb4 kam es zu Fehlern. Mit `ROW_FORMAT=DYNAMIC ` funktioniert es wieder.

Resolve #27 