### PR TITLE
Fix_buchungsart

### DIFF
--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -283,6 +283,10 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
     {
       return getSteuerBuchungsart();
     }
+    else if (fieldName.equals("buchungsklasse"))
+    {
+      return getBuchungsklasse();
+    }
     else
     {
       return super.getAttribute(fieldName);


### PR DESCRIPTION
In #535 habe ich noch etwas vergessen. getAttribute muss jetzt die getBuchungsklasse Methode aufrufen sonst funktioniert die Anzeige in der Buchungsart Liste nicht.