### PR TITLE
fix: LizenzAction.java wieder eingebunden

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/LizenzAction.java
+++ b/src/de/jost_net/JVerein/gui/action/LizenzAction.java
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * JVerein - Mitgliederverwaltung und einfache Buchhaltung für Vereine
+ * Copyright (c) by Heiner Jostkleigrewe
+ * Copyright (c) 2015 by Thomas Hooge
+ * Main Project: heiner@jverein.dem  http://www.jverein.de/
+ * Module Author: thomas@hoogi.de, http://www.hoogi.de/
+ *
+ * This file is part of JVerein.
+ *
+ * JVerein is free software: you can redistribute it and/or modify 
+ * it under the terms of the  GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JVerein is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.LizenzView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.util.ApplicationException;
+
+public class LizenzAction implements Action
+{
+
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    GUI.startView(LizenzView.class.getName(), null);
+  }
+
+}


### PR DESCRIPTION
Die Action wird benötigt, damit das Menü Lizenzinformationen funktioniert

fixes #635