### PR TITLE
Build check

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -34,7 +34,9 @@ jobs:
 
     - name: Build jameica nightly
       working-directory: ./
-      run: ant -noinput -buildfile jameica/build/build.xml nightly
+      run: |
+        ant -noinput -buildfile jameica/build/build.xml jar
+        find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
 
     - name: Check out hibiscus
       uses: actions/checkout@v4
@@ -44,7 +46,9 @@ jobs:
 
     - name: Build hibiscus nightly
       working-directory: ./
-      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
+      run: |
+        ant -noinput -buildfile hibiscus/build/build.xml jar
+        find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
 
     - name: Checkout openjverein
       id: openjverein_checkout

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -1,0 +1,58 @@
+# This workflow will build a Java project with Ant
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+
+name: openjverein build check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    paths:
+      - 'plugin.xml'
+      - 'build/**'
+      - 'lib/**'
+      - 'lib.src/**'
+      - 'src/**'
+jobs:
+  build:
+    name: Try to build a nightly release incorporating the current pull request
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 11 for x64
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        architecture: x64
+
+    - name: Check out jameica
+      uses: actions/checkout@v4
+      with:
+        repository: willuhn/jameica
+        path: jameica
+
+    - name: Build jameica nightly
+      working-directory: ./
+      run: ant -noinput -buildfile jameica/build/build.xml nightly
+
+    - name: Check out hibiscus
+      uses: actions/checkout@v4
+      with:
+        repository: willuhn/hibiscus
+        path: hibiscus
+
+    - name: Build hibiscus nightly
+      working-directory: ./
+      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
+
+    - name: Checkout openjverein
+      id: openjverein_checkout
+      uses: actions/checkout@v4
+      with:
+        path: jverein
+
+    - name: Build openjverein plugin
+      id: buildtest
+      working-directory: ./
+      run: ant -noinput -buildfile jverein/build/build.xml compile

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -14,7 +14,7 @@ on:
       - 'src/**'
 jobs:
   build:
-    name: Try to build a nightly release incorporating the current pull request
+    name: Try to compile the current pull request
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Build jameica nightly
       working-directory: ./
       run: |
-        ant -noinput -buildfile jameica/build/build.xml jar
+        sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' jameica/build/build.xml
+        ant -noinput -quiet -buildfile jameica/build/build.xml jar
         find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
 
     - name: Check out hibiscus
@@ -47,7 +48,8 @@ jobs:
     - name: Build hibiscus nightly
       working-directory: ./
       run: |
-        ant -noinput -buildfile hibiscus/build/build.xml jar
+        sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' hibiscus/build/build.xml
+        ant -noinput -quiet -buildfile hibiscus/build/build.xml jar
         find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
 
     - name: Checkout openjverein


### PR DESCRIPTION
Wie in [#497 (comment)](https://github.com/openjverein/jverein/pull/497#issuecomment-2504486043) angekündigt, habe ich einen GitHub Actions Workflow erstellt, der beim Erstellen von PRs und pushen von Commits zu einem bestehenden PR ausgeführt wird.

Er prüft, ob sich die Änderungen nach einem Merge kompilieren lassen.

Sollte sich die master branch ändern, müsste der Check eigentlich auch automatisch neu durchgeführt werden. Das konnte ich jedoch noch nicht intensiv testen.

Ich würde gern auch noch Caching einbauen. Das ist jedoch nicht so ganz einfach, da es für ANT keinen vordefinierten Action Cache gibt und wir die jars von jameica und hibiscus selbst bauen. Wobei, mir fällt gerade ein, dass ich die nightly jars ja über den commit hash cachen kann. Das ist jedoch nichts mehr für heute Nacht.