### PR TITLE
Mittelverwendung View und Reports

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MittelverwendungListeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MittelverwendungListeAction.java
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.MittelverwendungListeView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+
+public class MittelverwendungListeAction implements Action
+{
+  @Override
+  public void handleAction(Object context)
+  {
+    GUI.startView(MittelverwendungListeView.class.getName(), null);
+  }
+}

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -309,7 +309,6 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput summenAnlagenkonto;
 
-
   private IntegerInput qrcodesize;
 
   private CheckboxInput qrcodeptext;
@@ -335,6 +334,8 @@ public class EinstellungControl extends AbstractControl
   private SelectInput afaort;
 
   private TextInput beitragaltersstufen;
+  
+  private CheckboxInput mittelverwendung;
 
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
@@ -2027,6 +2028,17 @@ public class EinstellungControl extends AbstractControl
     return afaort;
   }
 
+  public CheckboxInput getMittelverwendung() throws RemoteException
+  {
+    if (mittelverwendung != null)
+    {
+      return mittelverwendung;
+    }
+    mittelverwendung = new CheckboxInput(
+        Einstellungen.getEinstellung().getMittelverwendung());
+    return mittelverwendung;
+  }
+
   public void handleStoreAllgemein()
   {
     try
@@ -2114,6 +2126,7 @@ public class EinstellungControl extends AbstractControl
         e.setAfaInJahresabschluss(false);
       else
         e.setAfaInJahresabschluss(true);
+      e.setMittelverwendung((Boolean) mittelverwendung.getValue());
 
       e.store();
       Einstellungen.setEinstellung(e);

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Date;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.FileDialog;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.parts.MittelverwendungList;
+import de.jost_net.JVerein.io.MittelverwendungExportCSV;
+import de.jost_net.JVerein.io.MittelverwendungExportPDF;
+import de.jost_net.JVerein.io.MittelverwendungZeile;
+import de.jost_net.JVerein.util.Dateiname;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.BackgroundTask;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class MittelverwendungControl extends SaldoControl
+{
+
+  private MittelverwendungList saldoList;
+
+  final static String ExportPDF = "PDF";
+
+  final static String ExportCSV = "CSV";
+
+  public MittelverwendungControl(AbstractView view)
+  {
+    super(view);
+  }
+
+  public Button getPDFExportButton()
+  {
+    Button b = new Button("PDF", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        starteExport(ExportPDF);
+      }
+    }, null, false, "file-pdf.png");
+    // button
+    return b;
+  }
+
+  public Button getCSVExportButton()
+  {
+    Button b = new Button("CSV", new Action()
+    {
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
+        starteExport(ExportCSV);
+      }
+    }, null, false, "xsd.png");
+    // button
+    return b;
+  }
+
+  public void handleStore()
+  {
+    //
+  }
+
+  public Part getSaldoList() throws ApplicationException
+  {
+    try
+    {
+      if (getDatumvon().getDate() != null)
+      {
+        settings.setAttribute("von",
+            new JVDateFormatTTMMJJJJ().format(getDatumvon().getDate()));
+        settings.setAttribute("bis",
+            new JVDateFormatTTMMJJJJ().format(getDatumbis().getDate()));
+      }
+
+      if (saldoList == null)
+      {
+        saldoList = new MittelverwendungList(null,
+            datumvon.getDate(), datumbis.getDate());
+      }
+      else
+      {
+        settings.setAttribute("von",
+            new JVDateFormatTTMMJJJJ().format(getDatumvon().getDate()));
+
+        saldoList.setDatumvon(datumvon.getDate());
+        saldoList.setDatumbis(datumbis.getDate());
+        ArrayList<MittelverwendungZeile> zeile = saldoList.getInfo();
+        saldoList.removeAll();
+        for (MittelverwendungZeile sz : zeile)
+        {
+          saldoList.addItem(sz);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException(
+          String.format("Fehler aufgetreten %s", e.getMessage()));
+    }
+    return saldoList.getSaldoList();
+  }
+
+  private void starteExport(String type) throws ApplicationException
+  {
+    try
+    {
+      ArrayList<MittelverwendungZeile> zeilen = saldoList.getInfo();
+
+      FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
+      fd.setText("Ausgabedatei wählen.");
+      //
+      Settings settings = new Settings(this.getClass());
+      //
+      String path = settings.getString("lastdir",
+          System.getProperty("user.home"));
+      if (path != null && path.length() > 0)
+      {
+        fd.setFilterPath(path);
+      }
+      fd.setFileName(new Dateiname("mittelverwendungsrechnung", "",
+          Einstellungen.getEinstellung().getDateinamenmuster(), type).get());
+
+      final String s = fd.open();
+
+      if (s == null || s.length() == 0)
+      {
+        return;
+      }
+
+      final File file = new File(s);
+      settings.setAttribute("lastdir", file.getParent());
+
+      exportSaldo(zeilen, file, getDatumvon().getDate(),
+          getDatumbis().getDate(), type);
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException(
+          String.format("Fehler beim Aufbau des Reports: %s", e.getMessage()));
+    }
+  }
+
+  private void exportSaldo(final ArrayList<MittelverwendungZeile> zeile,
+      final File file, final Date datumvon, final Date datumbis,
+      final String type)
+  {
+    BackgroundTask t = new BackgroundTask()
+    {
+      @Override
+      public void run(ProgressMonitor monitor) throws ApplicationException
+      {
+        try
+        {
+          if (type.equals(ExportCSV))
+            new MittelverwendungExportCSV(zeile, file, datumvon, datumbis);
+          else if (type.equals(ExportPDF))
+            new MittelverwendungExportPDF(zeile, file, datumvon, datumbis);
+          GUI.getCurrentView().reload();
+        }
+        catch (ApplicationException ae)
+        {
+          GUI.getStatusBar().setErrorText(ae.getMessage());
+          throw ae;
+        }
+      }
+
+      @Override
+      public void interrupt()
+      {
+        //
+      }
+
+      @Override
+      public boolean isInterrupted()
+      {
+        return false;
+      }
+    };
+    Application.getController().start(t);
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -40,6 +40,7 @@ import de.jost_net.JVerein.gui.action.AdministrationEinstellungenStatistikAction
 import de.jost_net.JVerein.gui.action.NichtMitgliedSucheAction;
 import de.jost_net.JVerein.gui.action.PreNotificationAction;
 import de.jost_net.JVerein.gui.action.MitgliedstypListAction;
+import de.jost_net.JVerein.gui.action.MittelverwendungListeAction;
 import de.jost_net.JVerein.gui.action.AnfangsbestandListAction;
 import de.jost_net.JVerein.gui.action.AnlagenlisteAction;
 import de.jost_net.JVerein.gui.action.ArbeitseinsaetzeListeAction;
@@ -213,6 +214,11 @@ public class MyExtension implements Extension
           new ProjektSaldoAction(), "euro-sign.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Kontensaldo",
           new KontensaldoAction(), "euro-sign.png"));
+      if (Einstellungen.getEinstellung().getMittelverwendung())
+      {
+        buchfuehrung.addChild(new MyItem(buchfuehrung, "Mittelverwendung",
+            new MittelverwendungListeAction(), "euro-sign.png"));
+      }
       if (anlagenkonto)
         buchfuehrung.addChild(new MyItem(buchfuehrung, "Anlagenverzeichnis",
             new AnlagenlisteAction(), "euro-sign.png"));

--- a/src/de/jost_net/JVerein/gui/parts/MittelverwendungList.java
+++ b/src/de/jost_net/JVerein/gui/parts/MittelverwendungList.java
@@ -1,0 +1,419 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.parts;
+
+import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.io.MittelverwendungZeile;
+import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.Kontoart;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+import de.willuhn.util.ApplicationException;
+
+public class MittelverwendungList extends TablePart implements Part
+{
+
+  private TablePart saldoList;
+
+  private Date datumvon = null;
+
+  private Date datumbis = null;
+
+  public MittelverwendungList(Action action, Date datumvon, Date datumbis)
+  {
+    super(action);
+    this.datumvon = datumvon;
+    this.datumbis = datumbis;
+  }
+
+  public Part getSaldoList() throws ApplicationException
+  {
+    ArrayList<MittelverwendungZeile> zeilen = null;
+    try
+    {
+      zeilen = getInfo();
+
+      if (saldoList == null)
+      {
+        saldoList = new TablePart(zeilen, null)
+        {
+          @Override
+          protected void orderBy(int index)
+          {
+            return;
+          }
+        };
+        saldoList.addColumn("Nr", "position");
+        saldoList.addColumn("Mittel", "bezeichnung");
+        saldoList.addColumn("Betrag", "betrag",
+            new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+            Column.ALIGN_RIGHT);
+        saldoList.addColumn("Summe", "summe",
+            new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+            Column.ALIGN_LEFT);
+        saldoList.setRememberColWidths(true);
+        saldoList.removeFeature(FeatureSummary.class);
+      }
+      else
+      {
+        saldoList.removeAll();
+        for (MittelverwendungZeile sz : zeilen)
+        {
+          saldoList.addItem(sz);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler aufgetreten" + e.getMessage());
+    }
+    return saldoList;
+  }
+
+  public ArrayList<MittelverwendungZeile> getInfo() throws RemoteException
+  {
+    DBService service = Einstellungen.getDBService();
+    String sql;
+    ArrayList<MittelverwendungZeile> zeilen = new ArrayList<>();
+    String bezeichnung = "";
+    Integer pos = 1;
+
+    ResultSetExtractor rsbk = new ResultSetExtractor()
+    {
+      @Override
+      public HashMap<Integer, String> extract(ResultSet rs) throws SQLException
+      {
+        HashMap<Integer, String> map = new HashMap<>();
+        while (rs.next())
+        {
+          map.put(Integer.valueOf(rs.getInt(1)), rs.getString(3));
+        }
+        return map;
+      }
+    };
+
+    // Ids der Buchunsklassen
+    sql = "SELECT buchungsklasse.* FROM buchungsklasse" + " ORDER BY nummer";
+    @SuppressWarnings("unchecked")
+    HashMap<Integer, String> bkMap = (HashMap<Integer, String>) service
+        .execute(sql, new Object[] {}, rsbk);
+
+    ResultSetExtractor rsd = new ResultSetExtractor()
+    {
+      @Override
+      public Object extract(ResultSet rs) throws SQLException
+      {
+        if (!rs.next())
+        {
+          return Double.valueOf(0);
+        }
+        return Double.valueOf(rs.getDouble(1));
+      }
+    };
+
+    bezeichnung = "Vorhandene Mittel zum Ende des letzten GJ";
+    sql = "SELECT SUM(anfangsbestand.betrag) FROM anfangsbestand, konto"
+        + " WHERE anfangsbestand.datum = ?"
+        + " AND anfangsbestand.konto = konto.id " + " AND konto.kontoart = ? ";
+    Double pos1 = (Double) service.execute(sql,
+        new Object[] { datumvon, Kontoart.GELD.getKey() }, rsd);
+    addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung, pos1,
+        null);
+
+    bezeichnung = "Nicht der zeitnahen Mittelverwendung unterliegende Mittel zum Ende des letzten GJ";
+    sql = "SELECT SUM(anfangsbestand.betrag) FROM anfangsbestand, konto"
+        + " WHERE anfangsbestand.datum = ?"
+        + " AND anfangsbestand.konto = konto.id "
+        + " AND (konto.kontoart = ? OR konto.kontoart = ?)";
+    Double pos2 = (Double) service.execute(sql, new Object[] { datumvon,
+        Kontoart.RUECKLAGE.getKey(), Kontoart.VERMOEGEN.getKey() }, rsd);
+    addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, null,
+        pos2);
+
+    bezeichnung = "          Verwendungsüberhang/Rückstand Ende des letzten GJ";
+    addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung, pos1,
+        -pos2);
+
+    Double zufuehrung = 0d;
+    Double verwendung = 0d;
+    // Mittel Zufluss und Abfluss für alle Buchungsklassen
+    for (Integer bkId : bkMap.keySet())
+    {
+      // Mittel Zufluss
+      // Summe der Buchungen bei Einnahmen
+      sql = getSummenBuchungSql();
+      Double zuf = (Double) service.execute(sql, new Object[] { datumvon,
+          datumbis, Kontoart.GELD.getKey(), bkId, ArtBuchungsart.EINNAHME },
+          rsd);
+      // Summe der positiven Buchungen bei Umbuchung
+      sql = getSummenUmbuchungSql() + " AND buchung.betrag < 0";
+      Double um = (Double) service.execute(sql,
+          new Object[] { datumvon, datumbis,
+              Kontoart.VERBINDLICHKEITEN.getKey(), Kontoart.ANLAGE.getKey(),
+              bkId, ArtBuchungsart.UMBUCHUNG },
+          rsd);
+      zuf -= um;
+      zufuehrung += zuf;
+
+      // Mittel Abfluss
+      // Summe der Buchungen bei Ausgaben
+      sql = getSummenBuchungSql();
+      Double verw = (Double) service.execute(sql, new Object[] { datumvon,
+          datumbis, Kontoart.GELD.getKey(), bkId, ArtBuchungsart.AUSGABE },
+          rsd);
+      // Summe der negativen Buchungen bei Umbuchung
+      sql = getSummenUmbuchungSql() + " AND buchung.betrag > 0";
+      Double um2 = (Double) service.execute(sql,
+          new Object[] { datumvon, datumbis,
+              Kontoart.VERBINDLICHKEITEN.getKey(), Kontoart.ANLAGE.getKey(),
+              bkId, ArtBuchungsart.UMBUCHUNG },
+          rsd);
+      verw -= um2;
+      verwendung += verw;
+
+      if (zuf != 0d || verw != 0d
+          || !Einstellungen.getEinstellung().getUnterdrueckungOhneBuchung())
+      {
+        bezeichnung = "Mittel Zufluss aus " + bkMap.get(bkId);
+        addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+            zuf, null);
+        bezeichnung = "Verwendete Mittel aus " + bkMap.get(bkId);
+        addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung,
+            null, verw);
+        bezeichnung = "          Überschuss/Verlust aus " + bkMap.get(bkId);
+        addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung, zuf,
+            verw);
+      }
+    }
+
+    // Summen über alle Sphären
+    bezeichnung = "Mittel Zufluss aus allen Sphären";
+    addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+        zufuehrung, 0d);
+    bezeichnung = "Verwendete Mittel aus allen Sphären";
+    addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, 0d,
+        verwendung);
+    bezeichnung = "          Überschuss/Verlust aus allen Sphären";
+    addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung,
+        zufuehrung, verwendung);
+
+    // Rücklagen nach § 62 Abs. 1 AO
+    sql = getSummenRuecklagenSql();
+    Double zuRuecklagen = (Double) service.execute(sql, new Object[] { datumvon,
+        datumbis, Kontoart.RUECKLAGE.getKey(), ArtBuchungsart.EINNAHME }, rsd);
+
+    sql = getSummenRuecklagenSql();
+    Double entRuecklagen = (Double) service.execute(sql,
+        new Object[] { datumvon, datumbis, Kontoart.RUECKLAGE.getKey(),
+            ArtBuchungsart.AUSGABE },
+        rsd);
+
+    if (zuRuecklagen != 0d || entRuecklagen != 0d
+        || !Einstellungen.getEinstellung().getUnterdrueckungOhneBuchung())
+    {
+      bezeichnung = "Zuführung zu Rücklagen nach § 62 Abs. 1 AO";
+      addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, null,
+          zuRuecklagen);
+      bezeichnung = "Entnahme aus Rücklagen nach § 62 Abs. 1 AO";
+      addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+          entRuecklagen, null);
+      bezeichnung = "          Summe der Buchungen zu Rücklagen nach § 62 Abs. 1 AO";
+      addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung,
+          entRuecklagen, zuRuecklagen);
+    }
+
+    // Vermögen nach § 62 Abs. 3 und 4 AO
+    sql = getSummenRuecklagenSql();
+    Double zuVermoegen = (Double) service.execute(sql, new Object[] { datumvon,
+        datumbis, Kontoart.VERMOEGEN.getKey(), ArtBuchungsart.EINNAHME }, rsd);
+
+    sql = getSummenRuecklagenSql();
+    Double entVermoegen = (Double) service.execute(sql, new Object[] { datumvon,
+        datumbis, Kontoart.VERMOEGEN.getKey(), ArtBuchungsart.AUSGABE }, rsd);
+
+    if (zuVermoegen != 0d || entVermoegen != 0d
+        || !Einstellungen.getEinstellung().getUnterdrueckungOhneBuchung())
+    {
+      bezeichnung = "Zuführung zum Vermögen nach § 62 Abs. 3 und 4 AO";
+      addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, null,
+          zuVermoegen);
+      bezeichnung = "Entnahme aus Vermögen nach § 62 Abs. 3 und 4 AO";
+      addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+          entVermoegen, null);
+      bezeichnung = "          Summe der Buchungen zum Vermögen nach § 62 Abs. 3 und 4 AO";
+      addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung,
+          entVermoegen, zuVermoegen);
+    }
+
+    // Sonstige Rücklagen
+    sql = getSummenRuecklagenSql();
+    Double zuSonstig = (Double) service.execute(sql,
+        new Object[] { datumvon, datumbis,
+            Kontoart.SONSTIGE_RUECKLAGEN.getKey(), ArtBuchungsart.EINNAHME },
+        rsd);
+
+    sql = getSummenRuecklagenSql();
+    Double entSonstig = (Double) service.execute(sql,
+        new Object[] { datumvon, datumbis,
+            Kontoart.SONSTIGE_RUECKLAGEN.getKey(), ArtBuchungsart.AUSGABE },
+        rsd);
+
+    if (zuSonstig != 0d || entSonstig != 0d
+        || !Einstellungen.getEinstellung().getUnterdrueckungOhneBuchung())
+    {
+      bezeichnung = "Zuführung zu sonstigen Rücklagen";
+      addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, null,
+          zuSonstig);
+      bezeichnung = "Entnahme aus sonstigen Rücklagen";
+      addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+          entSonstig, null);
+      bezeichnung = "          Summe der Buchungen aus sonstigen Rücklagen";
+      addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung,
+          entSonstig, zuSonstig);
+    }
+
+    bezeichnung = "Vorhandene Mittel zum Ende des aktuellen GJ";
+    Double einnahmen = pos1 + zufuehrung + verwendung;
+    addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
+        einnahmen, null);
+    bezeichnung = "Nicht der zeitnahen Mittelverwendung unterliegende Mittel zum Ende aktuellen GJ";
+    Double ausgaben = pos2 + zuRuecklagen + entRuecklagen + zuVermoegen
+        + entVermoegen + zuSonstig + entSonstig;
+    addZeile(zeilen, MittelverwendungZeile.AUSGABE, pos++, bezeichnung, null,
+        ausgaben);
+    bezeichnung = "          Verwendungsüberhang/Rückstand zum Ende des aktuellen GJ";
+    addZeile(zeilen, MittelverwendungZeile.SUMME, pos++, bezeichnung,
+        einnahmen, -ausgaben);
+
+    // Leerzeile am Ende wegen Scrollbar
+    zeilen.add(new MittelverwendungZeile(MittelverwendungZeile.UNDEFINED,
+        null, null, null, null));
+    return zeilen;
+  }
+
+  public void setDatumvon(Date datumvon)
+  {
+    this.datumvon = datumvon;
+  }
+
+  public void setDatumbis(Date datumbis)
+  {
+    this.datumbis = datumbis;
+  }
+
+  @Override
+  public void removeAll()
+  {
+    saldoList.removeAll();
+  }
+
+  @Override
+  public synchronized void paint(Composite parent) throws RemoteException
+  {
+    super.paint(parent);
+  }
+
+  private String getSummenBuchungSql() throws RemoteException
+  {
+    String sql = "";
+    if (!Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      sql = "SELECT sum(buchung.betrag) FROM buchung, konto, buchungsart"
+          + " WHERE datum >= ? AND datum <= ?"
+          + " AND buchung.konto = konto.id" + " AND konto.kontoart = ?"
+          + " AND buchung.buchungsart = buchungsart.id"
+          + " AND buchungsart.buchungsklasse = ? " + "AND buchungsart.art = ?";
+    }
+    else
+    {
+      sql = "SELECT sum(buchung.betrag) FROM buchung, konto, buchungsart"
+          + " WHERE datum >= ? AND datum <= ?"
+          + " AND buchung.konto = konto.id" + " AND konto.kontoart = ?"
+          + " AND buchung.buchungsart = buchungsart.id"
+          + " AND buchung.buchungsklasse = ? " + "AND buchungsart.art = ?";
+    }
+    return sql;
+  }
+
+  private String getSummenUmbuchungSql() throws RemoteException
+  {
+    String sql = "";
+    if (!Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      sql = "SELECT sum(buchung.betrag) FROM buchung, konto, buchungsart"
+          + " WHERE datum >= ? AND datum <= ?" + " AND buchung.konto = konto.id"
+          + " AND (konto.kontoart = ? OR konto.kontoart = ?)"
+          + " AND buchung.buchungsart = buchungsart.id"
+          + " AND buchungsart.buchungsklasse = ?" + " AND buchungsart.art = ?";
+    }
+    else
+    {
+      sql = "SELECT sum(buchung.betrag) FROM buchung, konto, buchungsart"
+          + " WHERE datum >= ? AND datum <= ?" + " AND buchung.konto = konto.id"
+          + " AND (konto.kontoart = ? OR konto.kontoart = ?)"
+          + " AND buchung.buchungsart = buchungsart.id"
+          + " AND buchung.buchungsklasse = ?" + " AND buchungsart.art = ?";
+    }
+    return sql;
+  }
+
+  private String getSummenRuecklagenSql()
+  {
+    return "SELECT sum(buchung.betrag) FROM buchung, konto, buchungsart"
+        + " WHERE datum >= ? AND datum <= ?  " + "AND buchung.konto = konto.id"
+        + " AND konto.kontoart = ?"
+        + " AND buchung.buchungsart = buchungsart.id"
+        + " AND buchungsart.art = ?";
+  }
+
+  private void addZeile(ArrayList<MittelverwendungZeile> zeilen, int status,
+      Integer position, String bezeichnung, Double einnahme, Double ausgabe)
+      throws RemoteException
+  {
+    switch (status)
+    {
+      case MittelverwendungZeile.EINNAHME:
+        zeilen.add(new MittelverwendungZeile(status, position, bezeichnung,
+            einnahme, null));
+        break;
+      case MittelverwendungZeile.AUSGABE:
+        zeilen.add(new MittelverwendungZeile(status, position, bezeichnung,
+            ausgabe, null));
+        break;
+      case MittelverwendungZeile.SUMME:
+        zeilen.add(new MittelverwendungZeile(status, position, bezeichnung,
+            null, einnahme + ausgabe));
+        break;
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -113,6 +113,8 @@ public class DokumentationUtil
   public static final String SPLITBUCHUNG = PRE + FUNKTIONEN + BUCHF + "splittbuchungen";
   
   public static final String ANLAGENLISTE = PRE + FUNKTIONEN + BUCHF + "anlagenverzeichnis";
+  
+  public static final String MITTELVERWENDUNG = PRE + FUNKTIONEN + BUCHF + "mittelverwendung";
 
 
   // Abrechnung

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -67,6 +67,8 @@ public class EinstellungenAnzeigeView extends AbstractView
     left.addLabelPair("Juristische Personen erlaubt",
         control.getJuristischePersonen());
     left.addLabelPair("Mitgliedsfoto *", control.getMitgliedfoto());
+    left.addLabelPair("Mittelverwendung anzeigen" + "*",
+        control.getMittelverwendung());
 
     SimpleContainer right = new SimpleContainer(cols1.getComposite());
     right.addLabelPair("Lesefelder anzeigen *", control.getUseLesefelder());

--- a/src/de/jost_net/JVerein/gui/view/MittelverwendungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MittelverwendungListeView.java
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.MittelverwendungControl;
+import de.jost_net.JVerein.gui.parts.QuickAccessPart;
+import de.jost_net.JVerein.gui.parts.VonBisPart;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+public class MittelverwendungListeView extends AbstractView
+{
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Mittelverwendung");
+
+    final MittelverwendungControl control = new MittelverwendungControl(this);
+  
+    VonBisPart vpart = new VonBisPart(control, false);
+    vpart.paint(this.getParent());
+    
+    QuickAccessPart qpart = new QuickAccessPart(control, false);
+    qpart.paint(this.getParent());
+
+    LabelGroup group = new LabelGroup(getParent(), "Liste", true);
+    group.addPart(control.getSaldoList());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.MITTELVERWENDUNG, false, "question-circle.png");
+    buttons.addButton(control.getCSVExportButton());
+    buttons.addButton(control.getPDFExportButton());
+    buttons.paint(this.getParent());
+  }
+}

