### PR TITLE
Zugeordnete Buchungen in Sollbuchung View anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -31,13 +31,13 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Messaging.MitgliedskontoMessage;
 import de.jost_net.JVerein.Queries.SollbuchungQuery;
 import de.jost_net.JVerein.gui.action.SollbuchungPositionEditAction;
-import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
-import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
 import de.jost_net.JVerein.gui.menu.SollbuchungPositionMenu;
+import de.jost_net.JVerein.gui.parts.BuchungListPart;
 import de.jost_net.JVerein.gui.parts.SollbuchungListTablePart;
+import de.jost_net.JVerein.gui.parts.SollbuchungPositionListPart;
 import de.jost_net.JVerein.gui.view.BuchungView;
 import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
 import de.jost_net.JVerein.io.Kontoauszug;
@@ -211,7 +211,7 @@ public class MitgliedskontoControl extends DruckMailControl
       z = getMitgliedskonto().getZweck1();
     }
     zweck1 = new TextAreaInput(z, 500);
-    zweck1.setHeight(50);
+    zweck1.setHeight(30);
     zweck1.setMandatory(true);
     return zweck1;
   }
@@ -524,7 +524,7 @@ public class MitgliedskontoControl extends DruckMailControl
     mitgliedskontoList2.sort();
   }
 
