### PR TITLE
Sollbuchungen manuell erstellen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SollbuchungEditAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungEditAction.java
@@ -44,8 +44,8 @@ public class SollbuchungEditAction implements Action
       mkn = (MitgliedskontoNode) context;
       try
       {
-        mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
-            Mitgliedskonto.class, mkn.getID());
+        mk = (Mitgliedskonto) Einstellungen.getDBService()
+            .createObject(Mitgliedskonto.class, mkn.getID());
       }
       catch (RemoteException e)
       {

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
@@ -36,26 +36,39 @@ public class SollbuchungNeuAction implements Action
     MitgliedskontoNode mkn = null;
     Mitgliedskonto mk = null;
 
-    if (context == null || !(context instanceof MitgliedskontoNode))
+    if (context instanceof MitgliedskontoNode)
     {
-      throw new ApplicationException("Keine Sollbuchung ausgewählt");
+      mkn = (MitgliedskontoNode) context;
+      try
+      {
+        Mitglied m = (Mitglied) Einstellungen.getDBService()
+            .createObject(Mitglied.class, mkn.getID());
+        mk = (Mitgliedskonto) Einstellungen.getDBService()
+            .createObject(Mitgliedskonto.class, null);
+        mk.setZahlungsweg(m.getZahlungsweg());
+        mk.setMitglied(m);
+        mk.setBetrag(0.0);
+      }
+      catch (RemoteException e)
+      {
+        throw new ApplicationException(
+            "Fehler bei der Erzeugung einer Sollbuchung");
+      }
     }
-
-    mkn = (MitgliedskontoNode) context;
-    try
+    else
     {
-      Mitglied m = (Mitglied) Einstellungen.getDBService().createObject(
-          Mitglied.class, mkn.getID());
-      mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
-          Mitgliedskonto.class, null);
-      mk.setZahlungsweg(m.getZahlungsweg());
-      mk.setMitglied(m);
+      try
+      {
+        mk = (Mitgliedskonto) Einstellungen.getDBService()
+            .createObject(Mitgliedskonto.class, null);
+        mk.setBetrag(0.0);
+      }
+      catch (Exception e)
+      {
+        throw new ApplicationException(
+            "Fehler bei der Erzeugung einer neuen Sollbuchung", e);
+      }
     }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException(
-          "Fehler bei der Erzeugung einer Sollbuchung");
-    }
-    GUI.startView(new SollbuchungDetailView(MitgliedskontoNode.SOLL), mk);
+    GUI.startView(new SollbuchungDetailView(), mk);
   }
 }

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungPositionDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungPositionDeleteAction.java
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+
+import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Löschen eines Formularfeldes
+ */
+public class SollbuchungPositionDeleteAction implements Action
+{
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (context instanceof TablePart)
+    {
+      TablePart tp = (TablePart) context;
+      context = tp.getSelection();
+    }
+    if (context == null || !(context instanceof SollbuchungPosition))
+    {
+      throw new ApplicationException("Keine Sollbuchungsposition ausgewählt");
+    }
+    try
+    {
+      SollbuchungPosition position = (SollbuchungPosition) context;
+      if (position.isNewObject())
+      {
+        return;
+      }
+
+      YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+      d.setTitle("Sollbuchungsposition löschen");
+      d.setText("Wollen Sie diese Sollbuchungsposition wirklich löschen?");
+
+      try
+      {
+        Boolean choice = (Boolean) d.open();
+        if (!choice.booleanValue())
+        {
+          return;
+        }
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Löschen der Sollbuchungsposition", e);
+        return;
+      }
+      position.delete();
+      // Betrag in Sollbuchung neu berechnen
+      Double betrag = 0.0;
+      Mitgliedskonto sollb = position.getSollbuchung();
+      ArrayList<SollbuchungPosition> sollbpList =  sollb.getSollbuchungPositionList();
+      for (SollbuchungPosition sollp : sollbpList)
+      {
+        betrag += sollp.getBetrag();
+      }
+      sollb.setBetrag(betrag);
+      sollb.store();
+      GUI.startView(SollbuchungDetailView.class.getName(), sollb);
+      GUI.getStatusBar().setSuccessText("Sollbuchungsposition gelöscht.");
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler beim Löschen der Sollbuchungsposition";
+      GUI.getStatusBar().setErrorText(fehler);
+      Logger.error(fehler, e);
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungPositionDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungPositionDeleteAction.java
@@ -76,7 +76,8 @@ public class SollbuchungPositionDeleteAction implements Action
       // Betrag in Sollbuchung neu berechnen
       Double betrag = 0.0;
       Mitgliedskonto sollb = position.getSollbuchung();
-      ArrayList<SollbuchungPosition> sollbpList =  sollb.getSollbuchungPositionList();
+      ArrayList<SollbuchungPosition> sollbpList = sollb
+          .getSollbuchungPositionList();
       for (SollbuchungPosition sollp : sollbpList)
       {
         betrag += sollp.getBetrag();

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungPositionEditAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungPositionEditAction.java
@@ -16,47 +16,29 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
-import java.rmi.RemoteException;
-
-import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
-import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
-import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.gui.view.SollbuchungPositionView;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
 
-public class SollbuchungEditAction implements Action
+public class SollbuchungPositionEditAction implements Action
 {
 
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    Mitgliedskonto mk = null;
-    MitgliedskontoNode mkn = null;
+    SollbuchungPosition position = null;
 
-    if (context instanceof Mitgliedskonto)
+    if (context != null && (context instanceof SollbuchungPosition))
     {
-      mk = (Mitgliedskonto) context;
-    }
-    else if (context instanceof MitgliedskontoNode)
-    {
-      mkn = (MitgliedskontoNode) context;
-      try
-      {
-        mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
-            Mitgliedskonto.class, mkn.getID());
-      }
-      catch (RemoteException e)
-      {
-        throw new ApplicationException(
-            "Fehler beim Editieren einer Sollbuchung");
-      }
+      position = (SollbuchungPosition) context;
     }
     else
     {
-      throw new ApplicationException("Keine Sollbuchung ausgewählt");
+      throw new ApplicationException("Keine Sollbuchungsposition ausgewählt");
     }
-    GUI.startView(new SollbuchungDetailView(), mk);
+
+    GUI.startView(SollbuchungPositionView.class.getName(), position);
   }
 }

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungPositionNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungPositionNeuAction.java
@@ -46,8 +46,8 @@ public class SollbuchungPositionNeuAction implements Action
           throw new ApplicationException(
               "Vor dem Anlegen der Sollbuchungsposition muss die Sollbuchung gespeichert werden!");
         }
