### PR TITLE
Change cache key from workflow_sha to repository_id

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -28,7 +28,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.workflow_sha }}
+        key: ${{ runner.os }}-${{ github.repository_id }}
 
     - name: Checkout openjverein
       uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.workflow_sha }}
+        key: ${{ runner.os }}-${{ github.repository_id }}
 
     - name: Checkout openjverein
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.workflow_sha }}
+        key: ${{ runner.os }}-${{ github.repository_id }}
 
     - name: Checkout openjverein
       uses: actions/checkout@v4

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -31,7 +31,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.workflow_sha }}
+        key: ${{ runner.os }}-${{ github.repository_id }}
 
     - name: Load cached tags
       id: load-cache
@@ -94,4 +94,4 @@ jobs:
             ./cached-tags
             jameica
             hibiscus
-        key: ${{ runner.os }}-${{ github.workflow_sha }}
+        key: ${{ runner.os }}-${{ github.repository_id }}


### PR DESCRIPTION
Der workflow_sha verhält sich anders als ich verstanden habe. Um die Cache korrekt nutzen zu können wird nun die repository_id genutzt, welche sich nicht ändert. Die Aktualisierung der Cache wird durch neue jameica/hibiscus tags getriggert.