### PR TITLE
Mitgliedskonto betrag auf null checken

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -346,7 +346,12 @@ public class MitgliedskontoImpl extends AbstractDBObject implements
   @Override
   public Double getBetrag() throws RemoteException
   {
-    return (Double) getAttribute("betrag");
+    Double d = (Double) getAttribute("betrag");
+    if (d == null)
+    {
+      return 0.0d;
+    }
+    return d;
   }
 
   @Override


### PR DESCRIPTION
Es kam zur exeption wenn im Mitgliedkonto ein Betrag null war.
siehe https://www.jverein-forum.de/viewtopic.php?p=20094