--- a/src/de/jost_net/JVerein/io/MittelverwendungExportCSV.java
+++ b/src/de/jost_net/JVerein/io/MittelverwendungExportCSV.java
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (c) by Thomas Laubrock
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.supercsv.cellprocessor.ConvertNullTo;
+import org.supercsv.cellprocessor.FmtNumber;
+import org.supercsv.cellprocessor.ift.CellProcessor;
+import org.supercsv.io.CsvMapWriter;
+import org.supercsv.io.ICsvMapWriter;
+import org.supercsv.prefs.CsvPreference;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class MittelverwendungExportCSV
+{
+
+  private static CellProcessor[] getProcessors()
+  {
+
+    final CellProcessor[] processors = new CellProcessor[] { 
+        new ConvertNullTo(""), // Nr
+        new ConvertNullTo(""), // Bezeichnung
+        new ConvertNullTo("", new FmtNumber(Einstellungen.DECIMALFORMAT)), // Betrag
+        new ConvertNullTo("", new FmtNumber(Einstellungen.DECIMALFORMAT)), // Summe
+    };
+
+    return processors;
+  }
+
+  public MittelverwendungExportCSV(ArrayList<MittelverwendungZeile> zeile,
+      final File file, Date datumvon, Date datumbis) throws ApplicationException
+  {
+    ICsvMapWriter writer = null;
+    try
+    {
+      writer = new CsvMapWriter(new FileWriter(file),
+          CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE);
+      final CellProcessor[] processors = getProcessors();
+      Map<String, Object> csvzeile = new HashMap<>();
+
+      String[] header = {"Nr", "Bezeichnung", "Betrag", "Summe"};
+      writer.writeHeader(header);
+
+      String title = "Mittelverwendung";
+      csvzeile.put(header[1], title);
+      writer.write(csvzeile, header, processors);
+      csvzeile = new HashMap<>();
+      String subtitle = "Geschäftsjahr " + new JVDateFormatTTMMJJJJ().format(datumvon) + " - "
+          + new JVDateFormatTTMMJJJJ().format(datumbis);
+      csvzeile.put(header[1], subtitle);
+      writer.write(csvzeile, header, processors);
+      
+      csvzeile = new HashMap<>();
+      csvzeile.put(header[1], " ");
+      writer.write(csvzeile, header, processors);
+
+      for (MittelverwendungZeile mvz : zeile)
+      {
+        csvzeile = new HashMap<>();
+        switch (mvz.getStatus())
+        {
+          case MittelverwendungZeile.EINNAHME:
+          case MittelverwendungZeile.AUSGABE:
+          {
+            String position = "";
+            if ((Integer) mvz.getAttribute("position") != null);
+            {
+              position = ((Integer) mvz.getAttribute("position")).toString();
+            }
+            csvzeile.put(header[0], position);
+            csvzeile.put(header[1], (String) mvz.getAttribute("bezeichnung"));
+            csvzeile.put(header[2],(Double) mvz.getAttribute("betrag"));
+            csvzeile.put(header[3], (Double) mvz.getAttribute("summe"));
+            break;
+          }
+          case MittelverwendungZeile.SUMME:
+          {
+            String position = "";
+            if ((Integer) mvz.getAttribute("position") != null);
+            {
+              position = ((Integer) mvz.getAttribute("position")).toString();
+            }
+            csvzeile.put(header[0], position);
+            csvzeile.put(header[1], (String) mvz.getAttribute("bezeichnung"));
+            csvzeile.put(header[2],(Double) mvz.getAttribute("betrag"));
+            csvzeile.put(header[3], (Double) mvz.getAttribute("summe"));
+            break;
+          }
+          case MittelverwendungZeile.UNDEFINED:
+          {
+            continue;
+          }
+        }
+
+        writer.write(csvzeile, header, processors);
+      }
+      GUI.getStatusBar().setSuccessText("Export fertig.");
+      writer.close();
+      FileViewer.show(file);
+    }
+    catch (Exception e)
+    {
+      Logger.error("Error while creating report", e);
+      throw new ApplicationException("Fehler", e);
+    }
+    finally
+    {
+      if (writer != null)
+      {
+        try
+        {
+          writer.close();
+        }
+        catch (Exception e)
+        {
+          Logger.error("Error while creating report", e);
+          throw new ApplicationException("Fehler", e);
+        }
+      }
+    }
+
+  }
+
+}

