### PR TITLE
Fix Update0462

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0462.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0462.java
@@ -41,6 +41,8 @@ public class Update0462 extends AbstractDDLUpdate
     }
 
     // Diese Attribute sind jetzt in der Sollbuchungposition
+    execute(dropForeignKey("fkMitgliedskonto3", "mitgliedskonto"));
+    execute(dropForeignKey("fkMitgliedkonto4", "mitgliedskonto"));
     execute(dropColumn("mitgliedskonto", "buchungsart"));
     execute(dropColumn("mitgliedskonto", "buchungsklasse"));
     execute(dropColumn("mitgliedskonto", "steuersatz"));


### PR DESCRIPTION
Bei H2DB werden anscheinend beim Löschen der Spalten automatisch die Indices und Foreign Keys mit gelöscht. Damit hatte ich getestet.

Bei MariaDB war das nicht so, man konnte die Spalten nicht löschen wenn es Foreign Keys zu der Spalte gab. Ich lösche jetzt die Foreign Keys zuerst. Die Indices werden anscheinend bei beiden implizit gelöscht.