### PR TITLE
Bei Dateinamen für Spendenbescheinigungen das Spendedatum verwenden

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -220,14 +220,14 @@ public class SpendenbescheinigungPrintAction implements Action
           if (spb.getMitglied() != null)
           {
             fileName = new Dateiname(spb.getMitglied(),
-                spb.getBescheinigungsdatum(), "Spendenbescheinigung",
+                spb.getSpendedatum(), "Spendenbescheinigung",
                 Einstellungen.getEinstellung().getDateinamenmusterSpende(),
                 "pdf").get();
           }
           else
           {
             fileName = new Dateiname(spb.getZeile1(), spb.getZeile2(),
-                spb.getBescheinigungsdatum(), "Spendenbescheinigung",
+                spb.getSpendedatum(), "Spendenbescheinigung",
                 Einstellungen.getEinstellung().getDateinamenmusterSpende(),
                 "pdf").get();
           }


### PR DESCRIPTION
Bei Dateinamen für Spendenbescheinigungen das Spendedatum verwenden statt Bescheinigungsdatum.
Siehe im Forum https://jverein-forum.de/viewtopic.php?t=7387

Ich glaube das macht Sinn. 

Es wurde auch der Spendenbetrag im Dateinamen gewünscht. Ich denke aber, das ist nicht so gut. Aus Sicht des Datenschutzes würde ich es nicht machen, wenn da mal einer über die Schulter schaut und das Verzeichnis Listing sieht.