### PR TITLE
Anlagenkonto Attribut in DB nicht löschen

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0453.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0453.java
@@ -37,6 +37,7 @@ public class Update0453 extends AbstractDDLUpdate
     execute("update konto set kontoart = 1 where anlagenkonto IS FALSE");
     execute("update konto set kontoart = 2 where anlagenkonto IS TRUE");
     
-    execute(dropColumn("konto", "anlagenkonto"));
+    // Das kann man später machen, so kann man auch wieder in der SW zurück gehen
+    // execute(dropColumn("konto", "anlagenkonto"));
   }
 }


### PR DESCRIPTION
Ich habe jetzt das Löschen des Anlagenkonto Attribut auskommentiert.
Damit kann man mit der SW wieder auf eine alte Version zurück kehren so wie das auch im neuen Rechnungs Feature möglich ist.