### PR TITLE
Vor Zurueck Buttons für Date Inputs in Listen Views

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -318,7 +318,7 @@ public class SollbuchungQuery
     {
       sql.append(" WHERE ").append(where);
     }
-    sql.append(" GROUP BY mitgliedskonto.id");
+    sql.append(" GROUP BY mitgliedskonto.id, mitgliedskonto.betrag");
 
     if (DIFFERENZ.FEHLBETRAG == diff)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -60,6 +60,7 @@ import de.jost_net.JVerein.gui.menu.BuchungMenu;
 import de.jost_net.JVerein.gui.menu.SplitBuchungMenu;
 import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
 import de.jost_net.JVerein.gui.parts.SplitbuchungListTablePart;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.gui.util.AfaUtil;
 import de.jost_net.JVerein.io.BuchungAuswertungCSV;
 import de.jost_net.JVerein.io.BuchungAuswertungPDF;
@@ -2197,9 +2198,9 @@ public class BuchungsControl extends AbstractControl
     return settingsprefix;
   }
 
-  public Button getZurueckButton()
+  public ToolTipButton getZurueckButton()
   {
-    return new Button("", new Action()
+    return new ToolTipButton("", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -2242,9 +2243,9 @@ public class BuchungsControl extends AbstractControl
     }, null, false, "go-previous.png");
   }
 
-  public Button getVorButton()
+  public ToolTipButton getVorButton()
   {
-    return new Button("", new Action()
+    return new ToolTipButton("", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -18,6 +18,9 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -148,6 +151,13 @@ public class FilterControl extends AbstractControl
   
   protected IntegerNullInput integerausw = null;
   
+  private Calendar calendar = Calendar.getInstance();
+
+  private enum RANGE
+  {
+    MONAT, TAG
+  }
+
   public enum Mitgliedstyp {
     MITGLIED,
     NICHTMITGLIED,
@@ -1576,6 +1586,111 @@ public class FilterControl extends AbstractControl
     else
     {
       settings.setAttribute(settingsprefix + setting, "");
+    }
+  }
+  
+  public Button getZurueckButton(DateInput vonDatum, DateInput bisDatum)
+  {
+    return new Button("", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        Date von = (Date) vonDatum.getValue();
+        Date bis = (Date) bisDatum.getValue();
+        if (getRangeTyp(von, bis) == RANGE.TAG)
+        {
+          int delta = (int) ChronoUnit.DAYS.between(von.toInstant(), bis.toInstant());
+          delta++;
+          calendar.setTime(von);
+          calendar.add(Calendar.DAY_OF_MONTH, -delta);
+          vonDatum.setValue(calendar.getTime());
+          calendar.setTime(bis);
+          calendar.add(Calendar.DAY_OF_MONTH, -delta);
+          bisDatum.setValue(calendar.getTime());
+        }
+        else
+        {
+          LocalDate lvon = von.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+          LocalDate lbis = bis.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+          int delta = (int) ChronoUnit.MONTHS.between(lvon, lbis);
+          delta++;
+          calendar.setTime(von);
+          calendar.add(Calendar.MONTH, -delta);
+          vonDatum.setValue(calendar.getTime());
+          calendar.add(Calendar.MONTH, delta);
+          calendar.add(Calendar.DAY_OF_MONTH, -1);
+          bisDatum.setValue(calendar.getTime());
+        }
+        TabRefresh();
+      }
+    }, null, false, "go-previous.png");
+  }
+
+  public Button getVorButton(DateInput vonDatum, DateInput bisDatum)
+  {
+    return new Button("", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        Date von = (Date) vonDatum.getValue();
+        Date bis = (Date) bisDatum.getValue();
+        if (getRangeTyp(von, bis) == RANGE.TAG)
+        {
+          int delta = (int) ChronoUnit.DAYS.between(von.toInstant(), bis.toInstant());
+          delta++;
+          calendar.setTime(von);
+          calendar.add(Calendar.DAY_OF_MONTH, delta);
+          vonDatum.setValue(calendar.getTime());
+          calendar.setTime(bis);
+          calendar.add(Calendar.DAY_OF_MONTH, delta);
+          bisDatum.setValue(calendar.getTime());
+        }
+        else
+        {
+          LocalDate lvon = von.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+          LocalDate lbis = bis.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+          int delta = (int) ChronoUnit.MONTHS.between(lvon, lbis);
+          delta++;
+          calendar.setTime(von);
+          calendar.add(Calendar.MONTH, delta);
+          vonDatum.setValue(calendar.getTime());
+          calendar.add(Calendar.MONTH, delta);
+          calendar.add(Calendar.DAY_OF_MONTH, -1);
+          bisDatum.setValue(calendar.getTime());
+        }
+        TabRefresh();
+      }
+    }, null, false, "go-next.png");
+  }
+
+  private RANGE getRangeTyp(Date von, Date bis) throws ApplicationException
+  {
+    checkDate(von, bis);
+    calendar.setTime(von);
+    if (calendar.get(Calendar.DAY_OF_MONTH) != 1)
+      return RANGE.TAG;
+    calendar.setTime(bis);
+    calendar.add(Calendar.DAY_OF_MONTH, 1);
+    if (calendar.get(Calendar.DAY_OF_MONTH) != 1)
+      return RANGE.TAG;
+    return RANGE.MONAT;
+  }
+  
+  private void checkDate(Date von, Date bis) throws ApplicationException
+  {
+    if (von == null)
+    {
+      throw new ApplicationException("Bitte Von Datum eingeben!");
+    }
+    if (bis == null)
+    {
+      throw new ApplicationException("Bitte Bis Datum eingeben!");
+    }
+    if (von.after(bis))
+    {
+      throw new ApplicationException("Von Datum ist nach Bis Datum!");
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -39,6 +39,7 @@ import de.jost_net.JVerein.gui.dialogs.ZusatzfelderAuswahlDialog;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Adresstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
@@ -1589,9 +1590,9 @@ public class FilterControl extends AbstractControl
     }
   }
   
