### PR TITLE
Update 457 Korrigiert

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0457.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0457.java
@@ -60,7 +60,7 @@ public class Update0457 extends AbstractDDLUpdate
         false);
     t.add(datum);
     
-    Column zweck = new Column("zweck", COLTYPE.VARCHAR, 140, null, false,
+    Column zweck = new Column("zweck", COLTYPE.VARCHAR, 500, null, false,
         false);
     t.add(zweck);
     


### PR DESCRIPTION
Wie in #654 beschriben kam es zT. zu Fehlern beim DBUpdate. Der Grund war, dass der Zweck1 in der mitgliedkonto Tabelle eine Länge von 500 Zeichen hatte, die Sollbuchungsposition aber nur 140 das habe ich nun auf 500 erhöht. Daher wurde bei der Migration ein Teil des Zwecks abgeschnitten, bzw. eine Exception geworfen. 
Es wär gut, wenn das möglichst schnell übernommen würde und eine 3.0.1 Patch erstellt würde damit die Nutzer gleich das richtige Update machen.
Ist das jetzt richtig mit dem PR hier oder muss ich irgendetwas anderes angeben damit er in den Patch Branch kommt?