### PR TITLE
Abrechnung Fällikeitsdatum in Vergangenheit, Rechnungsdatum

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -322,12 +322,13 @@ public class SollbuchungQuery
 
     if (DIFFERENZ.FEHLBETRAG == diff)
     {
-      sql.append(" HAVING SUM(buchung.betrag) < mitgliedskonto.betrag OR "
-          + "(SUM(buchung.betrag) IS NULL AND mitgliedskonto.betrag > 0)");
+      sql.append(" (HAVING SUM(buchung.betrag) < mitgliedskonto.betrag OR "
+          + "(SUM(buchung.betrag) IS NULL AND mitgliedskonto.betrag > 0))");
     }
     if (DIFFERENZ.UEBERZAHLUNG == diff)
     {
-      sql.append(" HAVING SUM(buchung.betrag) > mitgliedskonto.betrag");
+      sql.append(" (HAVING SUM(buchung.betrag) > mitgliedskonto.betrag OR"
+          + "(SUM(buchung.betrag) IS NULL AND mitgliedskonto.betrag < 0))");
     }
 
     List<Long> ids = (List<Long>) service.execute(sql.toString(), param.toArray(),

--- a/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
@@ -16,8 +16,10 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.dialogs.FormularAuswahlDialog;
+import de.jost_net.JVerein.gui.dialogs.RechnungDialog;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.rmi.Rechnung;
@@ -53,9 +55,14 @@ public class RechnungNeuAction implements Action
 
     try
     {
-      FormularAuswahlDialog dialog = new FormularAuswahlDialog();
-      Formular formular = dialog.open();
-      if (formular == null)
+      RechnungDialog dialog = new RechnungDialog();
+      if (!dialog.open())
+      {
+        return;
+      }
+      Formular formular = dialog.getFormular();
+      Date rechnungsdatum = dialog.getDatum();
+      if (formular == null || rechnungsdatum == null)
       {
         return;
       }
@@ -72,6 +79,7 @@ public class RechnungNeuAction implements Action
             .createObject(Rechnung.class, null);
 
         rechnung.setFormular(formular);
+        rechnung.setDatum(rechnungsdatum);
         rechnung.fill(mk);
         rechnung.store();
 

--- a/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.rmi.Rechnung;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -97,6 +98,10 @@ public class RechnungNeuAction implements Action
         GUI.getStatusBar().setSuccessText(erstellt + " Rechnung(en) erstellt"
             + (skip > 0 ? ", " + skip + " vorhandene übersprungen." : "."));
       }
+    }
+    catch (OperationCanceledException ignore)
+    {
+
     }
     catch (Exception e)
     {

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -627,6 +627,7 @@ public class AbrechnungSEPAControl extends AbstractControl
       }
       rechnungsformular.setEnabled((boolean) rechnung.getValue());
       rechnungstext.setEnabled((boolean) rechnung.getValue());
+      rechnungsdatum.setEnabled((boolean) rechnung.getValue());
     }
   }
 

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -105,6 +105,8 @@ public class AbrechnungSEPAControl extends AbstractControl
 
   private TextInput rechnungstext;
 
+  private DateInput rechnungsdatum;
+
   public AbrechnungSEPAControl(AbstractView view)
   {
     super(view);
@@ -312,6 +314,17 @@ public class AbrechnungSEPAControl extends AbstractControl
     return rechnungstext;
   }
   
