### PR TITLE
Box mit Changelog bei JVerein update

### DIFF
--- a/src/de/jost_net/JVerein/JVereinPlugin.java
+++ b/src/de/jost_net/JVerein/JVereinPlugin.java
@@ -152,12 +152,11 @@ public class JVereinPlugin extends AbstractPlugin
         service.update(oldVersion, getManifest().getVersion());
       }
     });
-    BootMessage msg = new BootMessage("Neue JVerein Version");
-    msg.setTitle(
-        "Es wurde eine neue JVerein Version installiert."
+    BootMessage msg = new BootMessage(
+        "Es wurde eine neue JVerein-Version installiert."
             + " Alle Änderungen sind auf folgender Seite zu finden:");
+    msg.setTitle("Neue JVerein-Version");
     msg.setIcon("gtk-info.png");
-    msg.setComment("Änderungen.....");
     msg.setUrl(DokumentationUtil.CHANGELOG);
     Application.getMessagingFactory().getMessagingQueue("jameica.boot")
         .queueMessage(msg);

--- a/src/de/jost_net/JVerein/JVereinPlugin.java
+++ b/src/de/jost_net/JVerein/JVereinPlugin.java
@@ -154,7 +154,7 @@ public class JVereinPlugin extends AbstractPlugin
     BootMessage msg = new BootMessage("Neue JVerein Version");
     msg.setTitle(
         "Es wurde eine neue JVerein Version installiert."
-            + " Alle Änderungen sind über fogende Seite zu finden:");
+            + " Alle Änderungen sind auf folgender Seite zu finden:");
     msg.setIcon("gtk-info.png");
     msg.setComment("Änderungen.....");
     msg.setUrl("https://openjverein.gitbook.io/doku/versionen/v2.9.0/notes");

--- a/src/de/jost_net/JVerein/JVereinPlugin.java
+++ b/src/de/jost_net/JVerein/JVereinPlugin.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.server.JVereinDBServiceImpl;
 import de.jost_net.JVerein.util.HelpConsumer;
 import de.jost_net.JVerein.util.MemoryAnalyzer;
 import de.willuhn.jameica.gui.extension.ExtensionRegistry;
+import de.willuhn.jameica.messaging.BootMessage;
 import de.willuhn.jameica.messaging.LookupService;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.plugin.AbstractPlugin;
@@ -150,6 +151,15 @@ public class JVereinPlugin extends AbstractPlugin
         service.update(oldVersion, getManifest().getVersion());
       }
     });
+    BootMessage msg = new BootMessage("Neue JVerein Version");
+    msg.setTitle(
+        "Es wurde eine neue JVerein Version installiert."
+            + " Alle Änderungen sind über fogende Seite zu finden:");
+    msg.setIcon("gtk-info.png");
+    msg.setComment("Änderungen.....");
+    msg.setUrl("https://openjverein.gitbook.io/doku/versionen/v2.9.0/notes");
+    Application.getMessagingFactory().getMessagingQueue("jameica.boot")
+        .queueMessage(msg);
   }
 
   /**

--- a/src/de/jost_net/JVerein/JVereinPlugin.java
+++ b/src/de/jost_net/JVerein/JVereinPlugin.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.navigation.MyExtension;
+import de.jost_net.JVerein.gui.view.DokumentationUtil;
 import de.jost_net.JVerein.io.UmsatzMessageConsumer;
 import de.jost_net.JVerein.rmi.JVereinDBService;
 import de.jost_net.JVerein.server.JVereinDBServiceImpl;
@@ -157,7 +158,7 @@ public class JVereinPlugin extends AbstractPlugin
             + " Alle Änderungen sind auf folgender Seite zu finden:");
     msg.setIcon("gtk-info.png");
     msg.setComment("Änderungen.....");
-    msg.setUrl("https://openjverein.gitbook.io/doku/versionen/v2.9.0/notes");
+    msg.setUrl(DokumentationUtil.CHANGELOG);
     Application.getMessagingFactory().getMessagingQueue("jameica.boot")
         .queueMessage(msg);
   }

--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -223,4 +223,7 @@ public class DokumentationUtil
   public static final String MITGRATION = PRE + FUNKTIONEN + ADMIN + ADMERWEITERT + "migration";
   
   public static final String QIFIMPORT = PRE + FUNKTIONEN + ADMIN + ADMERWEITERT + "qif-import";
+
+  // Changelog bei Update
+  public static final String CHANGELOG = PRE + FUNKTIONEN + "notes";
 }


### PR DESCRIPTION
Hier habe ich wie in #562 besprochen ein Box eingebaut die nach dem Update von JVerein angezeigt wird. (Schön was alles mit jameica möglich ist!)
![Bildschirmfoto zu 2025-01-24 21-56-42](https://github.com/user-attachments/assets/292d757d-bc9d-41ba-9c19-02d5f2030038)

Es ist die Frage, was wir hier drin anzeigen sollen. Nur den Link zu Internetseite wie ich es momentan gemacht habe, oder sollen wir bei jeder Version die Wichtigsten Änderungen zusammenfassen?