### PR TITLE
Sort für View Listen

### DIFF
--- a/src/com/schlevoigt/JVerein/gui/control/BuchungsTextKorrekturControl.java
+++ b/src/com/schlevoigt/JVerein/gui/control/BuchungsTextKorrekturControl.java
@@ -144,6 +144,7 @@ public class BuchungsTextKorrekturControl extends AbstractControl {
 		for (Buchung b : query.get()) {
 			buchungsList.addItem(b);
 		}
+		buchungsList.sort();
 	}
 
 	private void starteKorrektur() {

--- a/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
+++ b/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
@@ -169,6 +169,7 @@ public class MitgliedNextBGruppeChecker extends AbstractBox
       aenderungsListenPart.addItem(mitgliedBeitraege);
       datenVorhanden = true;
     }
+    aenderungsListenPart.sort();
     this.isAktiv = datenVorhanden;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufBuchungenControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufBuchungenControl.java
@@ -190,6 +190,7 @@ public class AbrechnungslaufBuchungenControl extends AbstractControl
       {
         SollbuchungsList.addItem(it.next());
       }
+      SollbuchungsList.sort();
     }
     return SollbuchungsList;
   }

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -397,6 +397,7 @@ public class AbrechnungslaufControl extends FilterControl
       {
         abrechnungslaufList.addItem(abrechnungslaeufe.next());
       }
+      abrechnungslaufList.sort();
     }
     return abrechnungslaufList;
   }

--- a/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
@@ -180,6 +180,7 @@ public class AnfangsbestandControl extends FilterControl
       {
         anfangsbestandList.addItem(anfangsbestaende.next());
       }
+      anfangsbestandList.sort();
     }
     catch (RemoteException e1)
     {

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -542,6 +542,7 @@ public class ArbeitseinsatzControl extends FilterControl
         {
           arbeitseinsatzueberpruefungList.addItem(az);
         }
+        arbeitseinsatzueberpruefungList.sort();
       }
     }
     catch (RemoteException e)
@@ -615,6 +616,7 @@ public class ArbeitseinsatzControl extends FilterControl
       {
         arbeitseinsatzList.addItem(arbeitseinsaetze.next());
       }
+      arbeitseinsatzList.sort();
     }
     catch (RemoteException e1)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1453,6 +1453,7 @@ public class BuchungsControl extends AbstractControl
     {
       splitbuchungsList.addItem(b);
     }
+    splitbuchungsList.sort();
   }
 
   private void starteAuswertung(boolean einzelbuchungen)

--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -227,6 +227,7 @@ public class DokumentControl extends AbstractControl
     {
       docsList.addItem(docs.next());
     }