--- a/src/de/jost_net/JVerein/io/MittelverwendungExportPDF.java
+++ b/src/de/jost_net/JVerein/io/MittelverwendungExportPDF.java
@@ -1,0 +1,123 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Date;
+
+import com.itextpdf.text.BaseColor;
+import com.itextpdf.text.Chunk;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Element;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.Phrase;
+import com.itextpdf.text.pdf.PdfPCell;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class MittelverwendungExportPDF
+{
+
+  public MittelverwendungExportPDF(ArrayList<MittelverwendungZeile> zeile,
+      final File file, Date datumvon, Date datumbis) throws ApplicationException
+  {
+    try
+    {
+      FileOutputStream fos = new FileOutputStream(file);
+      String subtitle = "Geschäftsjahr: " + new JVDateFormatTTMMJJJJ().format(datumvon)
+          + " - " + new JVDateFormatTTMMJJJJ().format(datumbis);
+      Reporter reporter = new Reporter(fos, "Mittelverwendung", subtitle,
+          zeile.size());
+      makeHeader(reporter);
+
+      for (MittelverwendungZeile mvz : zeile)
+      {
+        switch (mvz.getStatus())
+        {
+          case MittelverwendungZeile.EINNAHME:
+          case MittelverwendungZeile.AUSGABE:
+          {
+            reporter.addColumn(((Integer) mvz.getAttribute("position")).toString(),
+                Element.ALIGN_LEFT);
+            reporter.addColumn((String) mvz.getAttribute("bezeichnung"),
+                Element.ALIGN_LEFT);
+            reporter.addColumn((Double) mvz.getAttribute("betrag"));
+            reporter.addColumn(" ",  Element.ALIGN_LEFT);
+            break;
+          }
+          case MittelverwendungZeile.SUMME:
+          {
+            reporter.addColumn(
+                ((Integer) mvz.getAttribute("position")).toString(),
+                Element.ALIGN_LEFT);
+            PdfPCell cell = null;
+            cell = new PdfPCell(new Phrase(new Chunk(
+                reporter.notNull((String) mvz.getAttribute("bezeichnung")),
+                Reporter.getFreeSansBold(9))));
+            cell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            reporter.addColumn(cell);
+            reporter.addColumn(" ",  Element.ALIGN_LEFT);
+            Font f = null;
+            Double value = (Double) mvz.getAttribute("summe");
+            if (value >= 0)
+            {
+              f = Reporter.getFreeSansBold(9, BaseColor.BLACK);
+            }
+            else
+            {
+              f = Reporter.getFreeSansBold(9, BaseColor.RED);
+            }
+            cell = new PdfPCell(
+                new Phrase(Einstellungen.DECIMALFORMAT.format(value), f));
+            cell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            reporter.addColumn(cell);
+            break;
+          }
+        }
+      }
+      GUI.getStatusBar().setSuccessText("Export fertig.");
+      reporter.closeTable();
+      reporter.close();
+      fos.close();
+      FileViewer.show(file);
+    }
+    catch (Exception e)
+    {
+      Logger.error("error while creating report", e);
+      throw new ApplicationException("Fehler", e);
+    }
+  }
+
+  private void makeHeader(Reporter reporter) throws DocumentException
+  {
+    reporter.addHeaderColumn("Nr", Element.ALIGN_CENTER, 5,
+        BaseColor.LIGHT_GRAY);
+    reporter.addHeaderColumn("Mittel", Element.ALIGN_CENTER, 65,
+        BaseColor.LIGHT_GRAY);
+    reporter.addHeaderColumn("Betrag", Element.ALIGN_CENTER, 15,
+        BaseColor.LIGHT_GRAY);
+    reporter.addHeaderColumn("Summe", Element.ALIGN_CENTER, 15,
+        BaseColor.LIGHT_GRAY);
+    reporter.createHeader();
+  }
+}

