### PR TITLE
PDF Encryt nur bei Spendenbescheinigung mit Unterschrift

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
@@ -325,7 +325,7 @@ public class FormularAnzeigeAction implements Action
       map.put(RechnungVar.SUMME_OFFEN.getName(), 700);
       map.put(RechnungVar.QRCODE_INTRO.getName(),
           Einstellungen.getEinstellung().getQRCodeIntro());
-      FormularAufbereitung fab = new FormularAufbereitung(file, false);
+      FormularAufbereitung fab = new FormularAufbereitung(file, false, false);
       fab.writeForm(formular, map);
       fab.showFormular();
     }

--- a/src/de/jost_net/JVerein/gui/action/FreiesFormularAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FreiesFormularAction.java
@@ -112,7 +112,7 @@ public class FreiesFormularAction implements Action
     final File file = new File(s);
     settings.setAttribute("lastdir", file.getParent());
 
-    FormularAufbereitung fa = new FormularAufbereitung(file, false);
+    FormularAufbereitung fa = new FormularAufbereitung(file, false, false);
     for (Mitglied mi : m)
     {
       Formular fo = (Formular) Einstellungen.getDBService().createObject(

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -251,7 +251,10 @@ public class SpendenbescheinigungPrintAction implements Action
           map = new AllgemeineMap().getMap(map);
           if(spb.getMitglied() != null)
             map = new MitgliedMap().getMap(spb.getMitglied(), map);
-          FormularAufbereitung fa = new FormularAufbereitung(file, false);
+          boolean encrypt = Einstellungen.getEinstellung()
+              .getUnterschriftdrucken();
+          FormularAufbereitung fa = new FormularAufbereitung(file, false,
+              encrypt);
           fa.writeForm(fo, map);
           if (adressblatt != Adressblatt.OHNE_ADRESSBLATT)
           {

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -378,7 +378,7 @@ public class PreNotificationControl extends DruckMailControl
         .createObject(Formular.class, form.getID());
     if (!einzelnePdfs)
     {
-      fa = new FormularAufbereitung(file, false);
+      fa = new FormularAufbereitung(file, false, false);
     }
     
     int dateinummer = 0;
@@ -405,7 +405,7 @@ public class PreNotificationControl extends DruckMailControl
         sb.append(postfix);
 
         final File fx = new File(sb.toString());
-        fa = new FormularAufbereitung(fx, false);
+        fa = new FormularAufbereitung(fx, false, false);
       }
 
       aufbereitenFormular(ls, fo);

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -123,7 +123,8 @@ public class FormularAufbereitung
    *          Die Datei, in die geschrieben werden soll
    * @throws RemoteException
    */
-  public FormularAufbereitung(final File f, boolean pdfa) throws RemoteException
+  public FormularAufbereitung(final File f, boolean pdfa, boolean encrypt)
+      throws RemoteException
   {
     this.f = f;
     try
@@ -150,10 +151,13 @@ public class FormularAufbereitung
       else
       {
         writer = PdfWriter.getInstance(doc, fos);
-        writer.setEncryption(null, null,
-            PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS,
-            PdfWriter.ENCRYPTION_AES_256);
-        doc.open();
+        if (encrypt)
+        {
+          writer.setEncryption(null, null,
+              PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS,
+              PdfWriter.ENCRYPTION_AES_256);
+          doc.open();
+        }
       }
     }
     catch (IOException e)

--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -57,7 +57,7 @@ public class FreiesFormularAusgabe
     {
       case DRUCK:
         file = getDateiAuswahl("pdf", formular.getBezeichnung());
-        formularaufbereitung = new FormularAufbereitung(file, false);
+        formularaufbereitung = new FormularAufbereitung(file, false, false);
         break;
       case MAIL:
         file = getDateiAuswahl("zip", formular.getBezeichnung());
@@ -96,7 +96,7 @@ public class FreiesFormularAusgabe
             continue;
           }
           File f = File.createTempFile(getDateiname(m), ".pdf");
-          formularaufbereitung = new FormularAufbereitung(f, false);
+          formularaufbereitung = new FormularAufbereitung(f, false, false);
           aufbereitenFormular(m, formularaufbereitung, formular);
           formularaufbereitung.closeFormular();
           zos.putNextEntry(new ZipEntry(getDateiname(m) + ".pdf"));

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -72,7 +72,7 @@ public class Rechnungsausgabe
     {
       case DRUCK:
         file = getDateiAuswahl("pdf");
-        formularaufbereitung = new FormularAufbereitung(file, true);
+        formularaufbereitung = new FormularAufbereitung(file, true, false);
         break;
       case MAIL:
         file = getDateiAuswahl("zip");
@@ -132,7 +132,7 @@ public class Rechnungsausgabe
           break;
         case MAIL:
           File f = File.createTempFile(getDateiname(re), ".pdf");
-          formularaufbereitung = new FormularAufbereitung(f, true);
+          formularaufbereitung = new FormularAufbereitung(f, true, false);
           aufbereitenFormular(re, formularaufbereitung, formular);
           formularaufbereitung.closeFormular();
           formularaufbereitung.addZUGFeRD(re, typ == TYP.MAHNUNG);

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -133,8 +133,6 @@ public class Reporter
     rpt = new Document();
     hyph = new HyphenationAuto("de", "DE", 2, 2);
     PdfWriter writer = PdfWriter.getInstance(rpt, out);
-    writer.setEncryption(null, null, 
-        PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS, PdfWriter.ENCRYPTION_AES_256);
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);


### PR DESCRIPTION
Sonst sind PDFs nicht mehr Markierbar und es kann somit kein Text Kopiert werden. Siehe https://jverein-forum.de/viewtopic.php?t=7398