### PR TITLE
Erlaube Kopieren von Inhalt und Ausfüllen von verschlüsselten PDFs

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -314,7 +314,7 @@ public class SpendenbescheinigungPrintAction implements Action
     Map<String, Object> map = new SpendenbescheinigungMap().getMap(spb, null);
     map = new AllgemeineMap().getMap(map);
     boolean isSammelbestaetigung = spb.isSammelbestaetigung();
-    Reporter rpt = new Reporter(fos, 80, 50, 50, 50);
+    Reporter rpt = new Reporter(fos, 80, 50, 50, 50, true);
 
     // Aussteller, kein Header
     rpt.addHeaderColumn("", Element.ALIGN_CENTER, 100, BaseColor.LIGHT_GRAY);

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -155,7 +155,7 @@ public class FormularAufbereitung
         {
           writer.setEncryption(null, null,
               PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS
-                  | PdfWriter.ALLOW_COPY | PdfWriter.ALLOW_FILL_IN,
+                  | PdfWriter.ALLOW_COPY,
               PdfWriter.ENCRYPTION_AES_256 | PdfWriter.DO_NOT_ENCRYPT_METADATA);
         }
         doc.open();

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -154,8 +154,9 @@ public class FormularAufbereitung
         if (encrypt)
         {
           writer.setEncryption(null, null,
-              PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS,
-              PdfWriter.ENCRYPTION_AES_256);
+              PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS
+                  | PdfWriter.ALLOW_COPY | PdfWriter.ALLOW_FILL_IN,
+              PdfWriter.ENCRYPTION_AES_256 | PdfWriter.DO_NOT_ENCRYPT_METADATA);
           doc.open();
         }
       }

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -157,8 +157,8 @@ public class FormularAufbereitung
               PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS
                   | PdfWriter.ALLOW_COPY | PdfWriter.ALLOW_FILL_IN,
               PdfWriter.ENCRYPTION_AES_256 | PdfWriter.DO_NOT_ENCRYPT_METADATA);
-          doc.open();
-        }
+	}
+        doc.open();
       }
     }
     catch (IOException e)

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -107,7 +107,7 @@ public class Kontoauszug
         {
           return;
         }
-        rpt = new Reporter(new FileOutputStream(file), 40, 20, 20, 40);
+        rpt = new Reporter(new FileOutputStream(file), 40, 20, 20, 40, false);
         for (Mitglied mg : mitglieder)
         {
           if (generiereMitglied(mg, control))
@@ -137,7 +137,7 @@ public class Kontoauszug
             continue;
           }
           File f = File.createTempFile(getDateiname(mg), ".pdf");
-          rpt = new Reporter(new FileOutputStream(f), 40, 20, 20, 40);
+          rpt = new Reporter(new FileOutputStream(f), 40, 20, 20, 40, false);
           if (generiereMitglied(mg, control) == false)
           {
             continue;

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -64,6 +64,8 @@ public class Reporter
 
   private Document rpt;
 
+  private PdfWriter writer;
+
   private PdfPTable table;
 
   private HyphenationAuto hyph;
@@ -114,7 +116,7 @@ public class Reporter
     rpt = new Document();
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     hyph = new HyphenationAuto("de", "DE", 2, 2);
-    PdfWriter.getInstance(rpt, out);
+    writer = PdfWriter.getInstance(rpt, out);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);
     rpt.addAuthor(plugin.getManifest().getName() + " - Version "
@@ -128,16 +130,7 @@ public class Reporter
       int maxRecords, float linkerRand, float rechterRand, float obererRand,
       float untererRand) throws DocumentException
   {
-    this.out = out;
-    rpt = new Document();
-    hyph = new HyphenationAuto("de", "DE", 2, 2);
-    PdfWriter writer = PdfWriter.getInstance(rpt, out);
-    rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
-    AbstractPlugin plugin = Application.getPluginLoader()
-        .getPlugin(JVereinPlugin.class);
-    rpt.addAuthor(plugin.getManifest().getName() + " - Version "
-        + plugin.getManifest().getVersion());
-    rpt.addTitle(subtitle);
+    this(out, linkerRand, rechterRand, obererRand, untererRand);
 
     String fuss = title + " | " + subtitle + " | " + "erstellt am "
         + new JVDateFormatTTMMJJJJ().format(new Date()) + "     " + "Seite: ";
@@ -157,8 +150,6 @@ public class Reporter
       psubTitle.setAlignment(Element.ALIGN_CENTER);
       rpt.add(psubTitle);
     }
