### PR TITLE
Workflows: Use 2.10 branches and Java 11

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up JDK for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
@@ -31,8 +31,9 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
-    - name: Build jameica nightly
+    - name: Build jameica jar
       working-directory: ./
       run: |
         sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' jameica/build/build.xml
@@ -44,8 +45,9 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
-    - name: Build hibiscus nightly
+    - name: Build hibiscus jar
       working-directory: ./
       run: |
         sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' hibiscus/build/build.xml

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
     - name: Set up JDK for x64
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
@@ -29,6 +29,7 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
     - name: Build jameica nightly
       working-directory: ./
@@ -39,6 +40,7 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
     - name: Build hibiscus nightly
       working-directory: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Set up JDK 11 for x64
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -24,6 +24,7 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
     - name: Build jameica nightly
       working-directory: ./
@@ -34,6 +35,7 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
     - name: Build hibiscus nightly
       working-directory: ./


### PR DESCRIPTION
- github actions von v3 auf v4 aktualisiert
- jameica und hibiscus 2.10 branches als ref im checkout anstatt der master (2.11) branches
- Java 17 auf Java 11 umgestellt

Löst den https://github.com/openjverein/jverein/pull/515 ab und behebt https://github.com/openjverein/jverein/issues/516