### PR TITLE
OpenJVerein 2.9.0 and set action checkout to 2 10

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -26,18 +26,25 @@ jobs:
         distribution: 'temurin'
         architecture: x64
 
+    - name: Set env
+      id: setenvs
+      run: |
+        jameica_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/jameica.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "jameica_tag=${jameica_tag}" >> $GITHUB_OUTPUT
+        hibiscus_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/hibiscus.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_OUTPUT
+
     - name: Check out jameica
       uses: actions/checkout@v4
       with:
         repository: willuhn/jameica
         path: jameica
-        ref: 'JAMEICA_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.jameica_tag }}
 
     - name: Build jameica jar
       working-directory: ./
       run: |
-        sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' jameica/build/build.xml
-        ant -noinput -quiet -buildfile jameica/build/build.xml jar
+        ant -noinput -buildfile jameica/build/build.xml jar
         find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
 
     - name: Check out hibiscus
@@ -45,7 +52,7 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
-        ref: 'HIBISCUS_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.hibiscus_tag }}
 
     - name: Build hibiscus jar
       working-directory: ./

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up JDK for x64
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
@@ -31,8 +31,9 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
-    - name: Build jameica nightly
+    - name: Build jameica jar
       working-directory: ./
       run: |
         sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' jameica/build/build.xml
@@ -44,8 +45,9 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
-    - name: Build hibiscus nightly
+    - name: Build hibiscus jar
       working-directory: ./
       run: |
         sed -i -r 's/deprecation="(true|on)"/deprecation="off"/g' hibiscus/build/build.xml

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -24,27 +24,39 @@ jobs:
         distribution: 'temurin'
         architecture: x64
 
+    - name: Set env
+      id: setenvs
+      run: |
+        jameica_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/jameica.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "jameica_tag=${jameica_tag}" >> $GITHUB_OUTPUT
+        hibiscus_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/hibiscus.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_OUTPUT
+
     - name: Check out jameica
       uses: actions/checkout@v4
       with:
         repository: willuhn/jameica
         path: jameica
-        ref: 'JAMEICA_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.jameica_tag }}
 
-    - name: Build jameica nightly
+    - name: Build jameica jar
       working-directory: ./
-      run: ant -noinput -buildfile jameica/build/build.xml nightly
+      run: |
+        ant -noinput -buildfile jameica/build/build.xml jar
+        find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
 
     - name: Check out hibiscus
       uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
         path: hibiscus
-        ref: 'HIBISCUS_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.hibiscus_tag }}
 
-    - name: Build hibiscus nightly
+    - name: Build hibiscus jar
       working-directory: ./
-      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
+      run: |
+        ant -noinput -buildfile hibiscus/build/build.xml jar
+        find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
 
     - name: Checkout openjverein
       id: openjverein_checkout
@@ -75,7 +87,7 @@ jobs:
         text="${text%${ssb}*}.zip"
         tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
-        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+        echo "selected_version=$tmp_version" >> $GITHUB_OUTPUT
         echo "selected_filename=$tmp_filename" >> $GITHUB_OUTPUT
         echo "selected_path=$tmp_path" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
     - name: Set up JDK for x64
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '11'
         distribution: 'temurin'
         architecture: x64
 
@@ -29,6 +29,7 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
     - name: Build jameica nightly
       working-directory: ./
@@ -39,6 +40,7 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
     - name: Build hibiscus nightly
       working-directory: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,33 +19,39 @@ jobs:
         distribution: 'temurin'
         architecture: x64
 
+    - name: Set env
+      id: setenvs
+      run: |
+        jameica_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/jameica.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "jameica_tag=${jameica_tag}" >> $GITHUB_OUTPUT
+        hibiscus_tag=`git ls-remote --refs --tags --sort="-v:refname"  https://github.com/willuhn/hibiscus.git V_\* | head -1 | cut -f 2 | cut -d / -f 3`
+        echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_OUTPUT
+
     - name: Check out jameica
       uses: actions/checkout@v4
       with:
         repository: willuhn/jameica
         path: jameica
-        ref: 'JAMEICA_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.jameica_tag }}
 
-    - name: Build jameica nightly
+    - name: Build jameica jar
       working-directory: ./
-      run: ant -noinput -buildfile jameica/build/build.xml nightly
+      run: |
+        ant -noinput -buildfile jameica/build/build.xml jar
+        find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
 
     - name: Check out hibiscus
       uses: actions/checkout@v4
       with:
         repository: willuhn/hibiscus
         path: hibiscus
-        ref: 'HIBISCUS_2_10_BRANCH'
+        ref: ${{ steps.setenvs.outputs.hibiscus_tag }}
 
-    - name: Build hibiscus nightly
+    - name: Build hibiscus jar
       working-directory: ./
-      run: ant -noinput -buildfile hibiscus/build/build.xml nightly
-
-    - name: Checkout openjverein
-      id: openjverein_checkout
-      uses: actions/checkout@v4
-      with:
-        path: jverein
+      run: |
+        ant -noinput -buildfile hibiscus/build/build.xml jar
+        find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
 
     - name: Build openjverein plugin
       id: openjverein
@@ -71,7 +77,7 @@ jobs:
         text="${text%${ssb}*}.zip"
         tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
-        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+        echo "selected_version=$tmp_version" >> $GITHUB_OUTPUT
         echo "selected_filename=$tmp_filename" >> $GITHUB_OUTPUT
         echo "selected_path=$tmp_path" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Set up JDK 11 for x64
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -24,6 +24,7 @@ jobs:
       with:
         repository: willuhn/jameica
         path: jameica
+        ref: 'JAMEICA_2_10_BRANCH'
 
     - name: Build jameica nightly
       working-directory: ./
@@ -34,6 +35,7 @@ jobs:
       with:
         repository: willuhn/hibiscus
         path: hibiscus
+        ref: 'HIBISCUS_2_10_BRANCH'
 
     - name: Build hibiscus nightly
       working-directory: ./

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="https://www.willuhn.de/schema/jameica-plugin"
         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.willuhn.de/schema/jameica-plugin https://www.willuhn.de/schema/jameica-plugin-1.5.xsd"
-        name="jverein" version="2.8.24" class="de.jost_net.JVerein.JVereinPlugin">
+        name="jverein" version="2.9.0" class="de.jost_net.JVerein.JVereinPlugin">
 
   <description>OpenSource-Vereinsverwaltung</description>
   <url>https://openjverein.github.io/jameica-repository/[PLUGIN_ZIP]</url>


### PR DESCRIPTION
Neuer Versuch. Folgende Änderungen:

- OpenJVerein Version 2.8.24 > 2.9.0 
https://github.com/openjverein/jverein/discussions/482#discussioncomment-11452939
- workflow action laden neueste Jameica und Hibiscus 2.10 tags
https://github.com/openjverein/jverein/issues/516#issuecomment-2518784877
Testlauf: https://github.com/dippeal/jverein/actions/runs/12195976142/job/34022665419
- workflow Java SDK 17 > 11
- jameica und hibiscus nightly build > jar build

Ob Java 17 oder 11 genutzt werden soll muss noch bestimmt werden (https://github.com/openjverein/jverein/issues/516#issuecomment-2520195773). Anschließend sollten wir einheitlich die Version in allen workflows/actions einstellen.