### PR TITLE
Fix Splitbuchungen editieren

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -290,27 +290,42 @@ public class BuchungsControl extends AbstractControl
     {
       return dependent_buchungen;
     }
-
+    boolean isSteuerBuchung = false;
     // Falls noch nichts erzeugt wurde, neue Liste erzeugen und DependencyId setzen!
     dependent_buchungen = new ArrayList<Buchung>();
-    if (getBuchung().getDependencyId() == -1) {
+    if (getBuchung().getDependencyId() == -1)
+    {
       Buchung new_dependent_buchung = (Buchung) Einstellungen.getDBService()
-        .createObject(Buchung.class, null);
+          .createObject(Buchung.class, null);
       getBuchung().setDependencyId(SplitbuchungsContainer.getNewDependencyId());
       new_dependent_buchung.setDependencyId(getBuchung().getDependencyId());
       dependent_buchungen.add(new_dependent_buchung);
     }
     // Falls DependencyId vorhanden ist, alle anderen Elemente mit gleicher Id raussuchen
-    else {
+    // Ein Container wird nicht für die Steuerbuchungen generiert, sonst werden zugehörige
+    // Buchungen gelöscht
+    else
+    {
       int pos_b = SplitbuchungsContainer.get().indexOf(getBuchung());
-      for (Buchung b_tmp : SplitbuchungsContainer.get()) {
+      Double buchungBetrag = Math.abs(getBuchung().getBetrag());
+      for (Buchung b_tmp : SplitbuchungsContainer.get())
+      {
         if (b_tmp.getDependencyId() == getBuchung().getDependencyId() && 
-            SplitbuchungsContainer.get().indexOf(b_tmp) != pos_b) {
+            SplitbuchungsContainer.get().indexOf(b_tmp) != pos_b)
+        {
+          if (Math.abs(b_tmp.getBetrag()) > buchungBetrag)
+          {
+            // Das ist eine Steuerbuchung
+            isSteuerBuchung = true;
+            dependent_buchungen = new ArrayList<Buchung>();
+            break;
+          }
           dependent_buchungen.add(b_tmp);
         }
       }
     }
-    if (dependent_buchungen.size() == 0) {
+    if (dependent_buchungen.size() == 0 && !isSteuerBuchung)
+    {
       throw new RemoteException("Buchungen mit Id " + getBuchung().getDependencyId() + " konnten nicht gefunden werden!");
     }
     return dependent_buchungen;
@@ -967,7 +982,9 @@ public class BuchungsControl extends AbstractControl
       {
         b.plausi();
         Buchungsart b_art = b.getBuchungsart();
-        if (b_art.getSteuersatz() > 0) {
+        // Keine Steuer Buchungen erzeugen beim Speichern einer Haupt- bzw. Gegenbuchung
+        if (b.getSplitTyp() == SplitbuchungTyp.SPLIT && b_art.getSteuersatz() > 0)
+        {
           Buchung b_steuer = getDependentBuchungen().get(0);     
           fillBuchung(b_steuer);
 
@@ -996,10 +1013,12 @@ public class BuchungsControl extends AbstractControl
           SplitbuchungsContainer.add(b);
           SplitbuchungsContainer.add(b_steuer);
         }
-        else {
+        else
+        {
           // Falls vorher abhängige Buchungen erzeugt wurden, nun dies aber durch ändern der Buchungsart o.ä. aufgehoben wird, 
           // alle abhängigen Buchungen löschen und Abhängigkeit resetten
-          if (b.getDependencyId() != -1) {
+          if (b.getDependencyId() != -1 && getDependentBuchungen().size() > 0)
+          {
             for (Buchung b_tmp : getDependentBuchungen()) {
               b_tmp.setDependencyId(-1);
               b_tmp.setDelete(true);


### PR DESCRIPTION
Das ist eine Fix für #533 

Es gab verschiedene Fehler in der vorhandenen Implementierung.
- Wird eine Splitbuchung gespeichert wurde bei Steuersatz > 0 eine Steuerbuchung erzeugt wenn sie nicht schon existiert hat. Das gleiche passiert beim editieren. Es wurde aber auch beim editieren der Haupt- und Gegenbuchung eine Steuerbuchung erzeugt. Das passiert jetzt nur noch bei Splitbuchungen
- Hat man eine Splitbuchung editiert wird geprüft ob es abhängige Steuerbuchungen gibt. Diese werden als zu löschen markiert wenn die Splitbuchung keinen Steuersatz > 0 mehr hat. Das Problem war aber wenn man eine Steuerbuchung editiert hat. Da ihr Steuersatz nicht > 0 ist wurde die zugehörige Splitbuchung zum löschen markiert. Beim editieren von Steuerbuchungen darf man also dependent Buchungen nicht löschen. Es gibt aber kein Flag in der Buchung woran man erkennen könnte ob es sich bei dependent Buchungen um die Buchung selbst oder um die zugehörigen Steuerbuchungen handelt. Ich leite dies jetzt implizit aus dem Betrag der Buchung ab. Die Beträge bei Steuerbuchungen sind ja immer absolut gesehen kleiner als der Betrag der zugehörigen Buchung. Damit scheint es zu funktionieren.