--- a/src/de/jost_net/JVerein/io/MittelverwendungZeile.java
+++ b/src/de/jost_net/JVerein/io/MittelverwendungZeile.java
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.GenericObject;
+
+/**
+ * Hilfs-Objekt
+ */
+public class MittelverwendungZeile implements GenericObject
+{
+  private Integer position;
+
+  private String bezeichnung = "";
+
+  private Double betrag = null;
+
+  private Double summe = null;
+
+  public static final int UNDEFINED = 0;
+
+  public static final int EINNAHME = 1;
+
+  public static final int AUSGABE = 2;
+
+  public static final int SUMME = 3;
+
+  private int status = UNDEFINED;
+
+  public MittelverwendungZeile(int status, Integer position,
+      String bezeichnung, Double betrag, Double summe)
+  {
+    this.position = position;
+    this.status = status;
+    this.bezeichnung = bezeichnung;
+    this.betrag = betrag;
+    this.summe = summe;
+  }
+
+  public int getStatus()
+  {
+    return status;
+  }
+
+  @Override
+  public Object getAttribute(String arg0) throws RemoteException
+  {
+    if (arg0.equals("bezeichnung"))
+    {
+      return bezeichnung;
+    }
+    else if (arg0.equals("betrag"))
+    {
+      return betrag;
+    }
+    else if (arg0.equals("summe"))
+    {
+      return summe;
+    }
+    else if (arg0.equals("position"))
+    {
+      return position;
+    }
+    throw new RemoteException(
+        String.format("Ungültige Spaltenbezeichung: %s", arg0));
+  }
+
+  @Override
+  public String[] getAttributeNames()
+  {
+    return new String[] { "bezeichnung", "betrag" };
+  }
+
+  @Override
+  public String getID() throws RemoteException
+  {
+    return Integer.toString(position);
+  }
+
+  @Override
+  public String getPrimaryAttribute()
+  {
+    return "bezeichnung";
+  }
+
+  @Override
+  public boolean equals(GenericObject arg0) throws RemoteException
+  {
+    if (arg0 == null || !(arg0 instanceof MittelverwendungZeile))
+    {
+      return false;
+    }
+    return this.getID().equals(arg0.getID());
+  }
+}

