### PR TITLE
Zusatzbetrag Endedatum umbenannt

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -258,14 +258,15 @@ public class ZusatzbetragControl extends AbstractControl
       zusatzbetraegeList = new TablePart(zusatzbetraege,
           new ZusatzbetraegeAction(null));
       zusatzbetraegeList.addColumn("Name", "mitglied");
-      zusatzbetraegeList.addColumn("Startdatum", "startdatum",
+      zusatzbetraegeList.addColumn("Erste Fälligkeit", "startdatum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       zusatzbetraegeList.addColumn("Nächste Fälligkeit", "faelligkeit",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
-      zusatzbetraegeList.addColumn("Letzte Ausführung", "ausfuehrung",
+      zusatzbetraegeList.addColumn("Letzte abgerechnete Fälligkeit",
+          "ausfuehrung",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       zusatzbetraegeList.addColumn("Intervall", "intervalltext");
-      zusatzbetraegeList.addColumn("Endedatum", "endedatum",
+      zusatzbetraegeList.addColumn("Nicht mehr ausführen ab", "endedatum",
           new DateFormatter(new JVDateFormatTTMMJJJJ()));
       zusatzbetraegeList.addColumn("Buchungstext", "buchungstext");
       zusatzbetraegeList.addColumn("Betrag", "betrag",
@@ -423,11 +424,13 @@ public class ZusatzbetragControl extends AbstractControl
               BaseColor.LIGHT_GRAY);
           reporter.addHeaderColumn("Nächste Fälligkeit", Element.ALIGN_LEFT, 30,
               BaseColor.LIGHT_GRAY);
-          reporter.addHeaderColumn("Letzte Ausführung", Element.ALIGN_LEFT, 30,
+          reporter.addHeaderColumn("Letzte abgerechnete Fälligkeit",
+              Element.ALIGN_LEFT, 30,
               BaseColor.LIGHT_GRAY);
           reporter.addHeaderColumn("Intervall", Element.ALIGN_LEFT, 30,
               BaseColor.LIGHT_GRAY);
-          reporter.addHeaderColumn("Endedatum", Element.ALIGN_LEFT, 30,
+          reporter.addHeaderColumn("Nicht mehr ausführen ab",
+              Element.ALIGN_LEFT, 30,
               BaseColor.LIGHT_GRAY);
           reporter.addHeaderColumn("Buchungstext", Element.ALIGN_LEFT, 50,
               BaseColor.LIGHT_GRAY);

--- a/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/ZusatzbetraegeMenu.java
@@ -16,11 +16,10 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.menu;
 
-import de.jost_net.JVerein.gui.action.ZusatzbetraegeAction;
-
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
+import de.jost_net.JVerein.gui.action.ZusatzbetraegeAction;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeDeleteAction;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeNaechsteFaelligkeitAction;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeResetAction;
@@ -78,7 +77,8 @@ public class ZusatzbetraegeMenu extends ContextMenu
         Zusatzbetrag z = (Zusatzbetrag) o;
         try
         {
-          return z.getIntervall() == IntervallZusatzzahlung.KEIN ;
+          return z.getIntervall() == IntervallZusatzzahlung.KEIN
+              && z.getAusfuehrung() != null;
         }
         catch (RemoteException e)
         {

--- a/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
@@ -25,9 +25,9 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
+import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
-import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -88,10 +88,10 @@ public class ZusatzbetragPart implements Part
     {
       group.addLabelPair("Mitglied", getMitglied());
     }
-    group.addLabelPair("Startdatum", getStartdatum(true));
+    group.addLabelPair("Erste Fälligkeit ", getStartdatum(true));
     group.addLabelPair("Nächste Fälligkeit", getFaelligkeit());
     group.addLabelPair("Intervall", getIntervall());
-    group.addLabelPair("Endedatum", getEndedatum());
+    group.addLabelPair("Nicht mehr ausführen ab", getEndedatum());
     group.addLabelPair("Buchungstext", getBuchungstext());
     group.addLabelPair("Betrag", getBetrag());
     group.addLabelPair("Buchungsart", getBuchungsart());

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -762,7 +762,7 @@ public class AbrechnungSEPA
             za.setZusatzbetrag(z);
             za.setLetzteAusfuehrung(z.getAusfuehrung());
             za.store();
-            z.setAusfuehrung(Datum.getHeute());
+            z.setAusfuehrung(param.stichtag);
             z.store();
           }
         }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -341,12 +341,10 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
   @Override
   public boolean isOffen(Date datum) throws RemoteException
   {
-    if (!getMitglied().isAngemeldet(datum))
+    if (!getMitglied().isAngemeldet(datum)
+        && !Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
     {
-      if (!Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
-      {
-        return false;
-      }
+      return false;
     }
     // Einmalige Ausführung
     if (getIntervall().intValue() == IntervallZusatzzahlung.KEIN)
@@ -368,38 +366,26 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
   @Override
   public boolean isAktiv(Date datum) throws RemoteException
   {
-    if (!getMitglied().isAngemeldet(datum))
+    if (!getMitglied().isAngemeldet(datum)
+        && !Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
     {
-      if (!Einstellungen.getEinstellung().getZusatzbetragAusgetretene())
-      {
-        return false;
-      }
+      return false;
     }
     // Einmalige Ausführung
     if (getIntervall().intValue() == IntervallZusatzzahlung.KEIN)
     {
       // Ist das Ausführungsdatum gesetzt?
-      if (getAusfuehrung() == null)
+      if (getAusfuehrung() != null)
       {
-        if (getFaelligkeit().getTime() <= datum.getTime())
-        {
-          return true;
-        }
-        else
-        {
-          return false;
-        }
-      }
-      else
-      {
-        // ja: nicht mehr ausführen
         return false;
       }
+      return (getFaelligkeit().getTime() <= datum.getTime());
     }
 
     // Wenn das Endedatum gesetzt ist und das Ausführungsdatum liegt hinter
     // dem Endedatum: nicht mehr ausführen
-    if ((getEndedatum() != null && datum.getTime() >= getEndedatum().getTime())
+    if ((getEndedatum() != null
+        && getFaelligkeit().getTime() >= getEndedatum().getTime())
         || getFaelligkeit().getTime() > datum.getTime())
     {
       return false;


### PR DESCRIPTION
Wie in #582 besprochen habe ich das Endedatum beim Zusatzbetrag verändert.
Dabei habe ich jedoch gemerkt, dass unsere dort besprochene Änderung unlogisch ist, da sonst am ende "nächste Fälligkeit" nach "Endedatum" liegen würde.
Jetzt habe ich es folgendermaßen umgesetzt:

- "Startdatum" in "Erste Fälligkeit" umbenannt
- "Endedatum" in "Nicht mehr abrechnen ab" umbenannt
- "Letzte Ausführung" in "Letzte abgerechnete Fälligkeit" umbenannt und hier den Stichtag der Abrechnung und nicht den Tag der Ausführung eintragen

Außerdem habe ich geändert:

- Menueintrag "Erneut ausführen" nur enable wenn schon ausgeführt.
- Bei der Prüfung ob wiederholte Zusatzbeträge abgerechnet werden sollen muss geprüft werden, ob das Fälligkeitsdatum vor dem ende liegt und nicht wie bisher ob der Stichtag vor dem Ende liegt.