+    docsList.sort();
   }
 
   /**

--- a/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
@@ -163,6 +163,7 @@ public class EigenschaftControl extends AbstractControl
       {
         eigenschaftList.addItem(eigenschaften.next());
       }
+      eigenschaftList.sort();
     }
     return eigenschaftList;
   }

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -277,6 +277,7 @@ public class FormularControl extends FormularPartControl
     {
       formularList.addItem(formulare.next());
     }
+    formularList.sort();
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
@@ -79,6 +79,7 @@ public class FormularPartControl extends AbstractControl
     {
       formularfelderList.addItem(formularfelder.next());
     }
+    formularfelderList.sort();
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -297,6 +297,7 @@ public class JahresabschlussControl extends AbstractControl
     {
       jahresabschlussList.addItem(jahresabschluesse.next());
     }
+    jahresabschlussList.sort();
   }
   
   public String getInfo()

--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -344,11 +344,11 @@ public class KontoControl extends AbstractControl
     kontenList.removeAll();
     DBIterator<Konto> konten = Einstellungen.getDBService()
         .createList(Konto.class);
-    konten.setOrder("ORDER BY nummer");
     while (konten.hasNext())
     {
       kontenList.addItem(konten.next());
     }
+    kontenList.sort();
   }
 
   public Input getBuchungsart() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -416,6 +416,7 @@ public class KursteilnehmerControl extends FilterControl
         Kursteilnehmer kt = kursteilnehmer.next();
         part.addItem(kt);
       }
+      part.sort();
     }
     catch (RemoteException e1)
     {

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -138,6 +138,7 @@ public class LastschriftControl extends FilterControl
       {
         lastschriftList.addItem(lastschriften.next());
       }
+      lastschriftList.sort();
     }
     catch (RemoteException e1)
     {

--- a/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
@@ -231,6 +231,7 @@ public class LehrgangControl extends FilterControl
       {
         lehrgaengeList.addItem(lehrgaenge.next());
       }
+      lehrgaengeList.sort();
     }
     catch (RemoteException e1)
     {
@@ -301,6 +302,7 @@ public class LehrgangControl extends FilterControl
       {
         lehrgaengeList.addItem(lehrgaenge.next());
       }
+      lehrgaengeList.sort();
     }
     return lehrgaengeList;
   }

--- a/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
@@ -186,11 +186,11 @@ public class LehrgangsartControl extends AbstractControl
     lehrgangsartList.removeAll();
     DBIterator<Lehrgangsart> lehrgangsarten = Einstellungen.getDBService()
         .createList(Lehrgangsart.class);
-    lehrgangsarten.setOrder("ORDER BY bezeichnung");
     while (lehrgangsarten.hasNext())
     {
       lehrgangsartList.addItem(lehrgangsarten.next());
     }
+    lehrgangsartList.sort();
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -654,6 +654,7 @@ public class MailControl extends FilterControl
       {
         mailsList.addItem(mails.next());
       }
+      mailsList.sort();
     }
     catch (RemoteException e1)
     {

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1658,6 +1658,7 @@ public class MitgliedControl extends FilterControl
         m = getMitglied();
       familienangehoerige.addItem(m);
     }
+    familienangehoerige.sort();
   }
 
   public Part getFamilienangehoerigenTable() throws RemoteException
@@ -2185,6 +2186,7 @@ public class MitgliedControl extends FilterControl
     {
       part.addItem(m);
     }
+    part.sort();
     return part;
   }
   
@@ -2974,6 +2976,7 @@ public class MitgliedControl extends FilterControl
       MitgliedNextBGruppe m = datenIterator.next();
       beitragsTabelle.addItem(m);
     }
+    beitragsTabelle.sort();
   }
   
   @Override

--- a/src/de/jost_net/JVerein/gui/control/MitgliedSuchProfilControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedSuchProfilControl.java
@@ -104,6 +104,7 @@ public class MitgliedSuchProfilControl extends AbstractControl
       Suchprofil sp = (Suchprofil) it.next();
       profillist.addItem(sp);
     }
+    profillist.sort();
   }
 
   private DBIterator<Suchprofil> getIterator() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -564,6 +564,7 @@ public class MitgliedskontoControl extends DruckMailControl
       {
         mitgliedskontoList.addItem(mitgliedskonten.next());
       }
+      mitgliedskontoList.sort();
     }
     return mitgliedskontoList;
   }
@@ -591,6 +592,7 @@ public class MitgliedskontoControl extends DruckMailControl
       {
         mitgliedskontoList2.addItem(mitglieder.next());
       }
+      mitgliedskontoList2.sort();
     }
     return mitgliedskontoList2;
   }
@@ -603,6 +605,7 @@ public class MitgliedskontoControl extends DruckMailControl
     {
       mitgliedskontoList2.addItem(mitglieder.next());
     }
+    mitgliedskontoList2.sort();
   }
 
   private GenericIterator<Mitglied> getMitgliedIterator() throws RemoteException
@@ -655,6 +658,7 @@ public class MitgliedskontoControl extends DruckMailControl
     {
       mitgliedskontoList.addItem(mitgliedskonten.next());
     }
+    mitgliedskontoList.sort();
   }
 
   public Button getStartKontoauszugButton(final Object currentObject,

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -245,6 +245,7 @@ public class RechnungControl extends DruckMailControl
         {
           rechnungList.addItem(rechnungen.next());
         }
+        rechnungList.sort();
       }
       else if (rechnungTree != null)
       {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -581,6 +581,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
         {
           spbList.addItem(spb);
         }
+        spbList.sort();
       }
       catch (RemoteException e1)
       {

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -298,6 +298,7 @@ public class ZusatzbetragControl extends AbstractControl
       {
         zusatzbetraegeList.addItem(zusatzbetraege.next());
       }
+      zusatzbetraegeList.sort();
     }
     if (this.ausfuehrungSuch.getText().equals("Aktive"))
     {

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
@@ -335,6 +335,7 @@ public class ZusatzbetragVorlageControl extends AbstractControl
       {
         zusatzbetraegeList.addItem(zusatzbetragsvorlagen.next());
       }
+      zusatzbetraegeList.sort();
     }
     return zusatzbetraegeList;
   }

--- a/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzUeberpruefungList.java
+++ b/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzUeberpruefungList.java
@@ -92,6 +92,7 @@ public class ArbeitseinsatzUeberpruefungList extends TablePart implements Part
         {
           arbeitseinsatzueberpruefungList.addItem(az);
         }
+        arbeitseinsatzueberpruefungList.sort();
       }
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/parts/WiedervorlageList.java
+++ b/src/de/jost_net/JVerein/gui/parts/WiedervorlageList.java
@@ -75,6 +75,7 @@ public class WiedervorlageList extends TablePart implements Part
       {
         wiedervorlageList.addItem(wiedervorlagen.next());
       }
+      wiedervorlageList.sort();
     }
     return wiedervorlageList;
   }


### PR DESCRIPTION
Damit die ausgewählte Sortierung in Tabellen auch nach dem Filtern erhalten bleibt muss man das sort() beim Refresh einbauen.

Das war nur bei wenigen Tabellen der Fall.

Implementiert #490