### PR TITLE
nightly und build check action auf JDK17 erhöhen

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up JDK 11 for x64
+    - name: Set up JDK for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         architecture: x64
 

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Set up JDK 11 for x64
+    - name: Set up JDK for x64
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         architecture: x64
 


### PR DESCRIPTION
Dieser PR ist eine schnelle Lösung für das Problem, dass der nightly build von jameica nun JDK 17 benötigt.

Für OpenJVerein hat das keine Auswirkungen, da wir explizit für Java-Version 11 builds erzeugen. Siehe

https://github.com/openjverein/jverein/blob/dc822f8dbf2ae9830660253424060d8466ac8bae/build/build.properties#L12 und 
https://github.com/openjverein/jverein/blob/dc822f8dbf2ae9830660253424060d8466ac8bae/build/build.xml#L57

Das es funktioniert, sieht man hier: https://github.com/tolot27/jverein/actions/runs/12167194274