-    headers = new ArrayList<>();
-    widths = new ArrayList<>();
   }
 
   /**

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -110,13 +110,21 @@ public class Reporter
   }
 
   public Reporter(OutputStream out, float linkerRand, float rechterRand,
-      float obererRand, float untererRand) throws DocumentException
+      float obererRand, float untererRand, boolean encrypt)
+      throws DocumentException
   {
     this.out = out;
     rpt = new Document();
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     hyph = new HyphenationAuto("de", "DE", 2, 2);
     writer = PdfWriter.getInstance(rpt, out);
+    if (encrypt)
+    {
+      writer.setEncryption(null, null,
+          PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS
+              | PdfWriter.ALLOW_COPY | PdfWriter.ALLOW_FILL_IN,
+          PdfWriter.ENCRYPTION_AES_256 | PdfWriter.DO_NOT_ENCRYPT_METADATA);
+    }
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);
     rpt.addAuthor(plugin.getManifest().getName() + " - Version "
@@ -130,7 +138,7 @@ public class Reporter
       int maxRecords, float linkerRand, float rechterRand, float obererRand,
       float untererRand) throws DocumentException
   {
-    this(out, linkerRand, rechterRand, obererRand, untererRand);
+    this(out, linkerRand, rechterRand, obererRand, untererRand, false);
 
     StringBuilder fuss = new StringBuilder();
     if (title != null && title.length() > 0)

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -122,7 +122,7 @@ public class Reporter
     {
       writer.setEncryption(null, null,
           PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS
-              | PdfWriter.ALLOW_COPY | PdfWriter.ALLOW_FILL_IN,
+              | PdfWriter.ALLOW_COPY,
           PdfWriter.ENCRYPTION_AES_256 | PdfWriter.DO_NOT_ENCRYPT_METADATA);
     }
     AbstractPlugin plugin = Application.getPluginLoader()

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -114,8 +114,7 @@ public class Reporter
     rpt = new Document();
     rpt.setMargins(linkerRand, rechterRand, obererRand, untererRand);
     hyph = new HyphenationAuto("de", "DE", 2, 2);
-    PdfWriter.getInstance(rpt, out).setEncryption(null, null, 
-        PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS, PdfWriter.ENCRYPTION_AES_256);
+    PdfWriter.getInstance(rpt, out);
     AbstractPlugin plugin = Application.getPluginLoader()
         .getPlugin(JVereinPlugin.class);
     rpt.addAuthor(plugin.getManifest().getName() + " - Version "

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -132,24 +132,27 @@ public class Reporter
   {
     this(out, linkerRand, rechterRand, obererRand, untererRand);
 
-    String fuss = title + " | " + subtitle + " | " + "erstellt am "
-        + new JVDateFormatTTMMJJJJ().format(new Date()) + "     " + "Seite: ";
-    HeaderFooter hf = new HeaderFooter();
-    hf.setFooter(fuss);
-    writer.setPageEvent(hf);
-
-    rpt.open();
-
-    if (title.length() > 0)
+    StringBuilder fuss = new StringBuilder();
+    if (title != null && title.length() > 0)
     {
       Paragraph pTitle = new Paragraph(title, getFreeSansBold(13));
       pTitle.setAlignment(Element.ALIGN_CENTER);
       rpt.add(pTitle);
-
+      fuss.append(title + " | ");
+    }
+    if (subtitle != null && subtitle.length() > 0)
+    {
+      rpt.addTitle(subtitle);
       Paragraph psubTitle = new Paragraph(subtitle, getFreeSansBold(10));
       psubTitle.setAlignment(Element.ALIGN_CENTER);
       rpt.add(psubTitle);
+      fuss.append(subtitle + " | ");
     }
+    fuss.append("erstellt am " + new JVDateFormatTTMMJJJJ().format(new Date())
+        + "     Seite: ");
+    HeaderFooter hf = new HeaderFooter();
+    hf.setFooter(fuss.toString());
+    writer.setPageEvent(hf);
   }
 
   /**


### PR DESCRIPTION
- Man kann nun aus verschlüsselten PDFs wieder Inhalte kopieren.
- Sollte ein verschlüsseltes PDF ein Feld (z. B. Signatur) enthalten, ist dies nun wieder ausfüllbar.
- Metadaten werden unverschlüsselt gespeichert.