-        position = (SollbuchungPosition) Einstellungen.getDBService().createObject(
-            SollbuchungPosition.class, null);
+        position = (SollbuchungPosition) Einstellungen.getDBService()
+            .createObject(SollbuchungPosition.class, null);
         position.setSollbuchung(sollbuchung.getID());
       }
       catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/action/SollbuchungPositionNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungPositionNeuAction.java
@@ -19,44 +19,49 @@ package de.jost_net.JVerein.gui.action;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
-import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
+import de.jost_net.JVerein.gui.view.SollbuchungPositionView;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class SollbuchungEditAction implements Action
+public class SollbuchungPositionNeuAction implements Action
 {
 
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    Mitgliedskonto mk = null;
-    MitgliedskontoNode mkn = null;
+    Mitgliedskonto sollbuchung = null;
+    SollbuchungPosition position = null;
 
-    if (context instanceof Mitgliedskonto)
+    if (context != null && (context instanceof Mitgliedskonto))
     {
-      mk = (Mitgliedskonto) context;
-    }
-    else if (context instanceof MitgliedskontoNode)
-    {
-      mkn = (MitgliedskontoNode) context;
+      sollbuchung = (Mitgliedskonto) context;
       try
       {
-        mk = (Mitgliedskonto) Einstellungen.getDBService().createObject(
-            Mitgliedskonto.class, mkn.getID());
+        if (sollbuchung.isNewObject())
+        {
+          throw new ApplicationException(
+              "Vor dem Anlegen der Sollbuchungsposition muss die Sollbuchung gespeichert werden!");
+        }
+        position = (SollbuchungPosition) Einstellungen.getDBService().createObject(
+            SollbuchungPosition.class, null);
+        position.setSollbuchung(sollbuchung.getID());
       }
       catch (RemoteException e)
       {
+        Logger.error("Fehler", e);
         throw new ApplicationException(
-            "Fehler beim Editieren einer Sollbuchung");
+            "Fehler bei der Erzeugung einer neuen Sollbuchungsposition", e);
       }
     }
     else
     {
       throw new ApplicationException("Keine Sollbuchung ausgewählt");
     }
