### PR TITLE
Fehlende Defaultwerte in Map, Fehler bei Formular

### DIFF
--- a/src/de/jost_net/JVerein/Variable/AllgemeineMap.java
+++ b/src/de/jost_net/JVerein/Variable/AllgemeineMap.java
@@ -95,6 +95,11 @@ public class AllgemeineMap
         Einstellungen.getEinstellung().getPlz());
     map.put(AllgemeineVar.ORT.getName(),
         Einstellungen.getEinstellung().getOrt());
+    map.put(AllgemeineVar.ABSENDER.getName(),
+        Einstellungen.getEinstellung().getName() + ", "
+            + Einstellungen.getEinstellung().getStrasse() + ", "
+            + Einstellungen.getEinstellung().getPlz() + " "
+            + Einstellungen.getEinstellung().getOrt());
     map.put(AllgemeineVar.STAAT.getName(),
         Staat.getByKey(Einstellungen.getEinstellung().getStaat()).getText());
     map.put(AllgemeineVar.IBAN.getName(),

--- a/src/de/jost_net/JVerein/Variable/AllgemeineVar.java
+++ b/src/de/jost_net/JVerein/Variable/AllgemeineVar.java
@@ -33,9 +33,10 @@ public enum AllgemeineVar
   ZAEHLER("zaehler"), //
   NAME("verein_name"), //
   STRASSE("verein_strasse"), //
-  PLZ("verein_name"), //
+  PLZ("verein_plz"), //
   ORT("verein_ort"), //
   STAAT("verein_staat"), //
+  ABSENDER("verein_absender"), //
   IBAN("verein_iban"), //
   BIC("verein_bic"), //
   GLAEUBIGER_ID("verein_glaeubiger_id"), //

--- a/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
+++ b/src/de/jost_net/JVerein/gui/action/FormularAnzeigeAction.java
@@ -32,6 +32,7 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungMap;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.Variable.VarTools;
 import de.jost_net.JVerein.gui.control.FormularfeldControl;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.FormularAufbereitung;
@@ -314,6 +315,29 @@ public class FormularAnzeigeAction implements Action
       differenz.add(239.99d);
       ist.add(10d);
 
+      map.put(RechnungVar.STAND.getName(), -39.99d);
+      map.put(RechnungVar.QRCODE_SUMME.getName(), "");
+      map.put(RechnungVar.DATUM.getName(), new Date());
+      map.put(RechnungVar.ANREDE.getName(), "Herrn");
+      map.put(RechnungVar.TITEL.getName(), "Dr.");
+      map.put(RechnungVar.NAME.getName(), "Wichtig");
+      map.put(RechnungVar.VORNAME.getName(), "Willi");
+      map.put(RechnungVar.STRASSE.getName(), "Testgasse 1");
+      map.put(RechnungVar.ADRESSIERUNGSZUSATZ.getName(), "Hinterhaus");
+      map.put(RechnungVar.PLZ.getName(), "12345");
+      map.put(RechnungVar.ORT.getName(), "Testenhausen");
+      map.put(RechnungVar.STAAT.getName(), "DEUTSCHLAND");
+      map.put(RechnungVar.GESCHLECHT.getName(), GeschlechtInput.MAENNLICH);
+      map.put(RechnungVar.ANREDE_DU.getName(), "");
+      map.put(RechnungVar.ANREDE_FOERMLICH.getName(), "");
+      map.put(RechnungVar.PERSONENART.getName(), "");
+      map.put(RechnungVar.MANDATID.getName(), "105");
+      map.put(RechnungVar.MANDATDATUM.getName(), new Date());
+      map.put(RechnungVar.BIC.getName(), "NORSDE51XXX");
+      map.put(RechnungVar.IBAN.getName(), "DE27100777770209299700");
+      map.put(RechnungVar.IBANMASKIERT.getName(),
+          VarTools.maskieren("DE27100777770209299700"));
+
       map.put(RechnungVar.BUCHUNGSDATUM.getName(), buda.toArray());
       map.put(RechnungVar.ZAHLUNGSGRUND.getName(), zg.toArray());
       map.put(RechnungVar.NETTOBETRAG.getName(), nettobetrag.toArray());
@@ -325,6 +349,11 @@ public class FormularAnzeigeAction implements Action
       map.put(RechnungVar.SUMME_OFFEN.getName(), 700);
       map.put(RechnungVar.QRCODE_INTRO.getName(),
           Einstellungen.getEinstellung().getQRCodeIntro());
+      map.put(RechnungVar.EMPFAENGER.getName(),
+          "Herr\nDr. Willi Wichtig\nTestgasse 1\n12345 Testenhausen");
+      map.put(RechnungVar.NUMMER.getName(), "0001");
+      map.put(RechnungVar.ZAHLUNGSWEGTEXT.getName(),
+          Einstellungen.getEinstellung().getRechnungTextUeberweisung());
       FormularAufbereitung fab = new FormularAufbereitung(file, false, false);
       fab.writeForm(formular, map);
       fab.showFormular();

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -156,8 +156,8 @@ public class FormularAufbereitung
           writer.setEncryption(null, null,
               PdfWriter.ALLOW_PRINTING | PdfWriter.ALLOW_SCREENREADERS,
               PdfWriter.ENCRYPTION_AES_256);
-          doc.open();
         }
+        doc.open();
       }
     }
     catch (IOException e)


### PR DESCRIPTION
Für die neuen RechnungMap Felder gab es noch keine Standarddaten.
Bei FormularAufbereitung war ein Fehler, so dass das Formular nicht erstellt werden konnte.
Dann war noch ein Fehler in AllgemeineVar (name statt plz)