-  public Button getZurueckButton(DateInput vonDatum, DateInput bisDatum)
+  public ToolTipButton getZurueckButton(DateInput vonDatum, DateInput bisDatum)
   {
-    return new Button("", new Action()
+    return new ToolTipButton("", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -1627,9 +1628,9 @@ public class FilterControl extends AbstractControl
     }, null, false, "go-previous.png");
   }
 
-  public Button getVorButton(DateInput vonDatum, DateInput bisDatum)
+  public ToolTipButton getVorButton(DateInput vonDatum, DateInput bisDatum)
   {
-    return new Button("", new Action()
+    return new ToolTipButton("", new Action()
     {
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/parts/ToolTipButton.java
+++ b/src/de/jost_net/JVerein/gui/parts/ToolTipButton.java
@@ -1,0 +1,24 @@
+package de.jost_net.JVerein.gui.parts;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.parts.Button;
+
+public class ToolTipButton extends Button
+{
+  /**
+   * @param title
+   *          Beschriftung.
+   * @param action
+   *          Action, die beim Klick ausgefuehrt werden soll.
+   */
+  public ToolTipButton(String title, Action action, Object context,
+      boolean defaultButton, String icon)
+  {
+    super(title, action, context, defaultButton, icon);
+  }
+
+  public void setToolTipText(String text)
+  {
+    this.button.setToolTipText(text);
+  }
+}

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
@@ -46,6 +46,10 @@ public class AbrechnungslaufListView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.AbrechnungSEPAAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AbrechnungslaufControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -46,13 +47,17 @@ public class AbrechnungslaufListView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getAbrechnungslaeufeList().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
@@ -48,6 +48,10 @@ public class AnfangsbestandListView extends AbstractView
     right.addInput(control.getDatumbis());
 
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandListView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.AnfangsbestandNeuAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AnfangsbestandControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -48,13 +49,17 @@ public class AnfangsbestandListView extends AbstractView
     right.addInput(control.getDatumbis());
 
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getAnfangsbestandList().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungenListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungenListeView.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.gui.action.BuchungNeuAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenart;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.gui.control.BuchungsHeaderControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -67,13 +68,15 @@ public class AnlagenbuchungenListeView extends AbstractView
     left.addLabelPair("Buchungsart", control.getSuchBuchungsart());
     left.addLabelPair("Projekt", control.getSuchProjekt());
     left.addLabelPair("Betrag", control.getSuchBetrag());
-    right.addLabelPair("Von Datum", control.getVondatum());
-    right.addLabelPair("Bis Datum", control.getBisdatum());
+    right.addLabelPair("Datum von", control.getVondatum());
+    right.addLabelPair("Datum bis", control.getBisdatum());
     right.addLabelPair("Enthaltener Text", control.getSuchtext());
     
     ButtonArea buttons1 = new ButtonArea();
-    buttons1.addButton(control.getZurueckButton());
-    buttons1.addButton(control.getVorButton());
+    ToolTipButton zurueck = control.getZurueckButton();
+    buttons1.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton();
+    buttons1.addButton(vor);
     Button reset = new Button("Filter-Reset", new Action()
     {
       @Override
@@ -94,6 +97,8 @@ public class AnlagenbuchungenListeView extends AbstractView
     }, null, true, "search.png");
     buttons1.addButton(suchen);
     labelgroup1.addButtonArea(buttons1);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     // Zweiter Tab
     final BuchungsHeaderControl headerControl = new BuchungsHeaderControl(

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
@@ -49,6 +49,10 @@ public class ArbeitseinsatzListeView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.gui.action.ArbeitseinsatzAction;
 import de.jost_net.JVerein.gui.action.ArbeitseinsatzUeberpruefungAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.ArbeitseinsatzControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -49,13 +50,17 @@ public class ArbeitseinsatzListeView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getArbeitseinsatzTable().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungslisteView.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.gui.action.BuchungsuebernahmeAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenart;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.gui.control.BuchungsHeaderControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -68,14 +69,16 @@ public class BuchungslisteView extends AbstractView
     left.addLabelPair("Projekt", control.getSuchProjekt());
     left.addLabelPair("Betrag", control.getSuchBetrag());
     left.addLabelPair("Mitglied zugeordnet?", control.getSuchMitgliedZugeordnet());
-    right.addLabelPair("Von Datum", control.getVondatum());
-    right.addLabelPair("Bis Datum", control.getBisdatum());
+    right.addLabelPair("Datum von", control.getVondatum());
+    right.addLabelPair("Datum bis", control.getBisdatum());
     right.addLabelPair("Enthaltener Text", control.getSuchtext());
     right.addLabelPair("Mitglied Name", control.getMitglied());
     
     ButtonArea buttons1 = new ButtonArea();
-    buttons1.addButton(control.getZurueckButton());
-    buttons1.addButton(control.getVorButton());
+    ToolTipButton zurueck = control.getZurueckButton();
+    buttons1.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton();
+    buttons1.addButton(vor);
     Button reset = new Button("Filter-Reset", new Action()
     {
       @Override
@@ -96,6 +99,8 @@ public class BuchungslisteView extends AbstractView
     }, null, true, "search.png");
     buttons1.addButton(suchen);
     labelgroup1.addButtonArea(buttons1);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     // Zweiter Tab
     final BuchungsHeaderControl headerControl = new BuchungsHeaderControl(

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
@@ -70,8 +70,16 @@ public class KursteilnehmerSucheView extends AbstractView
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addInput(control.getAbbuchungsdatumvon());
     right.addInput(control.getAbbuchungsdatumbis());
-    
+
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getZurueckButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis()));
+    fbuttons.addButton(control.getVorButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis()));
+    fbuttons.addButton(control.getZurueckButton(control.getAbbuchungsdatumvon(),
+        control.getAbbuchungsdatumbis()));
+    fbuttons.addButton(control.getVorButton(control.getAbbuchungsdatumvon(),
+        control.getAbbuchungsdatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerSucheView.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.KursteilnehmerDetailAction;
 import de.jost_net.JVerein.gui.control.KursteilnehmerControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.AbstractView;
@@ -72,17 +73,25 @@ public class KursteilnehmerSucheView extends AbstractView
     right.addInput(control.getAbbuchungsdatumbis());
 
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(control.getZurueckButton(control.getEingabedatumvon(),
-        control.getEingabedatumbis()));
-    fbuttons.addButton(control.getVorButton(control.getEingabedatumvon(),
-        control.getEingabedatumbis()));
-    fbuttons.addButton(control.getZurueckButton(control.getAbbuchungsdatumvon(),
-        control.getAbbuchungsdatumbis()));
-    fbuttons.addButton(control.getVorButton(control.getAbbuchungsdatumvon(),
-        control.getAbbuchungsdatumbis()));
+    ToolTipButton zurueck1 = control.getZurueckButton(
+        control.getEingabedatumvon(), control.getEingabedatumbis());
+    fbuttons.addButton(zurueck1);
+    ToolTipButton vor1 = control.getVorButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis());
+    fbuttons.addButton(vor1);
+    ToolTipButton zurueck2 = control.getZurueckButton(
+        control.getAbbuchungsdatumvon(), control.getAbbuchungsdatumbis());
+    fbuttons.addButton(zurueck2);
+    ToolTipButton vor2 = control.getVorButton(control.getAbbuchungsdatumvon(),
+        control.getAbbuchungsdatumbis());
+    fbuttons.addButton(vor2);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck1.setToolTipText("Eingabe Datumsbereich zurück");
+    vor1.setToolTipText("Eingabe Datumsbereich vowärts");
+    zurueck2.setToolTipText("Abbuchung Datumsbereich zurück");
+    vor2.setToolTipText("Abbuchung Datumsbereich vowärts");
 
     if (anzahl.longValue() > 0)
     {

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.LastschriftControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -49,13 +50,17 @@ public class LastschriftListeView extends AbstractView
     right.addLabelPair("Abrechnungslauf ab", control.getIntegerAusw());
 
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
     
     control.getLastschriftList().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -47,8 +47,12 @@ public class LastschriftListeView extends AbstractView
     right.addLabelPair("Fälligkeit von", control.getDatumvon());
     right.addLabelPair("Fälligkeit bis", control.getDatumbis());
     right.addLabelPair("Abrechnungslauf ab", control.getIntegerAusw());
-    
+
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/LehrgaengeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgaengeListeView.java
@@ -48,6 +48,10 @@ public class LehrgaengeListeView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/LehrgaengeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgaengeListeView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.LehrgangAction;
 import de.jost_net.JVerein.gui.control.LehrgangControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -48,13 +49,17 @@ public class LehrgaengeListeView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getLehrgaengeList().paint(this.getParent());
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.RechnungAutoNeuAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -51,13 +52,17 @@ public class RechnungListeView extends AbstractView
     right.addInput(control.getMailauswahl());
     
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getRechnungList().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
@@ -51,6 +51,10 @@ public class RechnungListeView extends AbstractView
     right.addInput(control.getMailauswahl());
     
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.gui.action.SollbuchungEditAction;
 import de.jost_net.JVerein.gui.action.SollbuchungExportAction.EXPORT_TYP;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.menu.SollbuchungMenu;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -55,13 +56,17 @@ public class SollbuchungListeView extends AbstractView
     right.addInput(control.getMailauswahl());
 
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
 
     control.getMitgliedskontoList(new SollbuchungEditAction(),
         new SollbuchungMenu(), false).paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -55,6 +55,10 @@ public class SollbuchungListeView extends AbstractView
     right.addInput(control.getMailauswahl());
 
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAutoNeuAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -55,17 +56,25 @@ public class SpendenbescheinigungListeView extends AbstractView
     right.addLabelPair("Spendedatum bis", control.getEingabedatumbis());
 
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(control.getZurueckButton(control.getEingabedatumvon(),
-        control.getEingabedatumbis()));
-    fbuttons.addButton(control.getVorButton(control.getEingabedatumvon(),
-        control.getEingabedatumbis()));
+    ToolTipButton zurueck1 = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck1);
+    ToolTipButton vor1 = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor1);
+    ToolTipButton zurueck2 = control.getZurueckButton(
+        control.getEingabedatumvon(), control.getEingabedatumbis());
+    fbuttons.addButton(zurueck2);
+    ToolTipButton vor2 = control.getVorButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis());
+    fbuttons.addButton(vor2);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck1.setToolTipText("Bescheinigung Datumsbereich zurück");
+    vor1.setToolTipText("Bescheinigung Datumsbereich vowärts");
+    zurueck2.setToolTipText("Spende Datumsbereich zurück");
+    vor2.setToolTipText("Spende Datumsbereich vowärts");
 
     control.getSpendenbescheinigungList().paint(this.getParent());
 

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -53,8 +53,16 @@ public class SpendenbescheinigungListeView extends AbstractView
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addLabelPair("Spendedatum von", control.getEingabedatumvon());
     right.addLabelPair("Spendedatum bis", control.getEingabedatumbis());
-    
+
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(control.getZurueckButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis()));
+    fbuttons.addButton(control.getVorButton(control.getEingabedatumvon(),
+        control.getEingabedatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlagelisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlagelisteView.java
@@ -48,6 +48,10 @@ public class WiedervorlagelisteView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(
+        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
+    fbuttons.addButton(
+        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlagelisteView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlagelisteView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.WiedervorlageAction;
 import de.jost_net.JVerein.gui.control.WiedervorlageControl;
+import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -48,13 +49,17 @@ public class WiedervorlagelisteView extends AbstractView
     right.addInput(control.getDatumbis());
     
     ButtonArea fbuttons = new ButtonArea();
-    fbuttons.addButton(
-        control.getZurueckButton(control.getDatumvon(), control.getDatumbis()));
-    fbuttons.addButton(
-        control.getVorButton(control.getDatumvon(), control.getDatumbis()));
+    ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(zurueck);
+    ToolTipButton vor = control.getVorButton(control.getDatumvon(),
+        control.getDatumbis());
+    fbuttons.addButton(vor);
     fbuttons.addButton(control.getResetButton());
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
+    zurueck.setToolTipText("Datumsbereich zurück");
+    vor.setToolTipText("Datumsbereich vowärts");
     
     control.getWiedervorlageList().paint(this.getParent());
     ButtonArea buttons = new ButtonArea();


### PR DESCRIPTION
Ich habe jetzt auch noch in anderen Liste Views die Vor/Zurück Buttons für Date Inputs eingebaut. Ich fand es ganz praktisch wenn man Zeiträume einstellen kann und dann einfach vor und zurück blättern kann.
Bei Buchungen hatte ich das ja auch schon eingebaut.
![Bildschirmfoto_20241204_141750](https://github.com/user-attachments/assets/659102b0-2139-4b25-844e-e464f1762edf)

Bei Liste Views mit zwei Date Input Paaren habe ich die Pfeile doppelt plaziert. Die ersten beiden sind für das linke Paar und die anderen für das rechte Paar.
![Bildschirmfoto_20241204_141808](https://github.com/user-attachments/assets/32289709-0bf1-4169-b37e-2cad2595b890)

Dann war da noch ein Problem beim SollbuchungQuery. Die DB wollte da noch mitgliedskonto.betrag im group by haben.
