### PR TITLE
Update Oberer Bereich in Saldo Views

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
@@ -29,6 +29,7 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.util.ApplicationException;
@@ -58,15 +59,21 @@ public class VonBisPart implements Part
     SimpleContainer group = new SimpleContainer(parent, false, 2);
     
     LabelGroup zgroup = new LabelGroup(group.getComposite(), "Aktuell angezeigter Zeitraum");
-    zgroup.addLabelPair("Von", control.getDatumvon());
-    zgroup.addLabelPair("Bis", control.getDatumbis());
-    zgroup.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
-    
+    ColumnLayout cl1 = new ColumnLayout(zgroup.getComposite(), 2);
+    SimpleContainer left1 = new SimpleContainer(cl1.getComposite());
+    left1.addLabelPair("Von", control.getDatumvon());
+    SimpleContainer right1 = new SimpleContainer(cl1.getComposite());
+    right1.addLabelPair("Bis", control.getDatumbis());
+
     if (suchen)
     {
+      left1.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
       LabelGroup sgroup = new LabelGroup(group.getComposite(), "Suchen");
-      sgroup.addLabelPair("Von", control.getSuchDatumvon());
-      sgroup.addLabelPair("Bis", control.getSuchDatumbis());
+      ColumnLayout cl2 = new ColumnLayout(sgroup.getComposite(), 2);
+      SimpleContainer left2 = new SimpleContainer(cl2.getComposite());
+      left2.addLabelPair("Von", control.getSuchDatumvon());
+      SimpleContainer right2 = new SimpleContainer(cl2.getComposite());
+      right2.addLabelPair("Bis", control.getSuchDatumbis());
       ButtonArea buttons = new ButtonArea();
 
       Button zurueck = new Button("", new Action()
@@ -140,6 +147,17 @@ public class VonBisPart implements Part
         }
       }, null, false, "go-next.png");
       buttons.addButton(vor);
+
+      Button reset = new Button("Reset", new Action()
+      {
+        @Override
+        public void handleAction(Object context) throws ApplicationException
+        {
+          control.getSuchDatumvon().setValue(control.getDatumvon().getValue());
+          control.getSuchDatumbis().setValue(control.getDatumbis().getValue());
+        }
+      }, null, false, "eraser.png");
+      buttons.addButton(reset);
 
       Button suchen = new Button("Suchen", new Action()
       {

--- a/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
@@ -62,12 +62,19 @@ public class VonBisPart implements Part
     ColumnLayout cl1 = new ColumnLayout(zgroup.getComposite(), 2);
     SimpleContainer left1 = new SimpleContainer(cl1.getComposite());
     left1.addLabelPair("Von", control.getDatumvon());
-    SimpleContainer right1 = new SimpleContainer(cl1.getComposite());
-    right1.addLabelPair("Bis", control.getDatumbis());
+    if (!suchen)
+    {
+      SimpleContainer right1 = new SimpleContainer(cl1.getComposite());
+      right1.addLabelPair("Bis", control.getDatumbis());
+    }
+    else
+    {
+      left1.addLabelPair("Bis", control.getDatumbis());
+    }
 
     if (suchen)
     {
-      left1.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
+      // left1.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
       LabelGroup sgroup = new LabelGroup(group.getComposite(), "Suchen");
       ColumnLayout cl2 = new ColumnLayout(sgroup.getComposite(), 2);
       SimpleContainer left2 = new SimpleContainer(cl2.getComposite());

--- a/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
@@ -74,7 +74,6 @@ public class VonBisPart implements Part
 
     if (suchen)
     {
-      // left1.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
       LabelGroup sgroup = new LabelGroup(group.getComposite(), "Suchen");
       ColumnLayout cl2 = new ColumnLayout(sgroup.getComposite(), 2);
       SimpleContainer left2 = new SimpleContainer(cl2.getComposite());


### PR DESCRIPTION
Wegen #644 habe ich mir die Saldo Views angeschaut und zwei Änderungen gemacht.
* Im Suchen Bereich habe ich einen Reset Button hinzugefügt. Damit kann man die Suchwerte auf die den aktuell angezeigten Bereich setzen
* Wenn kein Suchen vorkommt zeige ich das Datum Von und Bis in einer Zeile an, das schafft mehr Platz für die Tabelle unten
* Das Geschäftsjahr habe ich entfernt, es diente nur früher dazu um die Höhe der beiden Bereiche auszugleichen

Mit Suchen:
![Bildschirmfoto_20250206_111909](https://github.com/user-attachments/assets/9d95eb70-202e-484f-81f3-be279fb07ecf)

Ohne Suchen:
![Bildschirmfoto_20250206_111005](https://github.com/user-attachments/assets/26895986-1a5d-434c-b7b6-7be184aa9d33)