--- a/src/de/jost_net/JVerein/keys/Kontoart.java
+++ b/src/de/jost_net/JVerein/keys/Kontoart.java
@@ -24,9 +24,11 @@ public enum Kontoart
   // Ids über dem Limit werden in beiden Salden ignoriert.
   GELD(1, "Geldkonto"),
   ANLAGE(2, "Anlagenkonto"),
+  VERBINDLICHKEITEN(3, "Verbindlichkeitskonto"),
   LIMIT(100, "-- Limit --"),
   RUECKLAGE(101, "Rücklagenkonto nach § 62 Abs. 1 (AO)"),
-  VERMOEGEN(102, "Vermögenskonto nach § 62 Abs. 3 und 4 (AO)");
+  VERMOEGEN(102, "Vermögenskonto nach § 62 Abs. 3 und 4 (AO)"),
+  SONSTIGE_RUECKLAGEN(103, "Konto für sonstige Rücklagen");
 
   private final String text;
 

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -616,4 +616,7 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public void setBeitragAltersstufen(String altersstufen) throws RemoteException;
 
+  public Boolean getMittelverwendung() throws RemoteException;
+
+  public void setMittelverwendung(Boolean mittelverwendung) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0454.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0454.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0454 extends AbstractDDLUpdate
+{
+  public Update0454(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung", new Column("mittelverwendung",
+        COLTYPE.BOOLEAN, 0, "FALSE", false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2151,4 +2151,17 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   {
     setAttribute("beitragaltersstufen", altersstufen);
   }
+  
+  @Override
+  public Boolean getMittelverwendung() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("mittelverwendung"));
+  }
+
+  @Override
+  public void setMittelverwendung(Boolean mittelverwendung)
+      throws RemoteException
+  {
+    setAttribute("mittelverwendung", mittelverwendung);
+  }
 }


