### PR TITLE
Unterschrift bei Spendenbescheinigungen über Formulare

### DIFF
--- a/src/de/jost_net/JVerein/Variable/SpendenbescheinigungVar.java
+++ b/src/de/jost_net/JVerein/Variable/SpendenbescheinigungVar.java
@@ -36,6 +36,7 @@ public enum SpendenbescheinigungVar {
   BEZEICHNUNGSACHZUWENDUNG("spendenbescheinigung_bezeichnungsachzuwendung"), //
   HERKUNFTSACHZUWENDUNG("spendenbescheinigung_herkunftsachzuwendung"), //
   UNTERLAGENWERTERMITTUNG("spendenbescheinigung_unterlagenwertermittlung"), //
+  UNTERSCHRIFT("spendenbescheinigung_unterschrift"), //
   ZEILE1("spendenbescheinigung_zeile1"), //
   ZEILE2("spendenbescheinigung_zeile2"), //
   ZEILE3("spendenbescheinigung_zeile3"), //

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -422,6 +422,13 @@ public class FormularAufbereitung
       float sz = mm2point(Einstellungen.getEinstellung().getQRCodeSizeInMm());
       contentByte.addImage(i, sz, 0, 0, sz, x, y);
     }
+    else if (val instanceof com.itextpdf.text.Image)
+    {
+      com.itextpdf.text.Image i = (com.itextpdf.text.Image) val;
+      float sh = i.getScaledHeight();
+      float sw = i.getScaledWidth();
+      contentByte.addImage(i, sw, 0, 0, sh, x, y);
+    }
     else
     {
       buendig = links;

--- a/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
+++ b/src/de/jost_net/JVerein/rmi/Spendenbescheinigung.java
@@ -98,6 +98,16 @@ public interface Spendenbescheinigung extends DBObject
   public boolean isSammelbestaetigung() throws RemoteException;
 
   /**
+   * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine echte
+   * Geldspende ist. Dies ist der Fall, wenn es sich um eine Gelspende handelt
+   * bei der bei keiner Buchung das Flag Erstattungsverzicht gesetzt ist.
+   * 
+   * @return Flag, ob echte Geldspende
+   * @throws RemoteException
+   */
+  public boolean isEchteGeldspende() throws RemoteException;
+
+  /**
    * Fügt der Liste der Buchungen eine Buchung hinzu. Der Gesamtbetrag der
    * Spendenbescheinigung wird anhand der Einzelbeträge der Buchungen berechnet.
    * Die Spendenart wird auf "GELDSPENDE" gesetzt.


### PR DESCRIPTION
Es lässt sich jetzt die Unterschrift in die Formulare plazieren.
Sie wird aber nur bei Geldspenden ohne Erstattungsverzicht gedruckt.