### PR TITLE
Spendenbescheinigung Liste PDF nur 4 Zeilen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -1102,7 +1102,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
               new SpendenbescheinigungExportCSV(file, spbList);
               break;
             case ExportPDF:
-              new SpendenbescheinigungExportPDF(file, spbList);
+              new SpendenbescheinigungExportPDF(file, spbList, 4);
               break;
           }
           GUI.getCurrentView().reload();

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -626,7 +626,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     DBIterator<Spendenbescheinigung> list = Einstellungen.getDBService()
         .createList(Spendenbescheinigung.class);
     list.addFilter("id in (" + StringUtils.join(ids, ",") + ")");
-    list.setOrder(" ORDER BY bescheinigungsdatum desc ");
+    list.setOrder(" ORDER BY bescheinigungsdatum desc, spendedatum desc ");
     ArrayList<Spendenbescheinigung> spendenbescheinigungen = list != null
         ? (ArrayList<Spendenbescheinigung>) PseudoIterator.asList(list)
         : null;

--- a/src/de/jost_net/JVerein/io/SpendenbescheinigungExportPDF.java
+++ b/src/de/jost_net/JVerein/io/SpendenbescheinigungExportPDF.java
@@ -32,34 +32,50 @@ public class SpendenbescheinigungExportPDF
 {
 
   public SpendenbescheinigungExportPDF(final File file,
-      final ArrayList<Spendenbescheinigung> spbList)
+      final ArrayList<Spendenbescheinigung> spbList, int columns)
           throws ApplicationException
   {
+    int breite = Math.min(columns, 7);
+    int breiteZeile = 10;
+    int breiteZeile1 = breite - 1;
+    int breiteDatum = breite + 1;
+    int breiteBetrag = breite;
+
     try
     {
       FileOutputStream fos = new FileOutputStream(file);
       Reporter reporter = new Reporter(fos, "Spendenbescheinigungen", "",
           spbList.size());
-      reporter.addHeaderColumn("Bescheinigungsdatum", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Bescheinigungsdatum", Element.ALIGN_LEFT,
+          breiteDatum,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Spendedatum", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Spendedatum", Element.ALIGN_LEFT, breiteDatum,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Betrag", Element.ALIGN_RIGHT, 10,
+      reporter.addHeaderColumn("Betrag", Element.ALIGN_RIGHT, breiteBetrag,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 1", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Zeile 1", Element.ALIGN_LEFT, breiteZeile1,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 2", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Zeile 2", Element.ALIGN_LEFT, breiteZeile,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 3", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Zeile 3", Element.ALIGN_LEFT, breiteZeile,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 4", Element.ALIGN_LEFT, 10,
+      reporter.addHeaderColumn("Zeile 4", Element.ALIGN_LEFT, breiteZeile,
           BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 5", Element.ALIGN_LEFT, 10,
-          BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 5", Element.ALIGN_LEFT, 10,
-          BaseColor.LIGHT_GRAY);
-      reporter.addHeaderColumn("Zeile 7", Element.ALIGN_LEFT, 10,
-          BaseColor.LIGHT_GRAY);
+      if (columns > 4)
+      {
+        reporter.addHeaderColumn("Zeile 5", Element.ALIGN_LEFT, breiteZeile,
+            BaseColor.LIGHT_GRAY);
+      }
+      if (columns > 5)
+      {
+        reporter.addHeaderColumn("Zeile 6", Element.ALIGN_LEFT, breiteZeile,
+            BaseColor.LIGHT_GRAY);
+      }
+      if (columns > 6)
+      {
+        reporter.addHeaderColumn("Zeile 7", Element.ALIGN_LEFT, breiteZeile,
+            BaseColor.LIGHT_GRAY);
+      }
       reporter.createHeader();
       for (Spendenbescheinigung spb : spbList)
       {
@@ -70,9 +86,18 @@ public class SpendenbescheinigungExportPDF
         reporter.addColumn(spb.getZeile2(), Element.ALIGN_LEFT);
         reporter.addColumn(spb.getZeile3(), Element.ALIGN_LEFT);
         reporter.addColumn(spb.getZeile4(), Element.ALIGN_LEFT);
-        reporter.addColumn(spb.getZeile5(), Element.ALIGN_LEFT);
-        reporter.addColumn(spb.getZeile6(), Element.ALIGN_LEFT);
-        reporter.addColumn(spb.getZeile7(), Element.ALIGN_LEFT);
+        if (columns > 4)
+        {
+          reporter.addColumn(spb.getZeile5(), Element.ALIGN_LEFT);
+        }
+        if (columns > 5)
+        {
+          reporter.addColumn(spb.getZeile6(), Element.ALIGN_LEFT);
+        }
+        if (columns > 6)
+        {
+          reporter.addColumn(spb.getZeile7(), Element.ALIGN_LEFT);
+        }
       }
       reporter.closeTable();
       reporter.close();


### PR DESCRIPTION
Ich habe die Spaltenanzahl beim PDF Report aus dem SpendenbescheinigungListeView auf 4 Zeilen aus der Bescheinigung reduziert. Die anderen sind ja sowieso meist leer, höchstens in Zeile 5 das Land.
Bisher war das mit den 7 Spalten etwas unbrauchbar.
![Bildschirmfoto_20250201_113343](https://github.com/user-attachments/assets/bcf806b4-11dc-486a-92ba-ae1c29d81eb8)

Ich übergebe die feste Anzahl 4 an den Report. Man könnte das aber auch noch in den Einstellungen konfigurierbar machen wenn nötig.