### PR TITLE
Docu Link angepasst

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -24,7 +24,7 @@ public class DokumentationUtil
   
   //private static final String ALLGEMEIN = "allgemein/";
   
-  private static final String FUNKTIONEN = "allgemeine-funktionen/";
+  private static final String FUNKTIONEN = "v2.9.0/";
   
   private static final String ADMIN = "administration/";
   


### PR DESCRIPTION
Ich habe jetzt entsprechend dem Vorschlag die Doku kopiert. Jetzt gibt es eine für 2.8.23 und eine für 2.9.0.
Die Links in der 2.8.23 funkltionieren weiterhin. Die 2.9.0 wird mit diesem PR auf die 2.9.0 Docu verlinkt.
Außerdem habe ich eine Release Note bei 2.9.0 eingefügt. Die muss aber noch vervollständigt werden. Ich bin davon ausgegangen, dass die aktuellen PRs noch rein kommen.

![Bildschirmfoto_20241130_134913](https://github.com/user-attachments/assets/0079416a-72ea-475c-9c75-c9640e44ad99)

Damit kann man auch jetzt schon während der Entwicklung der 2.9.0 die entsprechende Docu in Git einpflegen.
