### PR TITLE
Zusatzbetrag nur fällige abrechnen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -351,7 +351,7 @@ public class ZusatzbetragControl extends AbstractControl
     while (it.hasNext())
     {
       Zusatzbetrag z = (Zusatzbetrag) it.next();
-      if (!z.isAktiv(new Date()))
+      if (!z.isOffen(new Date()))
       {
         table.removeItem(z);
       }

--- a/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
+++ b/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.rmi;
 
 import java.rmi.RemoteException;
 import java.util.Date;
+
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.willuhn.datasource.rmi.DBObject;
 
@@ -58,6 +59,8 @@ public interface Zusatzbetrag extends DBObject
   public void setAusfuehrung(Date ausfuehrung) throws RemoteException;
 
   public boolean isAktiv(Date datum) throws RemoteException;
+
+  public boolean isOffen(Date datum) throws RemoteException;
 
   public void naechsteFaelligkeit() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -393,7 +393,8 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
 
     // Wenn das Endedatum gesetzt ist und das Ausführungsdatum liegt hinter
     // dem Endedatum: nicht mehr ausführen
-    if (getFaelligkeit().getTime() > datum.getTime())
+    if ((getEndedatum() != null && datum.getTime() >= getEndedatum().getTime())
+        || getFaelligkeit().getTime() > datum.getTime())
     {
       return false;
     }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -329,6 +329,36 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
     return super.getAttribute(fieldName);
   }
 
+  /*
+   * 
+   */
+  @Override
+  public boolean isOffen(Date datum) throws RemoteException
+  {
+    if (!getMitglied().isAngemeldet(datum))
+    {
+      if (!Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
+      {
+        return false;
+      }
+    }
+    // Einmalige Ausführung
+    if (getIntervall().intValue() == IntervallZusatzzahlung.KEIN)
+    {
+      return (getAusfuehrung() == null);
+    }
+
+    // Wenn das Endedatum gesetzt ist und das Fälligkeitsdatum liegt zum oder
+    // hinter
+    // dem Endedatum: nicht mehr ausführen
+    if (getEndedatum() != null
+        && getFaelligkeit().getTime() >= getEndedatum().getTime())
+    {
+      return false;
+    }
+    return true;
+  }
+
   @Override
   public boolean isAktiv(Date datum) throws RemoteException
   {
@@ -345,7 +375,14 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
       // Ist das Ausführungsdatum gesetzt?
       if (getAusfuehrung() == null)
       {
-        return true;
+        if (getFaelligkeit().getTime() <= datum.getTime())
+        {
+          return true;
+        }
+        else
+        {
+          return false;
+        }
       }
       else
       {
@@ -354,11 +391,9 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
       }
     }
 
-    // Wenn das Endedatum gesetzt ist und das Fälligkeitsdatum liegt zum oder
-    // hinter
+    // Wenn das Endedatum gesetzt ist und das Ausführungsdatum liegt hinter
     // dem Endedatum: nicht mehr ausführen
-    if (getEndedatum() != null
-        && getFaelligkeit().getTime() >= getEndedatum().getTime())
+    if (getFaelligkeit().getTime() > datum.getTime())
     {
       return false;
     }


### PR DESCRIPTION
In #410 wurde die Bestimmung der aktiven Zusatzbeträge für die View geändert. Das hatte jedoch auch Einfluss auf die Abrechnung. Da beides nicht kompatibel ist habe ich für die View nun die Funktion isOffen() hinzugefügt und isActiv() zurückgeändert.