### PR TITLE
fix SQL statement für Prefill des Verrechnungskontos

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0456.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0456.java
@@ -35,10 +35,19 @@ public class Update0456 extends AbstractDDLUpdate
           COLTYPE.BIGINT, 20, null, false, false)));
 
       // Standard Verrechnungskonto setzen wie es auch bisher bestimmt wurde
-      execute("UPDATE einstellung SET verrechnungskonto =  "
-          + " (SELECT konto.id from konto"
-          + "  JOIN einstellung ON einstellung.iban LIKE CONCAT('%', konto.nummer)"
-          + "  ORDER by length(konto.nummer) DESC  LIMIT 1)");
+      if (getDriver().equals(DRIVER.MYSQL))
+      {
+        execute("UPDATE einstellung INNER JOIN konto ON einstellung.iban LIKE "
+            + "CONCAT('%', konto.nummer) SET verrechnungskonto = konto.id "
+            + "WHERE konto.id IS NULL;");
+      }
+      else
+      {
+        execute("UPDATE einstellung SET verrechnungskonto =  "
+            + " (SELECT konto.id from konto"
+            + "  JOIN einstellung ON einstellung.iban LIKE CONCAT('%', konto.nummer)"
+            + "  ORDER by length(konto.nummer) DESC  LIMIT 1)");
+      }
     }
   }
 }


### PR DESCRIPTION
Wie in https://github.com/openjverein/jverein/pull/561#issuecomment-2600991596 geschrieben, ist dies ein Fix des Update Scripts 456 für MySQL unter der Annahme, dass es in #561 für die H2DB entwickelt und getestet wurde.