-  public Part getBuchungenList(boolean hasRechnung) throws RemoteException
+  public Part getSollbuchungPositionListPart(boolean hasRechnung) throws RemoteException
   {
     if (buchungList != null)
     {
@@ -536,31 +536,12 @@ public class MitgliedskontoControl extends DruckMailControl
 
     if (hasRechnung)
     {
-      buchungList = new TablePart(sps, null);
+      buchungList = new SollbuchungPositionListPart(sps, null);
     }
     else
     {
-      buchungList = new TablePart(sps, new SollbuchungPositionEditAction());
-    }
-    buchungList.addColumn("Datum", "datum",
-        new DateFormatter(new JVDateFormatTTMMJJJJ()));
-    buchungList.addColumn("Zweck", "zweck");
-    buchungList.addColumn("Betrag", "betrag",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    if (Einstellungen.getEinstellung().getOptiert())
-    {
-      buchungList.addColumn("Nettobetrag", "nettobetrag",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-      buchungList.addColumn("Steuersatz", "steuersatz");
-      buchungList.addColumn("Steuerbetrag", "steuerbetrag",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    }
-    buchungList.addColumn("Buchungsart", "buchungsart",
-        new BuchungsartFormatter());
-    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
-    {
-      buchungList.addColumn("Buchungsklasse", "buchungsklasse",
-          new BuchungsklasseFormatter());
+      buchungList = new SollbuchungPositionListPart(sps,
+          new SollbuchungPositionEditAction());
     }
 
     buchungList.setRememberColWidths(true);
@@ -568,9 +549,12 @@ public class MitgliedskontoControl extends DruckMailControl
     {
       buchungList.setContextMenu(new SollbuchungPositionMenu());
     }
-    buchungList.setRememberOrder(true);
-    buchungList.addFeature(new FeatureSummary());
     return buchungList;
+  }
+
+  public Part getBuchungListPart() throws RemoteException
+  {
+    return new BuchungListPart(getMitgliedskonto().getBuchungList(), null);
   }
 
   private GenericIterator<Mitglied> getMitgliedIterator() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -530,17 +530,16 @@ public class MitgliedskontoControl extends DruckMailControl
     {
       return buchungList;
     }
-    DBIterator<SollbuchungPosition> sps = Einstellungen.getDBService()
-        .createList(SollbuchungPosition.class);
-    sps.addFilter("sollbuchung = ?", getMitgliedskonto().getID());
+    ArrayList<SollbuchungPosition> list = getMitgliedskonto()
+        .getSollbuchungPositionList();
 
     if (hasRechnung)
     {
-      buchungList = new SollbuchungPositionListPart(sps, null);
+      buchungList = new SollbuchungPositionListPart(list, null);
     }
     else
     {
-      buchungList = new SollbuchungPositionListPart(sps,
+      buchungList = new SollbuchungPositionListPart(list,
           new SollbuchungPositionEditAction());
     }
 

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -39,7 +39,6 @@ import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Rechnung;
-import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.GenericIterator;
@@ -668,14 +667,8 @@ public class RechnungControl extends DruckMailControl
     {
       return buchungList;
     }
-    DBIterator<SollbuchungPosition> sps = Einstellungen.getDBService()
-        .createList(SollbuchungPosition.class);
-    sps.join("mitgliedskonto");
-    sps.addFilter("mitgliedskonto.id = sollbuchungposition.sollbuchung");
-    sps.addFilter("mitgliedskonto.rechnung = ?", getRechnung().getID());
-    sps.setOrder("order by sollbuchungposition.datum");
-    
-    buchungList = new SollbuchungPositionListPart(sps, null);
+    buchungList = new SollbuchungPositionListPart(
+        getRechnung().getSollbuchungPositionList(), null);
     return buchungList;
   }
   

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -25,8 +25,6 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.RechnungAction;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl.DIFFERENZ;
-import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
-import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.FormularInput;
@@ -35,6 +33,7 @@ import de.jost_net.JVerein.gui.input.IBANInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.menu.RechnungMenu;
+import de.jost_net.JVerein.gui.parts.SollbuchungPositionListPart;
 import de.jost_net.JVerein.io.Rechnungsausgabe;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.keys.Zahlungsweg;
@@ -663,7 +662,7 @@ public class RechnungControl extends DruckMailControl
     return leitwegID;
   }
 
-  public Part getBuchungenList() throws RemoteException
+  public Part getSollbuchungPositionListPart() throws RemoteException
   {
     if (buchungList != null)
     {
@@ -676,31 +675,7 @@ public class RechnungControl extends DruckMailControl
     sps.addFilter("mitgliedskonto.rechnung = ?", getRechnung().getID());
     sps.setOrder("order by sollbuchungposition.datum");
     
-    buchungList = new TablePart(sps, null);
-    buchungList.addColumn("Datum", "datum",
-        new DateFormatter(new JVDateFormatTTMMJJJJ()));
-    buchungList.addColumn("Zweck", "zweck");
-    buchungList.addColumn("Betrag", "betrag",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    if (Einstellungen.getEinstellung().getOptiert())
-    {
-      buchungList.addColumn("Nettobetrag", "nettobetrag",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-      buchungList.addColumn("Steuersatz", "steuersatz");
-      buchungList.addColumn("Steuerbetrag", "steuerbetrag",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-    }
-    buchungList.addColumn("Buchungsart", "buchungsart",
-        new BuchungsartFormatter());
-    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
-    {
-      buchungList.addColumn("Buchungsklasse", "buchungsklasse",
-          new BuchungsklasseFormatter());
-    }
-
-    buchungList.setRememberColWidths(true);
-    buchungList.setRememberOrder(true);
-    buchungList.addFeature(new FeatureSummary());
+    buchungList = new SollbuchungPositionListPart(sps, null);
     return buchungList;
   }
   

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -43,19 +43,16 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.VarTools;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungPrintAction;
-import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
-import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
-import de.jost_net.JVerein.gui.formatter.MitgliedskontoFormatter;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.menu.SpendenbescheinigungMenu;
-import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
+import de.jost_net.JVerein.gui.parts.BuchungListPart;
 import de.jost_net.JVerein.gui.view.SpendenbescheinigungMailView;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.MailSender;
-import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.io.SpendenbescheinigungExportCSV;
 import de.jost_net.JVerein.io.SpendenbescheinigungExportPDF;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -64,7 +61,6 @@ import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.keys.SuchSpendenart;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Formular;
-import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
@@ -137,14 +133,12 @@ public class SpendenbescheinigungControl extends DruckMailControl
 
   private CheckboxInput unterlagenwertermittlung;
 
-  private TablePart buchungsList;
-
   private Spendenbescheinigung spendenbescheinigung;
   
   private boolean and = false;
 
   private String sql = "";
-  
+
   private boolean editable = false;
 
   final static String ExportPDF = "PDF";
@@ -452,81 +446,9 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return unterlagenwertermittlung;
   }
 
-  public Part getBuchungsList() throws RemoteException
+  public Part getBuchungListPart() throws RemoteException
   {
-    Spendenbescheinigung spb = getSpendenbescheinigung();
-    if (buchungsList == null)
-    {
-
-      buchungsList = new BuchungListTablePart(spb.getBuchungen(), null);
-      buchungsList.addColumn("Nr", "id-int");
-      buchungsList.addColumn("Konto", "konto", new Formatter()
-      {
-
-        @Override
-        public String format(Object o)
-        {
-          Konto k = (Konto) o;
-          if (k != null)
-          {
-            try
-            {
-              return k.getBezeichnung();
-            }
-            catch (RemoteException e)
-            {
-              Logger.error("Fehler", e);
-            }
-          }
-          return "";
-        }
-      });
-      buchungsList.addColumn("Datum", "datum",
-          new DateFormatter(new JVDateFormatTTMMJJJJ()));
-      buchungsList.addColumn("Auszug", "auszugsnummer");
-      buchungsList.addColumn("Blatt", "blattnummer");
-      buchungsList.addColumn("Name", "name");
-      buchungsList.addColumn("Verwendungszweck", "zweck", new Formatter()
-      {
-
-        @Override
-        public String format(Object value)
-        {
-          if (value == null)
-          {
-            return null;
-          }
-          String s = value.toString();
-          s = s.replaceAll("\r\n", " ");
-          s = s.replaceAll("\r", " ");
-          s = s.replaceAll("\n", " ");
-          return s;
-        }
-      });
-      buchungsList.addColumn("Buchungsart", "buchungsart",
-          new BuchungsartFormatter());
-      buchungsList.addColumn("Betrag", "betrag",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-      buchungsList.addColumn("Mitglied", "mitgliedskonto",
-          new MitgliedskontoFormatter());
-      buchungsList.addColumn("Ersatz für Aufwendungen", "verzicht", new JaNeinFormatter());
-      buchungsList.setMulti(true);
-      // buchungsList.setContextMenu(new BuchungMenu(this));
-      buchungsList.setRememberColWidths(true);
-      buchungsList.setRememberOrder(true);
-      buchungsList.setRememberState(true);
-      buchungsList.addFeature(new FeatureSummary());
-    }
-    else
-    {
-      buchungsList.removeAll();
-      for (Buchung bu : spb.getBuchungen())
-      {
-        buchungsList.addItem(bu);
-      }
-      buchungsList.sort();
-    }
-    return buchungsList;
+    return new BuchungListPart(getSpendenbescheinigung().getBuchungen(), null);
   }
 
   /**

--- a/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.parts;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
+import de.jost_net.JVerein.gui.formatter.MitgliedskontoFormatter;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Konto;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.formatter.Formatter;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.logging.Logger;
+
+public class BuchungListPart extends TablePart
+{
+  public BuchungListPart(Action action)
+  {
+    super(action);
+  }
+
+  public BuchungListPart(List<Buchung> list, Action action)
+  {
+    super(list, action);
+
+    addColumn("Nr", "id-int");
+    addColumn("Konto", "konto", new Formatter()
+    {
+
+      @Override
+      public String format(Object o)
+      {
+        Konto k = (Konto) o;
+        if (k != null)
+        {
+          try
+          {
+            return k.getBezeichnung();
+          }
+          catch (RemoteException e)
+          {
+            Logger.error("Fehler", e);
+          }
+        }
+        return "";
+      }
+    });
+    addColumn("Datum", "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    addColumn("Auszug", "auszugsnummer");
+    addColumn("Blatt", "blattnummer");
+    addColumn("Name", "name");
+    addColumn("Verwendungszweck", "zweck", new Formatter()
+    {
+
+      @Override
+      public String format(Object value)
+      {
+        if (value == null)
+        {
+          return null;
+        }
+        String s = value.toString();
+        s = s.replaceAll("\r\n", " ");
+        s = s.replaceAll("\r", " ");
+        s = s.replaceAll("\n", " ");
+        return s;
+      }
+    });
+    addColumn("Buchungsart", "buchungsart", new BuchungsartFormatter());
+    addColumn("Betrag", "betrag",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    addColumn("Mitglied", "mitgliedskonto", new MitgliedskontoFormatter());
+    addColumn("Ersatz für Aufwendungen", "verzicht", new JaNeinFormatter());
+    setRememberColWidths(true);
+    setRememberOrder(true);
+    setRememberState(true);
+  }
+}

--- a/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.parts;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+
+public class SollbuchungPositionListPart extends TablePart
+{
+  public SollbuchungPositionListPart(Action action)
+  {
+    super(action);
+  }
+
+  public SollbuchungPositionListPart(DBIterator<SollbuchungPosition> sps,
+      Action action) throws RemoteException
+  {
+    super(sps, action);
+
+    addColumn("Datum", "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    addColumn("Zweck", "zweck");
+    addColumn("Betrag", "betrag",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if (Einstellungen.getEinstellung().getOptiert())
+    {
+      addColumn("Nettobetrag", "nettobetrag",
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+      addColumn("Steuersatz", "steuersatz");
+      addColumn("Steuerbetrag", "steuerbetrag",
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    }
+    addColumn("Buchungsart", "buchungsart", new BuchungsartFormatter());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
+    }
+
+    setRememberColWidths(true);
+    setRememberOrder(true);
+    addFeature(new FeatureSummary());
+  }
+}

--- a/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
@@ -17,13 +17,13 @@
 package de.jost_net.JVerein.gui.parts;
 
 import java.rmi.RemoteException;
+import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
@@ -37,10 +37,10 @@ public class SollbuchungPositionListPart extends TablePart
     super(action);
   }
 
-  public SollbuchungPositionListPart(DBIterator<SollbuchungPosition> sps,
+  public SollbuchungPositionListPart(List<SollbuchungPosition> list,
       Action action) throws RemoteException
   {
-    super(sps, action);
+    super(list, action);
 
     addColumn("Datum", "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));
     addColumn("Zweck", "zweck");

--- a/src/de/jost_net/JVerein/gui/view/RechnungView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungView.java
@@ -68,7 +68,7 @@ public class RechnungView extends AbstractView
     rigth.addInput(control.getZahlungsweg());
     
     LabelGroup cont = new LabelGroup(getParent(), "Rechnungspositionen", true);
-    cont.addPart(control.getBuchungenList());
+    cont.addPart(control.getSollbuchungPositionListPart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -29,7 +29,10 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.ScrolledContainer;
+import de.willuhn.jameica.gui.util.SimpleContainer;
 
 public class SollbuchungDetailView extends AbstractView
 {
@@ -40,18 +43,26 @@ public class SollbuchungDetailView extends AbstractView
     GUI.getView().setTitle("Sollbuchung");
 
     final MitgliedskontoControl control = new MitgliedskontoControl(this);
-    LabelGroup grBuchung = new LabelGroup(getParent(), "Sollbuchung");
-    grBuchung.addLabelPair("Mitglied", control.getMitglied());
-    grBuchung.addLabelPair("Zahler", control.getZahler());
-    grBuchung.addLabelPair("Datum", control.getDatum());
-    grBuchung.addLabelPair("Verwendungszweck", control.getZweck1());
-    grBuchung.addLabelPair("Zahlungsweg", control.getZahlungsweg());
+
+    ScrolledContainer scrolled = new ScrolledContainer(getParent(), 1);
+    LabelGroup group = new LabelGroup(scrolled.getComposite(), "Sollbuchung");
+    ColumnLayout cols = new ColumnLayout(group.getComposite(), 2);
+
+    SimpleContainer left = new SimpleContainer(cols.getComposite());
+    left.addLabelPair("Mitglied", control.getMitglied());
+    left.addLabelPair("Datum", control.getDatum());
+    left.addLabelPair("Zahlungsweg", control.getZahlungsweg());
+
+    SimpleContainer right = new SimpleContainer(cols.getComposite());
+    right.addLabelPair("Zahler", control.getZahler());
+    right.addLabelPair("Verwendungszweck", control.getZweck1());
     control.getBetrag().setMandatory(true);
-    grBuchung.addLabelPair("Betrag", control.getBetrag());
+    right.addLabelPair("Betrag", control.getBetrag());
 
     boolean hasRechnung = control.hasRechnung();
-    
-    LabelGroup cont = new LabelGroup(getParent(), "Sollbuchungspositionen", true);
+
+    LabelGroup cont = new LabelGroup(scrolled.getComposite(),
+        "Sollbuchungspositionen");
     
     ButtonArea buttons1 = new ButtonArea();
     Button neu = new Button("Neu", new SollbuchungPositionNeuAction(),
@@ -66,7 +77,11 @@ public class SollbuchungDetailView extends AbstractView
     comp.setLayoutData(new GridData(GridData.END));
 
     buttons1.paint(cont.getComposite());
-    cont.addPart(control.getBuchungenList(hasRechnung));
+    cont.addPart(control.getSollbuchungPositionListPart(hasRechnung));
+
+    LabelGroup buch = new LabelGroup(scrolled.getComposite(),
+        "Zugeordnete Buchungen");
+    buch.addPart(control.getBuchungListPart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungView.java
@@ -64,11 +64,11 @@ public class SpendenbescheinigungView extends AbstractView
     left.addLabelPair("Zeile 6", control.getZeile6());
     left.addLabelPair("Zeile 7", control.getZeile7());
 
-    left.addHeadline("Datum");
-    left.addLabelPair("Spende", control.getSpendedatum());
-    left.addLabelPair("Bescheinigung", control.getBescheinigungsdatum());
-
     SimpleContainer right = new SimpleContainer(cols1.getComposite());
+
+    right.addHeadline("Datum");
+    right.addLabelPair("Spende", control.getSpendedatum());
+    right.addLabelPair("Bescheinigung", control.getBescheinigungsdatum());
 
     right.addHeadline("Betrag");
     right.addLabelPair("Betrag", control.getBetrag());
@@ -92,7 +92,7 @@ public class SpendenbescheinigungView extends AbstractView
       // Buchnungen nur für Geldspenden
       LabelGroup grBuchungen = new LabelGroup(scrolled.getComposite(),
           "Buchungen");
-      grBuchungen.addPart(control.getBuchungsList());
+      grBuchungen.addPart(control.getBuchungListPart());
     }
 
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
+++ b/src/de/jost_net/JVerein/rmi/Mitgliedskonto.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.rmi;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import de.willuhn.datasource.rmi.DBObject;
 
@@ -67,4 +68,7 @@ public interface Mitgliedskonto extends DBObject
 
   ArrayList<SollbuchungPosition> getSollbuchungPositionList()
       throws RemoteException;
+
+  public List<Buchung> getBuchungList() throws RemoteException;
+
 }

--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -21,9 +21,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.jost_net.JVerein.rmi.Rechnung;
@@ -363,5 +365,21 @@ public class MitgliedskontoImpl extends AbstractDBObject
       sps.add((SollbuchungPosition) it.next());
     }
     return sps;
+  }
+
+  @Override
+  public List<Buchung> getBuchungList() throws RemoteException
+  {
+    ArrayList<Buchung> buchungen = new ArrayList<>();
+    DBIterator<Buchung> it = Einstellungen.getDBService()
+        .createList(Buchung.class);
+    it.addFilter("mitgliedskonto = ?", getID());
+    it.setOrder("ORDER BY datum asc");
+    while (it.hasNext())
+    {
+      Buchung bu = it.next();
+      buchungen.add(bu);
+    }
+    return buchungen;
   }
 }


### PR DESCRIPTION
Ich habe den Sollbuchung View erweitert um eine Tabelle der zugeordneten Buchungen anzuzeigen. Dazu habe ich auch den oberen Bereich zweispaltig gemacht, damit mehr Platz ist. Zudem habe ich alles in eine scrolled Container verpackt.
![Bildschirmfoto_20250130_171918](https://github.com/user-attachments/assets/a8d52ac8-4ae4-4cdc-87a4-bbd766ba378d)

Weil die Buchungsliste auch in der Spendenbescheinigung vorkommt habe ich den Code in eine eigene Klasse ausgelagert.

Weil die Liste der Sollbuchung Positionen auch in der Sollbuchung und in der Rechnung vorkommt, habe ich diese auch in eine eigene Klasse ausgelagert. So ist der Code nicht mehr doppelt.