### PR TITLE
Filter in Anlagenbuchungen zweispaltig

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungenListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungenListeView.java
@@ -57,23 +57,21 @@ public class AnlagenbuchungenListeView extends AbstractView
     folder.setBackground(Color.BACKGROUND.getSWTColor());
 
     // Erster Tab
-    TabGroup tabAllgemein = new TabGroup(folder, "Suche Buchungen", true, 3);
+    TabGroup tabAllgemein = new TabGroup(folder, "Suche Buchungen", true, 1);
     LabelGroup labelgroup1 = new LabelGroup(tabAllgemein.getComposite(), "Filter");
-    ColumnLayout cl = new ColumnLayout(labelgroup1.getComposite(), 3);
+    ColumnLayout cl = new ColumnLayout(labelgroup1.getComposite(), 2);
     SimpleContainer left = new SimpleContainer(cl.getComposite());
-    SimpleContainer center = new SimpleContainer(cl.getComposite());
     SimpleContainer right = new SimpleContainer(cl.getComposite());
 
     left.addLabelPair("Konto", control.getSuchKonto());
     left.addLabelPair("Buchungsart", control.getSuchBuchungsart());
     left.addLabelPair("Projekt", control.getSuchProjekt());
-
-    center.addLabelPair("Splitbuchung", control.getSuchSplibuchung());
-    center.addLabelPair("Betrag", control.getSuchBetrag());
+    left.addLabelPair("Splitbuchung", control.getSuchSplibuchung());
 
     right.addLabelPair("Datum von", control.getVondatum());
     right.addLabelPair("Datum bis", control.getBisdatum());
     right.addLabelPair("Enthaltener Text", control.getSuchtext());
+    right.addLabelPair("Betrag", control.getSuchBetrag());
     
     ButtonArea buttons1 = new ButtonArea();
     ToolTipButton zurueck = control.getZurueckButton();
@@ -106,7 +104,7 @@ public class AnlagenbuchungenListeView extends AbstractView
     // Zweiter Tab
     final BuchungsHeaderControl headerControl = new BuchungsHeaderControl(
         this, control);
-    TabGroup tabKonto = new TabGroup(folder, "Konto Kenndaten", true, 4);
+    TabGroup tabKonto = new TabGroup(folder, "Konto Kenndaten", true, 1);
     LabelGroup labelgroup2 = new LabelGroup(tabKonto.getComposite(), "");
     ColumnLayout c2 = new ColumnLayout(labelgroup2.getComposite(), 2);
     SimpleContainer left2 = new SimpleContainer(c2.getComposite());


### PR DESCRIPTION
Im aktuellen Anlagenbuchungen gibt es einen Abstand zwischen dem Filter und der Tabelle darunter. Das liegt daran, dass der zweite Tab höher als der erste Tab ist.
Alt:
![Bildschirmfoto_20250202_114910](https://github.com/user-attachments/assets/6b259f3a-2482-4375-bcde-267f49e0460f)

Wenn ich den Filterbereich zweispaltig mache wird auch der erste Tab höher und es gibt den Abstand nicht mehr. Das schaut optisch besser aus:
![Bildschirmfoto_20250202_120225](https://github.com/user-attachments/assets/92ff570a-fd1c-4f96-994b-6a287faa92d9)