### PR DESCRIPTION
Entsprechend der Diskussion im Forum (https://jverein-forum.de/viewtopic.php?t=7359) habe ich einen View für Mittelverwendung eingeführt und die entsprechende Export Möglichkeit als PDF und CSV.
Das Feature kann über die Einstellungen aktiviert werden:
![Bildschirmfoto_20241220_135436](https://github.com/user-attachments/assets/30348017-44f9-46a0-9705-2a1152deb811)
Ein Beispiel schaut wie folgt aus:
![Bildschirmfoto_20241220_135350](https://github.com/user-attachments/assets/5dea27bf-e771-4a71-8b99-b448ec0bc09f)

Gemeinnützige Vereine müssen ihre Einnahmen (Geld!) im aktuellen und den zwei folgenden Jahren ausgegeben haben (zeitnahe Verwendung). Dieses müssen sie dem Finanzamt nachweisen. Sie dürfen aber Rücklagen bilden. Diese sind der zeitnahen Verwendung entzogen.

Es gibt keine feste Vorgabe wie ein Mittelverwendung Nachweis auszuschauen hat. Ich habe im Internet verschiedenes gefunden und erst einmal einen Report erstellt, der den Mittel Zufluss und Abfluss zeigt. Es werden auch pro Sphäre die Einnahmen und Ausgaben aufgelistet. Daraus kann man z.B. ableiten wieviel freie Rücklagen man bilden darf (höchstens ein Drittel des Überschusses aus der Vermögensverwaltung und zusätzlich maximal 10% der Einnahmen im Ideellen Bereich und maximal 10% der Überschüsse in den Zweckbetrieben und den wirtschaftlichen Geschäftsbetrieben).

Aus dem Report kann man z.B. auch sehen ob die vorhandenen Mittel kleiner sind als die Summe der Ausgaben. Falls ja wurde alles in diesem Jahr ausgegeben und die zeitnahe Mittelverwendung wäre erfüllt. Wird nicht alles ausgegeben muss es im folge Jahr passieren. Dazu könnte man einen eigenen Report machen, der für die Einnahmen eines Jahres zeigt in welchem Jahr diese ausgegeben wurden. Dies wäre ein weiteres Feature.

Bei dem Report habe ich folgende Annahmen getroffen. Es wäre hier oder im Forum zu besprechen ob diese richtig sind und ob etwas geändert werden sollte. Da dies nur eine Aufbereitung vorhandener Daten ist greift das Feature nicht in die sonstige Logik der SW ein.
- Als Mittel betrachte ich alle Geld Zu- und Abflüsse auf den Geldkonten. Der Unterschied zum Buchungsklassensaldo ist, dass es sich hier um echte Geldflüsse handelt. Z.B. ist der Kauf einer Anlage im Buchungsklassensaldo eine Umbuchung und taucht da nicht auf, nur die spätere Abschreibung. In der Mittelverwendung ist der Kauf aber eine Ausgabe, genauso wie Tilgungen von Darlehen welche im Buchungsklassensaldo nicht auftauchen.
- Für Konten wie Darlehen, Kredite etc. habe ich darum eine Kontoart "Verbindlichkeitskonto" eingeführt. 
- Der Mittelzufluss und Abfluss wird aus den Buchungen auf den Geldkonten (Girokonto, Geldanlagen) abgeleitet und zwar aus der Art der Buchungsart. Bei Art Einnahme sind es Einnahmen und bei Ausgabe sind es Ausgaben. Man muss hier bei der Buchung aufpassen. Z.B. erzeugt ein Abrechnungslauf mit Lastschriften einzelne Buchungen und eine Gegenbuchung. Die Gegenbuchung muss der Art Einnahme sein weil sie sonst als Ausgabe gerechnet wird und die Beiträge werden doppelt als Einnahme gerechnet wenn die Lastschrift eingelöst wird. Als Summe ist das egal aber die Einnahmen/Ausgaben stimmen nicht.
- Die Frage hier wäre ob wirklich alle Einnahmen und Ausgaben als Mittelzufluss bzw. Abfluss zu werten sind oder ob es Ausnahmen gibt. Z.B. unterliegen Sachspenden nicht der zeitnahen Verwendung. Die könnte man aber auf Anlagenkonten einbuchen. Damit erscheinen sie nicht auf dem Geldkonto. Sollte es Ausnahmen geben müsste man bei den Arten neue Typen einführen wie "Einnahme/Mittelzufluss", "Ausgabe/Mittelabfluss" und die Buchungsarten entsprechend zu kennzeichnen.
- Als weiteres sind die Umbuchungen zu betrachten. Umbuchungen können innerhalb Geldkonten sein und sind dann keine Einnahmen und Ausgaben. Aber Umbuchungen auf Verbindlichkeitskonten oder Anlagenkonten sind als Einnahmen oder Ausgaben zu betrachten. Da es in JVerein keine Beziehung zwischen dem Buchungspaar gibt kann ich das so nicht veststellen. Ich habe jetzt das so gelöst, dass ich Umbuchungen auf Verbindlichkeitskonten und Anlagenkonten betrachte. Was dort als Umbuchung eingeht muss von einem Geldkonto abgegangen sein und was dort abgeht muss auf ein Geldkonto eingegenagen sein. Das funktioniert solange es keine Umbuchungen zwischen Verbindlichkeitskonten und Anlagenkonten gibt. Ich habe das bei meinem Verein ausprobiert, da klappt es. Sollte diese Annahme nicht stimmen müsste ich weitere Arten neben "Umbuchung" einführen wie "Umbuchung/Mittelabfluss" und "Umbuchug/Mittelzufluss". Dann könnte ich dei Umbuchungen auf den Geldkonten auswerten.
- Man könnte aber auch sofort die neuen Buchungsarten einführen. Damit läge es dann in der Hand der Anwender was als Mittel Einnahme und Ausgabe zu nehmen ist.

Da ich hier kein Experte bin, und es wie gesagt bei meinem Verein funktioniert, bin ich auf Kommentare hier im Review oder später durch die Anwender angewiesen.