-    GUI.startView(new SollbuchungDetailView(), mk);
+
+    GUI.startView(SollbuchungPositionView.class.getName(), position);
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -568,7 +568,7 @@ public class MitgliedskontoControl extends DruckMailControl
     buchungList.addFeature(new FeatureSummary());
     return buchungList;
   }
-  
+
   private GenericIterator<Mitglied> getMitgliedIterator() throws RemoteException
   {
     DBIterator<Mitglied> mitglieder = Einstellungen.getDBService()

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -30,9 +30,13 @@ import org.eclipse.swt.widgets.TreeItem;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Messaging.MitgliedskontoMessage;
 import de.jost_net.JVerein.Queries.SollbuchungQuery;
+import de.jost_net.JVerein.gui.action.SollbuchungPositionEditAction;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
+import de.jost_net.JVerein.gui.menu.SollbuchungPositionMenu;
 import de.jost_net.JVerein.gui.parts.SollbuchungListTablePart;
 import de.jost_net.JVerein.gui.view.BuchungView;
 import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
@@ -247,6 +251,7 @@ public class MitgliedskontoControl extends DruckMailControl
       b = getMitgliedskonto().getBetrag();
     }
     betrag = new DecimalInput(b, Einstellungen.DECIMALFORMAT);
+    betrag.setEnabled(false);
     return betrag;
   }
 
@@ -371,7 +376,7 @@ public class MitgliedskontoControl extends DruckMailControl
                     .getDBService()
                     .createObject(Mitgliedskonto.class, mkn.getID());
                 GUI.startView(
-                    new SollbuchungDetailView(MitgliedskontoNode.SOLL), mk);
+                    new SollbuchungDetailView(), mk);
               }
             }
             catch (RemoteException e)
@@ -515,7 +520,7 @@ public class MitgliedskontoControl extends DruckMailControl
     mitgliedskontoList2.sort();
   }
 