+  public DateInput getRechnungsdatum()
+  {
+    if (rechnungsdatum != null)
+    {
+      return rechnungsdatum;
+    }
+    rechnungsdatum = new DateInput(new Date());
+    rechnungsdatum.setEnabled(settings.getBoolean("rechnung", false));
+    return rechnungsdatum;
+  }
+
   public CheckboxInput getSEPAPrint()
   {
     if (sepaprint != null)
@@ -413,9 +426,16 @@ public class AbrechnungSEPAControl extends AbstractControl
   private void doAbrechnung() throws ApplicationException, RemoteException
   {
     settings.setAttribute("zahlungsgrund", (String) zahlungsgrund.getValue());
-    settings.setAttribute("zusatzbetraege", (Boolean) zusatzbetrag.getValue());
-    settings.setAttribute("kursteilnehmer",
-        (Boolean) kursteilnehmer.getValue());
+    if (zusatzbetrag != null)
+    {
+      settings.setAttribute("zusatzbetraege",
+          (Boolean) zusatzbetrag.getValue());
+    }
+    if (kursteilnehmer != null)
+    {
+      settings.setAttribute("kursteilnehmer",
+          (Boolean) kursteilnehmer.getValue());
+    }
     settings.setAttribute("kompakteabbuchung",
         (Boolean) kompakteabbuchung.getValue());
     settings.setAttribute("sollbuchungenzusammenfassen",
@@ -443,12 +463,6 @@ public class AbrechnungSEPAControl extends AbstractControl
     if (faelligkeit.getValue() == null)
     {
       throw new ApplicationException("Fälligkeitsdatum fehlt");
-    }
-    Date f = (Date) faelligkeit.getValue();
-    if (f.before(new Date()))
-    {
-      throw new ApplicationException(
-          "Fälligkeit muss in der Zukunft liegen");
     }
     Date vondatum = null;
     if (stichtag.getValue() == null)

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -188,9 +188,9 @@ public class AbrechnungSEPAControl extends AbstractControl
         1 + Einstellungen.getEinstellung().getSEPADatumOffset());
     this.faelligkeit = new DateInput(cal.getTime(),
         new JVDateFormatTTMMJJJJ());
-    this.faelligkeit.setTitle("Fälligkeit SEPA-Lastschrift");
+    this.faelligkeit.setTitle("Fälligkeit");
     this.faelligkeit.setText(
-        "Bitte Fälligkeitsdatum der SEPA-Lastschrift wählen");
+        "Bitte Fälligkeitsdatum wählen");
     faelligkeit.addListener(event -> {
       if (event.type != SWT.Selection && event.type != SWT.FocusOut)
       {

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -130,7 +130,9 @@ public class AbrechnungSEPAControl extends AbstractControl
     {
       return modus;
     }
-    modus = new AbbuchungsmodusInput(Abrechnungsmodi.KEINBEITRAG);
+    Integer mod = settings.getInt("modus", Abrechnungsmodi.KEINBEITRAG);
+
+    modus = new AbbuchungsmodusInput(mod);
     modus.addListener(new Listener()
     {
       @Override
@@ -189,6 +191,17 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.faelligkeit.setTitle("Fälligkeit SEPA-Lastschrift");
     this.faelligkeit.setText(
         "Bitte Fälligkeitsdatum der SEPA-Lastschrift wählen");
+    faelligkeit.addListener(event -> {
+      if (event.type != SWT.Selection && event.type != SWT.FocusOut)
+      {
+        return;
+      }
+      if (faelligkeit.getValue() != null && getStichtag() != null
+          && getStichtag().getValue() == null)
+      {
+        getStichtag().setValue(faelligkeit.getValue());
+      }
+    });
     return faelligkeit;
   }
 
@@ -425,6 +438,8 @@ public class AbrechnungSEPAControl extends AbstractControl
 
   private void doAbrechnung() throws ApplicationException, RemoteException
   {
+    settings.setAttribute("modus",
+        (Integer) modus.getValue());
     settings.setAttribute("zahlungsgrund", (String) zahlungsgrund.getValue());
     if (zusatzbetrag != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -374,10 +374,16 @@ public class AbrechnungslaufControl extends FilterControl
       abrechnungslaufList.addColumn("Austrittsdatum", "austrittsdatum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       abrechnungslaufList.addColumn("Zahlungsgrund", "zahlungsgrund");
-      abrechnungslaufList.addColumn("Zusatzbeträge", "zusatzbetraege",
-          new JaNeinFormatter());
-      abrechnungslaufList.addColumn("Kursteilnehmer", "kursteilnehmer",
-          new JaNeinFormatter());
+      if (Einstellungen.getEinstellung().getZusatzbetrag())
+      {
+        abrechnungslaufList.addColumn("Zusatzbeträge", "zusatzbetraege",
+            new JaNeinFormatter());
+      }
+      if (Einstellungen.getEinstellung().getKursteilnehmer())
+      {
+        abrechnungslaufList.addColumn("Kursteilnehmer", "kursteilnehmer",
+            new JaNeinFormatter());
+      }
       abrechnungslaufList.setContextMenu(new AbrechnungslaufMenu());
       abrechnungslaufList.setRememberColWidths(true);
       abrechnungslaufList.setRememberOrder(true);

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2096,7 +2096,7 @@ public class EinstellungControl extends AbstractControl
       e.setOrt((String) getOrt().getValue());
       e.setBic((String) getBic().getValue());
       String ib = (String) getIban().getValue();
-      if (ib == null)
+      if (ib == null || ib.isBlank())
         e.setIban(null);
       else
         e.setIban(ib.toUpperCase().replace(" ",""));

--- a/src/de/jost_net/JVerein/gui/dialogs/RechnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/RechnungDialog.java
@@ -27,7 +27,9 @@ import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Formular;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.gui.input.LabelInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.LabelGroup;
 
 public class RechnungDialog extends AbstractDialog<Boolean>
@@ -41,6 +43,8 @@ public class RechnungDialog extends AbstractDialog<Boolean>
 
   private Date datum;
 
+  private LabelInput status = null;
+
   private boolean fortfahren = false;
 
   public RechnungDialog()
@@ -53,6 +57,16 @@ public class RechnungDialog extends AbstractDialog<Boolean>
   protected Boolean getData() throws Exception
   {
     return fortfahren;
+  }
+
+  private LabelInput getStatus()
+  {
+    if (status != null)
+    {
+      return status;
+    }
+    status = new LabelInput("");
+    return status;
   }
 
   public Formular getFormular()
@@ -72,6 +86,7 @@ public class RechnungDialog extends AbstractDialog<Boolean>
     group.addText(
         "Bitte Rechnungsdatum und zu verwendendes Formular auswählen.",
         true);
+    group.addInput(getStatus());
     formularInput = new FormularInput(FormularArt.RECHNUNG);
     group.addLabelPair("Formular", formularInput);
 
@@ -82,6 +97,14 @@ public class RechnungDialog extends AbstractDialog<Boolean>
     buttons.addButton("Rechnung(en) erstellen", context -> {
       if (formularInput.getValue() == null)
       {
+        status.setValue("Bitte Formular auswählen");
+        status.setColor(Color.ERROR);
+        return;
+      }
+      if (datumInput.getValue() == null)
+      {
+        status.setValue("Bitte Datum auswählen");
+        status.setColor(Color.ERROR);
         return;
       }
       formular = (Formular) formularInput.getValue();

--- a/src/de/jost_net/JVerein/gui/dialogs/RechnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/RechnungDialog.java
@@ -17,6 +17,8 @@
 
 package de.jost_net.JVerein.gui.dialogs;
 
+import java.util.Date;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
@@ -24,26 +26,43 @@ import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Formular;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
 
-public class FormularAuswahlDialog extends AbstractDialog<Formular>
+public class RechnungDialog extends AbstractDialog<Boolean>
 {
 
-  private FormularInput formular;
+  private FormularInput formularInput;
 
-  private Formular data;
+  private DateInput datumInput;
 
-  public FormularAuswahlDialog()
+  private Formular formular;
+
+  private Date datum;
+
+  private boolean fortfahren = false;
+
+  public RechnungDialog()
   {
     super(SWT.CENTER);
-    setTitle("Formular auswählen");
+    setTitle("Rechnung(en) erstellen");
   }
 
   @Override
-  protected Formular getData() throws Exception
+  protected Boolean getData() throws Exception
   {
-    return data;
+    return fortfahren;
+  }
+
+  public Formular getFormular()
+  {
+    return formular;
+  }
+
+  public Date getDatum()
+  {
+    return datum;
   }
 
   @Override
@@ -51,19 +70,23 @@ public class FormularAuswahlDialog extends AbstractDialog<Formular>
   {
     LabelGroup group = new LabelGroup(parent, "");
     group.addText(
-        "Bitte Formular, das für die\n"
-            + "Rechnung(en) verwendet werden soll, auswählen.",
+        "Bitte Rechnungsdatum und zu verwendendes Formular auswählen.",
         true);
-    formular = new FormularInput(FormularArt.RECHNUNG);
-    group.addLabelPair("Formular", formular);
+    formularInput = new FormularInput(FormularArt.RECHNUNG);
+    group.addLabelPair("Formular", formularInput);
+
+    datumInput = new DateInput(new Date());
+    group.addLabelPair("Datum", datumInput);
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Rechnung(en) erstellen", context -> {
-      if (formular.getValue() == null)
+      if (formularInput.getValue() == null)
       {
         return;
       }
-      data = (Formular) formular.getValue();
+      formular = (Formular) formularInput.getValue();
+      datum = (Date) datumInput.getValue();
+      fortfahren = true;
       close();
     }, null, false, "ok.png");
     buttons.addButton("Abbrechen", context -> close(), null, false,

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -24,7 +24,9 @@ import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class AbrechnungSEPAView extends AbstractView
 {
@@ -37,39 +39,46 @@ public class AbrechnungSEPAView extends AbstractView
     final AbrechnungSEPAControl control = new AbrechnungSEPAControl(this);
 
     LabelGroup group = new LabelGroup(getParent(), "Parameter");
-    group.addLabelPair("Modus", control.getAbbuchungsmodus());
-    group.addLabelPair("Fälligkeit SEPA", control.getFaelligkeit());
+    ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    SimpleContainer rigth = new SimpleContainer(cl.getComposite());
+
+    left.addLabelPair("Modus", control.getAbbuchungsmodus());
+    left.addLabelPair("Fälligkeit", control.getFaelligkeit());
     if (Einstellungen.getEinstellung()
         .getBeitragsmodel() == Beitragsmodel.FLEXIBEL)
     {
-      group.addLabelPair("Abrechnungsmonat", control.getAbrechnungsmonat());
+      left.addLabelPair("Abrechnungsmonat", control.getAbrechnungsmonat());
     }
-    group.addLabelPair("Stichtag¹", control.getStichtag());
-    group.addLabelPair("Von Eintrittsdatum", control.getVondatum());
-    group.addLabelPair("Bis Austrittsdatum", control.getBisdatum());
-    group.addLabelPair("Zahlungsgrund für Beiträge",
+    left.addLabelPair("Stichtag¹", control.getStichtag());
+    left.addLabelPair("Von Eintrittsdatum", control.getVondatum());
+    left.addLabelPair("Bis Austrittsdatum", control.getBisdatum());
+    left.addLabelPair("Zahlungsgrund für Beiträge",
         control.getZahlungsgrund());
-    group.addLabelPair("Zusatzbeträge", control.getZusatzbetrag());
-    if (!Einstellungen.getEinstellung().getZusatzbetrag())
+    if (Einstellungen.getEinstellung().getZusatzbetrag())
     {
-      control.getZusatzbetrag().setEnabled(false);
+      left.addLabelPair("Zusatzbeträge", control.getZusatzbetrag());
     }
-    group.addLabelPair("Kursteilnehmer", control.getKursteilnehmer());
-    group.addLabelPair("Kompakte Abbuchung(en)",
-        control.getKompakteAbbuchung());
-    group.addLabelPair("Sollbuchung(en) zusammenfassen",
+    if (Einstellungen.getEinstellung().getKursteilnehmer())
+    {
+      left.addLabelPair("Kursteilnehmer", control.getKursteilnehmer());
+    }
+    left.addLabelPair("Sollbuchung(en) zusammenfassen",
         control.getSollbuchungenZusammenfassen());
-    group.addLabelPair("Rechnung(en) erstellen²", control.getRechnung());
-    group.addLabelPair("Rechnung Formular", control.getRechnungFormular());
-    group.addLabelPair("Rechnung Text", control.getRechnungstext());
-    group.addLabelPair("SEPA-Datei drucken", control.getSEPAPrint());
-    group.addLabelPair("SEPA-Check temporär deaktivieren", control.getSEPACheck());
 
-    if (!Einstellungen.getEinstellung().getKursteilnehmer())
-    {
-      control.getKursteilnehmer().setEnabled(false);
-    }
-    group.addLabelPair("Abbuchungsausgabe", control.getAbbuchungsausgabe());
+    rigth.addHeadline("Lastschriften");
+    rigth.addLabelPair("Kompakte Abbuchung(en)",
+        control.getKompakteAbbuchung());
+    rigth.addLabelPair("SEPA-Check temporär deaktivieren", control.getSEPACheck());
+    rigth.addLabelPair("SEPA-Datei drucken", control.getSEPAPrint());
+    rigth.addLabelPair("Abbuchungsausgabe", control.getAbbuchungsausgabe());
+    
+    rigth.addHeadline("Rechnungen");
+    rigth.addLabelPair("Rechnung(en) erstellen²", control.getRechnung());
+    rigth.addLabelPair("Rechnung Formular", control.getRechnungFormular());
+    rigth.addLabelPair("Rechnung Text", control.getRechnungstext());
+    rigth.addLabelPair("Rechnung Datum", control.getRechnungsdatum());
+
     group.addSeparator();
     group.addText(
         "¹) Für die Berechnung, ob ein Mitglied bereits eingetreten oder ausgetreten ist. "

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -70,7 +70,7 @@ public class AbrechnungSEPAView extends AbstractView
     rigth.addLabelPair("Kompakte Abbuchung(en)",
         control.getKompakteAbbuchung());
     rigth.addLabelPair("SEPA-Check temporär deaktivieren", control.getSEPACheck());
-    rigth.addLabelPair("SEPA-Datei drucken", control.getSEPAPrint());
+    rigth.addLabelPair("Lastschrift-Datei drucken", control.getSEPAPrint());
     rigth.addLabelPair("Abbuchungsausgabe", control.getAbbuchungsausgabe());
     
     rigth.addHeadline("Rechnungen");

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -70,7 +70,7 @@ public class AbrechnungSEPAView extends AbstractView
     rigth.addLabelPair("Kompakte Abbuchung(en)",
         control.getKompakteAbbuchung());
     rigth.addLabelPair("SEPA-Check temporär deaktivieren", control.getSEPACheck());
-    rigth.addLabelPair("Lastschrift-Datei drucken", control.getSEPAPrint());
+    rigth.addLabelPair("Lastschrift-PDF erstellen", control.getSEPAPrint());
     rigth.addLabelPair("Abbuchungsausgabe", control.getAbbuchungsausgabe());
     
     rigth.addHeadline("Rechnungen");

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.rmi.RemoteException;
 import java.util.Date;
 
+import org.kapott.hbci.sepa.SepaVersion;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.AbrechnungSEPAControl;
 import de.jost_net.JVerein.keys.Abrechnungsausgabe;
@@ -34,7 +36,6 @@ import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
-import org.kapott.hbci.sepa.SepaVersion;
 
 public class AbrechnungSEPAParam
 {
@@ -67,6 +68,8 @@ public class AbrechnungSEPAParam
   public final Formular rechnungsformular;
   
   public final String rechnungstext;
+
+  public final Date rechnungsdatum;
 
   public final Boolean sepaprint;
 
@@ -104,6 +107,7 @@ public class AbrechnungSEPAParam
     rechnung = (Boolean) ac.getRechnung().getValue(); 
     rechnungsformular = (Formular) ac.getRechnungFormular().getValue(); 
     rechnungstext = (String) ac.getRechnungstext().getValue();
+    rechnungsdatum = (Date) ac.getRechnungsdatum().getValue();
     sepaprint = (Boolean) ac.getSEPAPrint().getValue();
     sepacheckdisable = (Boolean) ac.getSEPACheck().getValue();
     this.pdffileRCUR = pdffileRCUR;

--- a/src/de/jost_net/JVerein/rmi/Rechnung.java
+++ b/src/de/jost_net/JVerein/rmi/Rechnung.java
@@ -33,6 +33,13 @@ public interface Rechnung extends DBObject, IAdresse
 
   public void setFormular(Formular formular) throws RemoteException;
 
+  /**
+   * Füllt alle Daten aus der Sollbuchung in die Rechnung. Das Datum und das
+   * Formular müssen selbst hinzugefügt werden
+   * 
+   * @param mk
+   *          die Sollbuchung aus der eine Rechnung erstellt werden soll
+   */
   public void fill(Mitgliedskonto mk)
       throws RemoteException, ApplicationException;
 

--- a/src/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/de/jost_net/JVerein/server/RechnungImpl.java
@@ -394,7 +394,6 @@ public class RechnungImpl extends AbstractDBObject implements Rechnung, IAdresse
       setStaat(mitglied.getKtoiStaat());
       setGeschlecht(mitglied.getKtoiGeschlecht());
     }
-    setDatum(new Date());
     if (!mitglied.getMandatDatum().equals(Einstellungen.NODATE))
     {
       setMandatDatum(mitglied.getMandatDatum());


### PR DESCRIPTION
Ermöglichen Abrechnungen von nur Überweisungen mit Fälligkeitsdatum in der Vergangenheit und ohne IBAN und GläubigerID zu machen.
Außerdem habe ich ein neues Feld zum festlegen des Rechnungsdatums erstellt.
Da es im AbrechnungView nun sehr viele Felder geworden sind habe ich es in zwei Spalten unterteilt un neu strukturiert.