### PR TITLE
Fix Sepa Check

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
@@ -122,7 +122,6 @@ public class MitgliedLastschriftAction implements Action
     if (m.getZahlungsweg() == null
         || m.getZahlungsweg() != Zahlungsweg.BASISLASTSCHRIFT)
     {
-
       abortDialog("Fehler", "Zahlungsweg ist nicht Basislastschrift");
       return false;
     }
@@ -136,22 +135,24 @@ public class MitgliedLastschriftAction implements Action
       }
     }
 
-    // pruefe Sepa Gueltigkeit: Datum der letzen Abbuchung
-    Date letzte_lastschrift = m.getLetzteLastschrift();
-    if (letzte_lastschrift != null)
+    // Pruefe Sepa Gueltigkeit:
+    // Bei Mandaten älter als 3 Jahre muss es eine Lastschrift
+    // innerhalb der letzten 3 Jahre geben
+    Calendar sepagueltigkeit = Calendar.getInstance();
+    sepagueltigkeit.add(Calendar.MONTH, -36);
+    if (m.getMandatDatum().before(sepagueltigkeit.getTime()))
     {
-      Calendar sepagueltigkeit = Calendar.getInstance();
-      sepagueltigkeit.add(Calendar.MONTH, -36);
-      if (letzte_lastschrift.before(sepagueltigkeit.getTime()))
+      Date letzte_lastschrift = m.getLetzteLastschrift();
+      if (letzte_lastschrift == null
+          || letzte_lastschrift.before(sepagueltigkeit.getTime()))
       {
-        if (!confirmDialog("Letzte Lastschrift",
-            "Letzte Lastschrift ist älter als 36 Monate"))
+        if (!confirmDialog("Mandat abgelaufen",
+            "Mandat-Datum ist älter als 36 Monate und keine Lastschrift in den letzten 36 Monaten"))
         {
           return false;
         }
-        }
+      }
     }
-
     return true;
   }
 

--- a/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
@@ -147,7 +147,7 @@ public class MitgliedLastschriftAction implements Action
           || letzte_lastschrift.before(sepagueltigkeit.getTime()))
       {
         if (!confirmDialog("Mandat abgelaufen",
-            "Mandat-Datum ist älter als 36 Monate und keine Lastschrift in den letzten 36 Monaten"))
+            "Das Mandat-Datum ist älter als 36 Monate und es erfolgte keine Lastschrift in den letzten 36 Monaten."))
         {
           return false;
         }

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -91,8 +91,6 @@ import de.willuhn.util.ProgressMonitor;
 
 public class AbrechnungSEPA
 {
-  private final Calendar sepagueltigkeit;
-
   private int counter = 0;
 
   public AbrechnungSEPA(AbrechnungSEPAParam param, ProgressMonitor monitor)
@@ -117,8 +115,6 @@ public class AbrechnungSEPA
 
     Abrechnungslauf abrl = getAbrechnungslauf(param);
 
-    sepagueltigkeit = Calendar.getInstance();
-    sepagueltigkeit.add(Calendar.MONTH, -36);
     Basislastschrift lastschrift = new Basislastschrift();
     // Vorbereitung: Allgemeine Informationen einstellen
     lastschrift.setBIC(Einstellungen.getEinstellung().getBic());
@@ -990,6 +986,8 @@ public class AbrechnungSEPA
     }
     // Bei Mandaten älter als 3 Jahre muss es eine Lastschrift
     // innerhalb der letzten 3 Jahre geben
+    Calendar sepagueltigkeit = Calendar.getInstance();
+    sepagueltigkeit.add(Calendar.MONTH, -36);
     if (m.getMandatDatum().before(sepagueltigkeit.getTime()))
     {
       Date letzte_lastschrift = m.getLetzteLastschrift();
@@ -997,7 +995,7 @@ public class AbrechnungSEPA
           || letzte_lastschrift.before(sepagueltigkeit.getTime()))
       {
         monitor.log(Adressaufbereitung.getNameVorname(m)
-            + ": Mandat-Datum ist älter als 36 Monate und keine Lastschrift in den letzten 36 Monaten");
+            + ": Das Mandat-Datum ist älter als 36 Monate und es erfolgte keine Lastschrift in den letzten 36 Monaten.");
         return false;
       }
     }

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -981,19 +981,25 @@ public class AbrechnungSEPA
     {
       return true;
     }
-    Date letzte_lastschrift = m.getLetzteLastschrift();
-    if (letzte_lastschrift != null
-        && letzte_lastschrift.before(sepagueltigkeit.getTime()))
-    {
-      monitor.log(Adressaufbereitung.getNameVorname(m)
-          + ": Letzte Lastschrift ist älter als 36 Monate.");
-      return false;
-    }
+    // Ohne Mandat keine Lastschrift
     if (m.getMandatDatum() == Einstellungen.NODATE)
     {
       monitor.log(Adressaufbereitung.getNameVorname(m)
           + ": Kein Mandat-Datum vorhanden.");
       return false;
+    }
+    // Bei Mandaten älter als 3 Jahre muss es eine Lastschrift
+    // innerhalb der letzten 3 Jahre geben
+    if (m.getMandatDatum().before(sepagueltigkeit.getTime()))
+    {
+      Date letzte_lastschrift = m.getLetzteLastschrift();
+      if (letzte_lastschrift == null
+          || letzte_lastschrift.before(sepagueltigkeit.getTime()))
+      {
+        monitor.log(Adressaufbereitung.getNameVorname(m)
+            + ": Mandat-Datum ist älter als 36 Monate und keine Lastschrift in den letzten 36 Monaten");
+        return false;
+      }
     }
     return true;
   }


### PR DESCRIPTION
Diese PR korrigiert den falschen SEPA Check wie in  #568 beschrieben.

Den Code gab es an zwei Stellen.

Es gibt noch eine kleine Unschönheit. Wenn man manuell eine Lastschrift erzeugt wird diese direkt in Hibiskus eingetragen. Es gibt keine Entsprechung in JVerein. Wenn man also später wieder Lastschriften macht werden die manuellen Lastschriften beim Sepa Check nicht berücksichtigt.
Man kann auch Lastschriften löschen.
Evtl. wäre es besser wenn das Datum der letzten Lastschrift als Attribut des Mitglied gespeichert wird. Aber das wäre dann ein neuer PR.