### PR TITLE
Fix Mailversand an Outlook Empfänger

### DIFF
--- a/src/de/jost_net/JVerein/io/MailSender.java
+++ b/src/de/jost_net/JVerein/io/MailSender.java
@@ -181,6 +181,7 @@ public class MailSender
     }
     props.put("mail.mime.charset", UTF_8);
     System.setProperty("mail.mime.charset", UTF_8);
+    System.setProperty("mail.mime.encodeparameters", "false");
     if (smtp_ssl)
     {
       props.put("mail.smtp.ssl.enable", "true");


### PR DESCRIPTION
Im Forum wird von Problemen beim Mail Versand berichtet. Siehe https://jverein-forum.de/viewtopic.php?t=7396.
Ich selbst hatte auch schon das Problem, dass bei mehreren Anhängen nur der erste als .pdf ankam und die anderen als .DAT. Das tritt bei Empfängern auf die Outlook verwenden bzw. Microsoft Exchange. Mit Thunderbird als Mailempfänger gibt es diese Probleme nicht.

Das Problem liegt wohl an MIME Extension die in JAVAX.MAIL verwendet werden aber nicht von Microsoft unterstützt werden. Zumindest nicht bei allen Versionen. Siehe einen Problembericht und die Lösung in https://takeaction.github.io/Java-Mail-Attachment-Converted-To-DAT/

Ich habe jetzt wie vorgeschlagen die Extensions abgeschaltet.