### PR TITLE
Hibiscus Kontoimport Kontoart setzen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/HibiscusKontenImportAction.java
+++ b/src/de/jost_net/JVerein/gui/action/HibiscusKontenImportAction.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.KontoControl;
+import de.jost_net.JVerein.keys.Kontoart;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.hbci.gui.dialogs.KontoAuswahlDialog;
@@ -76,6 +77,7 @@ public class HibiscusKontenImportAction implements Action
       jvereinkonto.setNummer(k.getKontonummer());
       jvereinkonto.setBezeichnung(k.getBezeichnung());
       jvereinkonto.setHibiscusId(Integer.valueOf(k.getID()));
+      jvereinkonto.setKontoArt(Kontoart.GELD);
       jvereinkonto.store();
       control.refreshTable();
       GUI.getStatusBar().setSuccessText(


### PR DESCRIPTION
Beim Import eines Kontos aus Hibiscus wurde die Kontoart nicht gesetzt. Das führt dazu, dass die Buchungen des Kontos nicht in den Salden auftauchen.