-  public Part getBuchungenList() throws RemoteException
+  public Part getBuchungenList(boolean hasRechnung) throws RemoteException
   {
     if (buchungList != null)
     {
@@ -523,9 +528,16 @@ public class MitgliedskontoControl extends DruckMailControl
     }
     DBIterator<SollbuchungPosition> sps = Einstellungen.getDBService()
         .createList(SollbuchungPosition.class);
-    sps.addFilter( "sollbuchung = ?", getMitgliedskonto().getID());
-    
-    buchungList = new TablePart(sps, null);
+    sps.addFilter("sollbuchung = ?", getMitgliedskonto().getID());
+
+    if (hasRechnung)
+    {
+      buchungList = new TablePart(sps, null);
+    }
+    else
+    {
+      buchungList = new TablePart(sps, new SollbuchungPositionEditAction());
+    }
     buchungList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     buchungList.addColumn("Zweck", "zweck");
@@ -539,13 +551,19 @@ public class MitgliedskontoControl extends DruckMailControl
       buchungList.addColumn("Steuerbetrag", "steuerbetrag",
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     }
-    buchungList.addColumn("Buchungsart", "buchungsart");
+    buchungList.addColumn("Buchungsart", "buchungsart",
+        new BuchungsartFormatter());
     if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
     {
-      buchungList.addColumn("Buchungsklasse", "buchungsklasse");
+      buchungList.addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
     }
 
     buchungList.setRememberColWidths(true);
+    if (!hasRechnung)
+    {
+      buchungList.setContextMenu(new SollbuchungPositionMenu());
+    }
     buchungList.setRememberOrder(true);
     buchungList.addFeature(new FeatureSummary());
     return buchungList;

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -682,7 +682,14 @@ public class RechnungControl extends DruckMailControl
     buchungList.addColumn("Zweck", "zweck");
     buchungList.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    buchungList.addColumn("Steuersatz", "steuersatz");
+    if (Einstellungen.getEinstellung().getOptiert())
+    {
+      buchungList.addColumn("Nettobetrag", "nettobetrag",
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+      buchungList.addColumn("Steuersatz", "steuersatz");
+      buchungList.addColumn("Steuerbetrag", "steuerbetrag",
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    }
     buchungList.addColumn("Buchungsart", "buchungsart",
         new BuchungsartFormatter());
     if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
@@ -216,14 +216,15 @@ public class SollbuchungPositionControl extends AbstractControl
       // Betrag in Sollbuchung neu berechnen
       Double betrag = 0.0;
       Mitgliedskonto sollb = pos.getSollbuchung();
-      ArrayList<SollbuchungPosition> sollbpList =  sollb.getSollbuchungPositionList();
+      ArrayList<SollbuchungPosition> sollbpList = sollb
+          .getSollbuchungPositionList();
       for (SollbuchungPosition sollp : sollbpList)
       {
         betrag += sollp.getBetrag();
       }
       sollb.setBetrag(betrag);
       sollb.store();
-      
+
       GUI.startView(SollbuchungDetailView.class.getName(), sollb);
       GUI.getStatusBar().setSuccessText("Sollbuchungsposition gespeichert");
     }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
@@ -1,0 +1,242 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe, Leonardo Mörlein
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Date;
+
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
+import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
+import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
+import de.jost_net.JVerein.keys.SteuersatzBuchungsart;
+import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.AbstractInput;
+import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.gui.input.DecimalInput;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.input.TextAreaInput;
+import de.willuhn.logging.Logger;
+
+public class SollbuchungPositionControl extends AbstractControl
+{
+
+  private DateInput datum;
+
+  private TextAreaInput zweck;
+
+  private DecimalInput betrag;
+
+  private AbstractInput buchungsart;
+
+  private SelectInput buchungsklasse;
+
+  private SelectInput steuersatz;
+
+  private SollbuchungPosition position = null;
+
+  public SollbuchungPositionControl(AbstractView view)
+  {
+    super(view);
+  }
+
+  public SollbuchungPosition getPosition()
+  {
+    if (position != null)
+    {
+      return position;
+    }
+    position = (SollbuchungPosition) getCurrentObject();
+    return position;
+  }
+
+  public DecimalInput getBetrag() throws RemoteException
+  {
+    if (betrag != null)
+    {
+      return betrag;
+    }
+
+    if (getPosition().isNewObject() && getPosition().getBetrag() == null)
+    {
+      betrag = new DecimalInput(Einstellungen.DECIMALFORMAT);
+    }
+    else
+    {
+      betrag = new DecimalInput(getPosition().getBetrag(),
+          Einstellungen.DECIMALFORMAT);
+    }
+    betrag.setMandatory(true);
+    return betrag;
+  }
+
+  public Input getZweck() throws RemoteException
+  {
+    if (zweck != null)
+    {
+      return zweck;
+    }
+    zweck = new TextAreaInput(getPosition().getZweck(), 500);
+    zweck.setHeight(50);
+    zweck.setMandatory(true);
+    return zweck;
+  }
+
+  public DateInput getDatum() throws RemoteException
+  {
+    if (datum != null)
+    {
+      return datum;
+    }
+    Date d = getPosition().getDatum();
+    this.datum = new DateInput(d, new JVDateFormatTTMMJJJJ());
+    this.datum.setTitle("Datum");
+    this.datum.setText("Bitte Datum wählen");
+    datum.setMandatory(true);
+    return datum;
+  }
+
+  public Input getBuchungsart() throws RemoteException
+  {
+    if (buchungsart != null)
+    {
+      return buchungsart;
+    }
+    buchungsart = new BuchungsartInput().getBuchungsartInput(buchungsart,
+        getPosition().getBuchungsart(), buchungsarttyp.BUCHUNGSART,
+        Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
+
+    buchungsart.addListener(new Listener()
+    {
+      @Override
+      public void handleEvent(Event event)
+      {
+        try
+        {
+          Buchungsart bua = (Buchungsart) buchungsart.getValue();
+          if (buchungsklasse != null && buchungsklasse.getValue() == null
+              && bua != null)
+            buchungsklasse.setValue(bua.getBuchungsklasse());
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+      }
+    });
+    return buchungsart;
+  }
+
+  public Input getBuchungsklasse() throws RemoteException
+  {
+    if (buchungsklasse != null)
+    {
+      return buchungsklasse;
+    }
+    buchungsklasse = new BuchungsklasseInput().getBuchungsklasseInput(
+        buchungsklasse, getPosition().getBuchungsklasse());
+    return buchungsklasse;
+  }
+
+  public SelectInput getSteuersatz() throws RemoteException
+  {
+    if (steuersatz != null)
+    {
+      return steuersatz;
+    }
+    if (getPosition().getSteuersatz() == null)
+    {
+      steuersatz = new SelectInput(SteuersatzBuchungsart.getArray(),
+          new SteuersatzBuchungsart(0));
+    }
+    else
+    {
+      steuersatz = new SelectInput(SteuersatzBuchungsart.getArray(),
+          new SteuersatzBuchungsart(getPosition().getSteuersatz()));
+    }
+    return steuersatz;
+  }
+
+  public void handleStore()
+  {
+    try
+    {
+      SollbuchungPosition pos = getPosition();
+      pos.setDatum((Date) getDatum().getValue());
+      pos.setZweck((String) getZweck().getValue());
+      pos.setBetrag((Double) getBetrag().getValue());
+      if (getBuchungsart().getValue() != null)
+      {
+        Buchungsart ba = (Buchungsart) getBuchungsart().getValue();
+        pos.setBuchungsartId(Long.parseLong(ba.getID()));
+        pos.setSteuersatz(ba.getSteuersatz());
+      }
+      else
+      {
+        pos.setBuchungsartId(null);
+        pos.setSteuersatz(0.0);
+      }
+      if (getBuchungsklasse().getValue() != null)
+      {
+        pos.setBuchungsklasseId(Long.parseLong(
+            ((Buchungsklasse) getBuchungsklasse().getValue()).getID()));
+      }
+      else
+      {
+        pos.setBuchungsklasseId(null);
+      }
+      pos.store();
+      // Betrag in Sollbuchung neu berechnen
+      Double betrag = 0.0;
+      Mitgliedskonto sollb = pos.getSollbuchung();
+      ArrayList<SollbuchungPosition> sollbpList =  sollb.getSollbuchungPositionList();
+      for (SollbuchungPosition sollp : sollbpList)
+      {
+        betrag += sollp.getBetrag();
+      }
+      sollb.setBetrag(betrag);
+      sollb.store();
+      
+      GUI.startView(SollbuchungDetailView.class.getName(), sollb);
+      GUI.getStatusBar().setSuccessText("Sollbuchungsposition gespeichert");
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler beim Speichern der Sollbuchungsposition";
+      Logger.error(fehler, e);
+      GUI.getStatusBar().setErrorText(fehler);
+    }
+    catch (Exception e)
+    {
+      GUI.getStatusBar().setErrorText(e.getMessage());
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -46,10 +46,10 @@ public class MitgliedskontoMenu extends ContextMenu
    */
   public MitgliedskontoMenu()
   {
-    addItem(new MitgliedItem("Neue Sollbuchung",
-        new SollbuchungNeuAction(), "document-new.png"));
-    addItem(new SollItem("Sollbuchung bearbeiten",
-        new SollbuchungEditAction(), "text-x-generic.png"));
+    addItem(new MitgliedItem("Neue Sollbuchung", new SollbuchungNeuAction(),
+        "document-new.png"));
+    addItem(new SollItem("Sollbuchung bearbeiten", new SollbuchungEditAction(),
+        "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
         new SollbuchungLoeschenAction(), "user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.gui.action.IstbuchungEditAction;
 import de.jost_net.JVerein.gui.action.IstbuchungLoesenAction;
 import de.jost_net.JVerein.gui.action.SollbuchungEditAction;
 import de.jost_net.JVerein.gui.action.SollbuchungLoeschenAction;
+import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
 import de.jost_net.JVerein.keys.Spendenart;
@@ -45,9 +46,8 @@ public class MitgliedskontoMenu extends ContextMenu
    */
   public MitgliedskontoMenu()
   {
-    // TODO Das mauelle erstellen von Sollbuchungen muss überarbeitet werden
-    // addItem(new MitgliedItem("Neue Sollbuchung",
-    // new SollbuchungNeuAction(), "document-new.png"));
+    addItem(new MitgliedItem("Neue Sollbuchung",
+        new SollbuchungNeuAction(), "document-new.png"));
     addItem(new SollItem("Sollbuchung bearbeiten",
         new SollbuchungEditAction(), "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",

--- a/src/de/jost_net/JVerein/gui/menu/SollbuchungPositionMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SollbuchungPositionMenu.java
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.menu;
+
+import de.jost_net.JVerein.gui.action.SollbuchungPositionDeleteAction;
+import de.jost_net.JVerein.gui.action.SollbuchungPositionEditAction;
+import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+
+/**
+ * Kontext-Menu zu den Formularen.
+ */
+public class SollbuchungPositionMenu extends ContextMenu
+{
+
+  /**
+   * Erzeugt ein Kontext-Menu fuer die Liste der Formulare.
+   */
+  public SollbuchungPositionMenu()
+  {
+    addItem(new CheckedSingleContextMenuItem("Bearbeiten",
+        new SollbuchungPositionEditAction(), "text-x-generic.png"));
+    addItem(new CheckedContextMenuItem("Löschen",
+        new SollbuchungPositionDeleteAction(), "user-trash-full.png"));
+  }
+}

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -16,9 +16,14 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.SollbuchungPositionNeuAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
-import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -29,21 +34,13 @@ import de.willuhn.jameica.gui.util.LabelGroup;
 public class SollbuchungDetailView extends AbstractView
 {
 
-  private int typ;
-
-  public SollbuchungDetailView(int typ)
-  {
-    this.typ = typ;
-  }
-
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Buchung");
+    GUI.getView().setTitle("Sollbuchung");
 
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
-    LabelGroup grBuchung = new LabelGroup(getParent(),
-        (typ == MitgliedskontoNode.SOLL ? "Soll" : "Ist") + "buchung");
+    LabelGroup grBuchung = new LabelGroup(getParent(), "Sollbuchung");
     grBuchung.addLabelPair("Mitglied", control.getMitglied());
     grBuchung.addLabelPair("Datum", control.getDatum());
     grBuchung.addLabelPair("Verwendungszweck", control.getZweck1());
@@ -51,15 +48,30 @@ public class SollbuchungDetailView extends AbstractView
     control.getBetrag().setMandatory(true);
     grBuchung.addLabelPair("Betrag", control.getBetrag());
 
-    LabelGroup cont = new LabelGroup(getParent(), "Sollbuchungspositionen", true);
-    cont.addPart(control.getBuchungenList());
+    boolean hasRechnung = control.hasRechnung();
     
+    LabelGroup cont = new LabelGroup(getParent(), "Sollbuchungspositionen", true);
+    
+    ButtonArea buttons1 = new ButtonArea();
+    Button neu = new Button("Neu", new SollbuchungPositionNeuAction(),
+        getCurrentObject(), false, "document-new.png");
+    neu.setEnabled(!hasRechnung);
+    buttons1.addButton(neu);
+
+    // Diese Zeilen werden gebraucht um die Buttons rechts zu plazieren
+    GridLayout layout = new GridLayout();
+    Composite comp = new Composite(cont.getComposite(), SWT.NONE);
+    comp.setLayout(layout);
+    comp.setLayoutData(new GridData(GridData.END));
+
+    buttons1.paint(cont.getComposite());
+    cont.addPart(control.getBuchungenList(hasRechnung));
+
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIEDSKONTO_UEBERSICHT, false,
         "question-circle.png");
     
-    boolean hasRechnung = control.hasRechnung();
     Button save = new Button("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.SollbuchungEditAction;
 import de.jost_net.JVerein.gui.action.SollbuchungExportAction;
 import de.jost_net.JVerein.gui.action.SollbuchungExportAction.EXPORT_TYP;
+import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.menu.SollbuchungMenu;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
@@ -78,9 +79,8 @@ public class SollbuchungListeView extends AbstractView
     buttons.addButton(new Button("Export",
         new SollbuchungExportAction(EXPORT_TYP.MITGLIEDSKONTO), control, false,
         "document-save.png"));
-    // TODO das Bearbeiten der Sollbuchungen muss noch überarbeitet werden
-    // buttons.addButton("Neu", new SollbuchungEditAction(), control, false,
-    // "document-new.png");
+    buttons.addButton("Neu", new SollbuchungNeuAction(), control, false,
+        "document-new.png");
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungPositionView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungPositionView.java
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.SollbuchungPositionControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+public class SollbuchungPositionView extends AbstractView
+{
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Sollbuchungsposition");
+
+    final SollbuchungPositionControl control = new SollbuchungPositionControl(
+        this);
+
+    LabelGroup group = new LabelGroup(getParent(), "Sollbuchungsposition");
+    group.addLabelPair("Datum", control.getDatum());
+    group.addLabelPair("Zweck", control.getZweck());
+    group.addLabelPair("Betrag", control.getBetrag());
+    group.addLabelPair("Buchungsart", control.getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      group.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
+    }
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.MITGLIEDSKONTO_UEBERSICHT, false,
+        "question-circle.png");
+    buttons.addButton("Speichern", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        control.handleStore();
+      }
+    }, null, true, "document-save.png");
+    buttons.paint(this.getParent());
+  }
+}

--- a/src/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
@@ -24,6 +24,8 @@ import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class SollbuchungPositionImpl extends AbstractDBObject
     implements SollbuchungPosition
@@ -34,6 +36,43 @@ public class SollbuchungPositionImpl extends AbstractDBObject
   public SollbuchungPositionImpl() throws RemoteException
   {
     super();
+  }
+
+  @Override
+  protected void insertCheck() throws ApplicationException
+  {
+    try
+    {
+      plausi();
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      throw new ApplicationException(
+          "Buchung kann nicht gespeichert werden. Siehe system log");
+    }
+  }
+
+  public void plausi() throws RemoteException, ApplicationException
+  {
+    if (getDatum() == null)
+    {
+      throw new ApplicationException("Bitte Datum eingeben");
+    }
+    if (getBetrag() == null)
+    {
+      throw new ApplicationException("Bitte Betrag eingeben");
+    }
+    if (getZweck() == null || getZweck().length() == 0)
+    {
+      throw new ApplicationException("Bitte Verwendungszweck eingeben");
+    }
+  }
+
+  @Override
+  protected void updateCheck() throws ApplicationException
+  {
+    insertCheck();
   }
 
   @Override


### PR DESCRIPTION
Der PR erlaubt das manuelle Erstellen einer Sollbuchung über den Neu Button im SollbuchungListeView und aus dem Kontextmenü im Mitgliedskonto Tab beim Mitglied.
Man kann Sollbuchungspositionen erzeugen, editieren und löschen.
Die Implementierung orientiert sich an der Implementierung für Formulare und Formularfelder.

Dann habe ich noch die Anzeige der Steuerspalten bei den Rechnungspositionen hinzugefügt, analog zu den Positionen bei der Sollbuchung.

Implementiert #596 