### PR TITLE
Fix 651

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0462.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0462.java
@@ -41,9 +41,17 @@ public class Update0462 extends AbstractDDLUpdate
     }
 
     // Diese Attribute sind jetzt in der Sollbuchungposition
-    execute(dropForeignKey("fkMitgliedskonto3", "mitgliedskonto"));
+    try
+    {
+      execute(dropForeignKey("fkMitgliedskonto3", "mitgliedskonto"));
+      execute(dropColumn("mitgliedskonto", "buchungsart"));
+    }
+    catch (Exception e)
+    {
+      // Wenn bei MySQL der Key einen anderen NAmen hat damm lassen wir das
+      // Attribut halt bestehen
+    }
     execute(dropForeignKey("fkMitgliedkonto4", "mitgliedskonto"));
-    execute(dropColumn("mitgliedskonto", "buchungsart"));
     execute(dropColumn("mitgliedskonto", "buchungsklasse"));
     execute(dropColumn("mitgliedskonto", "steuersatz"));
     execute(dropColumn("mitgliedskonto", "nettobetrag"));


### PR DESCRIPTION
Ich kenne jetzt die ursache für #651 nicht.
Der Key müsste vorhanden sein wenn nicht schon zum Testen schon mal migriert wurde.

Wegen eine bereits korrigierten Fehlers könnt es aber sein, das der Key in alten MySQL Datenbanken einen anderen Namen hat. Ich habe jetzt keine solche Datenbank zur verfügung.

Wenn jemand eine solche hat könnte er nachschauen wie der Key dort heißt. Falls er einen anderen Namen hat kann ich das in den Upgrade Code einbauen.

Ansonsten habe ich jetzt einfach ein try rumgemacht. Sollte der Key bei MySQL einen anderen Namen haben dann wird das jetzt abgefangen und das Attribut bleibt halt in der DB.

Bei "fkMitgliedkonto4" sollte es das Problem nicht geben weil dieser Key nach meinem Fix erzeugt wurde und darum der Name stimmen sollte.

Wenn das Problem also nicht daher kommt, dass schon mal migriert wurde, dann kann man den PR hier nehmen.