### PR TITLE
Java Version vordefinieren und build errors zu reduzieren

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=11

--- a/build/build.xml
+++ b/build/build.xml
@@ -54,7 +54,7 @@
 
   <target name="compile" depends="init, clean">
     <mkdir dir="${class.dir}" />
-    <javac debug="true" includeantruntime="false" debuglevel="lines,vars,source" source="${define.java.version}" target="${define.java.version}" encoding="${define.encoding}" deprecation="true" destdir="${class.dir}" srcdir="${src.dir}">
+    <javac debug="true" includeantruntime="false" debuglevel="lines,vars,source" release="${define.java.version}" encoding="${define.encoding}" deprecation="true" destdir="${class.dir}" srcdir="${src.dir}">
 			<classpath refid="compilepath" />
 		</javac>
   </target>


### PR DESCRIPTION
Mit diesen beiden Commits habe ich die eingecheckten javac Versionen angepasst, damit zum einen bei einem frischen Checkout von master keine build errors von Eclipse angezeigt werden und man dazu neigt, eine neuere Java-Version als 11 zu verwenden.

Der zweite Commit stellt sicher, dass ant auch nur die vorgegebene API-Version verwendet. Mit den bisherigen Einstellungen hat sie gegen die neueste installierte API-Version gelinkt und ich habe die build errors von #497 bei mir lokal nicht erhalten.
Die Hintergründe sind in [JEP 247: Compile for Older Platform Versions](https://openjdk.org/jeps/247) beschrieben.