### PR TITLE
Endedatum optional bei Zusatzbeträge Import

### DIFF
--- a/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
+++ b/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
@@ -277,6 +277,10 @@ public class DefaultZusatzbetraegeImport implements Importer
                   anz, mitgliedIdString));
               fehlerInDaten = true;
             }
+            catch (SQLException e)
+            {
+              //
+            }
             try
             {
               String buchungsart = results.getString("Buchungsart");


### PR DESCRIPTION
Im einem Beispiel in der Online Help war beim Import von Zusatzbeiträgen keine Spalte Endedatum dabei. Damit ging der Import aber schief weil die Spalte erwartet wurde. Mit dem Fix geht es auch ohne Endedatum.