### PR TITLE
Umbenennungen

### DIFF
--- a/src/de/jost_net/JVerein/JVereinAdressbuch.java
+++ b/src/de/jost_net/JVerein/JVereinAdressbuch.java
@@ -23,6 +23,7 @@ import java.util.List;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.MitgliedAddress;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.hbci.rmi.Address;
 import de.willuhn.jameica.hbci.rmi.Addressbook;
@@ -49,8 +50,9 @@ public class JVereinAdressbuch implements Addressbook
     while (it.hasNext())
     {
       Mitglied m = (Mitglied) it.next();
-      String kategorie = m.getAdresstyp().getBezeichnung();
-      if (m.getAdresstyp().getID().equals("1"))
+      String kategorie = m.getMitgliedstyp().getBezeichnung();
+      if (m.getMitgliedstyp().getID()
+          .equals(String.valueOf(Mitgliedstyp.MITGLIED)))
       {
         kategorie = m.getBeitragsgruppe().getBezeichnung();
       }

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -34,6 +34,7 @@ import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.server.EigenschaftenNode;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -64,7 +65,7 @@ public class MitgliedQuery
   }
 
   @SuppressWarnings("unchecked")
-  public ArrayList<Mitglied> get(int adresstyp, String sort) throws RemoteException
+  public ArrayList<Mitglied> get(int mitgliedstyp, String sort) throws RemoteException
   {
 
     this.sort = sort;
@@ -205,13 +206,13 @@ public class MitgliedQuery
         bedingungen.add(Integer.valueOf(bg.getID()));
       }
     }
-    if (adresstyp > 0)
+    if (mitgliedstyp > 0)
     {
-      addCondition("adresstyp = " + adresstyp);
+      addCondition(Mitglied.MITGLIEDSTYP + " = " + mitgliedstyp);
     }
-    else if (adresstyp == 0)
+    else if (mitgliedstyp == 0)
     {
-      addCondition("adresstyp != " + 1);
+      addCondition(Mitglied.MITGLIEDSTYP + " != " + Mitgliedstyp.MITGLIED);
     }
     if (control.isMitgliedStatusAktiv())
     {

--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -71,8 +71,8 @@ public class MitgliedMap
     }
     map.put(MitgliedVar.ADRESSIERUNGSZUSATZ.getName(),
         StringTool.toNotNullString(mitglied.getAdressierungszusatz()));
-    map.put(MitgliedVar.ADRESSTYP.getName(),
-        StringTool.toNotNullString(mitglied.getAdresstyp().getID()));
+    map.put(MitgliedVar.MITGLIEDSTYP.getName(),
+        StringTool.toNotNullString(mitglied.getMitgliedstyp().getID()));
     map.put(MitgliedVar.ANREDE.getName(),
         StringTool.toNotNullString(mitglied.getAnrede()));
     map.put(MitgliedVar.ANREDE_FOERMLICH.getName(),

--- a/src/de/jost_net/JVerein/Variable/MitgliedVar.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedVar.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.Variable;
 public enum MitgliedVar
 {
   ADRESSIERUNGSZUSATZ("mitglied_adressierungszusatz"), //
-  ADRESSTYP("mitglied_adresstyp"), //
+  MITGLIEDSTYP("mitglied_adresstyp"), //
   ANREDE("mitglied_anrede"), //
   ANREDE_DU("mitglied_anrede_du"), //
   ANREDE_FOERMLICH("mitglied_anrede_foermlich"), //

--- a/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
@@ -27,7 +27,7 @@ import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.server.AbrechnungslaufImpl;
-import de.jost_net.JVerein.server.AdresstypImpl;
+import de.jost_net.JVerein.server.MitgliedstypImpl;
 import de.jost_net.JVerein.server.AltersstaffelImpl;
 import de.jost_net.JVerein.server.AnfangsbestandImpl;
 import de.jost_net.JVerein.server.ArbeitseinsatzImpl;
@@ -163,7 +163,7 @@ public class BackupCreateAction implements Action
           monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mitgliedstypen");
-          backup(AdresstypImpl.class, writer, monitor);
+          backup(MitgliedstypImpl.class, writer, monitor);
           monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Buchungsklassen");

--- a/src/de/jost_net/JVerein/gui/action/BackupRestoreAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BackupRestoreAction.java
@@ -31,7 +31,7 @@ import org.eclipse.swt.widgets.FileDialog;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.JVereinPlugin;
 import de.jost_net.JVerein.DBTools.DBTransaction;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
 import de.jost_net.JVerein.rmi.Einstellung;
 import de.jost_net.JVerein.rmi.Version;
@@ -206,7 +206,7 @@ public class BackupRestoreAction implements Action
             catch (Exception e)
             {
               //Fehler Bei Adresstyp ignorieren, da hier bereits "Spender" und "Mitglied" existiert und es einen DUPLICATE KEY gibt
-              if(!(o instanceof Adresstyp))
+              if(!(o instanceof Mitgliedstyp))
               {
                 Logger.error("unable to import " + o.getClass().getName() + ":"
                     + o.getID() + ", skipping", e);

--- a/src/de/jost_net/JVerein/gui/action/KursteilnehmerWirdMitgliedAction.java
+++ b/src/de/jost_net/JVerein/gui/action/KursteilnehmerWirdMitgliedAction.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.view.MitgliedDetailView;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
@@ -40,7 +41,7 @@ public class KursteilnehmerWirdMitgliedAction implements Action
     {
       Mitglied m = (Mitglied) Einstellungen.getDBService().createObject(
           Mitglied.class, null);
-      m.setAdresstyp(1);
+      m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
       m.setAnrede(k.getAnrede());
       m.setBic(k.getBic());
       m.setEmail(k.getEmail());

--- a/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.rmi.Wiedervorlage;
@@ -123,7 +124,8 @@ public class MitgliedDetailAction implements Action
           mitglied.setPersonenart("n");
         }
       }
-      if (mitglied.getAdresstyp() == null || mitglied.getAdresstyp().getID().equals("1"))
+      if (mitglied.getMitgliedstyp() == null || mitglied.getMitgliedstyp()
+          .getID().equals(String.valueOf(Mitgliedstyp.MITGLIED)))
       {
         GUI.startView(new MitgliedDetailView(), mitglied);
       }

--- a/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.action;
 import de.jost_net.JVerein.gui.view.NichtMitgliedDetailView;
 import de.jost_net.JVerein.gui.view.MitgliedDetailView;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
@@ -38,7 +39,7 @@ public class MitgliedDuplizierenAction implements Action
     {
       m = (Mitglied) context;
       m.setID(null);
-      if (m.getAdresstyp().getJVereinid() == 1)
+      if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
       {
         GUI.startView(new MitgliedDetailView(), m);
       }

--- a/src/de/jost_net/JVerein/gui/action/MitgliedstypAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedstypAction.java
@@ -20,7 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.view.MitgliedstypView;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
@@ -30,11 +30,11 @@ public class MitgliedstypAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    Adresstyp at = null;
+    Mitgliedstyp at = null;
 
-    if (context != null && (context instanceof Adresstyp))
+    if (context != null && (context instanceof Mitgliedstyp))
     {
-      at = (Adresstyp) context;
+      at = (Mitgliedstyp) context;
       try
       {
         if (at.getJVereinid() > 0)
@@ -52,8 +52,8 @@ public class MitgliedstypAction implements Action
     {
       try
       {
-        at = (Adresstyp) Einstellungen.getDBService().createObject(
-            Adresstyp.class, null);
+        at = (Mitgliedstyp) Einstellungen.getDBService().createObject(
+            Mitgliedstyp.class, null);
       }
       catch (RemoteException e)
       {

--- a/src/de/jost_net/JVerein/gui/action/MitgliedstypDefaultAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedstypDefaultAction.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.action;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.logging.Logger;
@@ -35,15 +35,15 @@ public class MitgliedstypDefaultAction implements Action
   {
     try
     {
-      Adresstyp at = (Adresstyp) Einstellungen.getDBService().createObject(
-          Adresstyp.class, "1");
+      Mitgliedstyp at = (Mitgliedstyp) Einstellungen.getDBService().createObject(
+          Mitgliedstyp.class, String.valueOf(Mitgliedstyp.MITGLIED));
       at.setBezeichnung("Mitglied");
-      at.setJVereinid(1);
+      at.setJVereinid(Mitgliedstyp.MITGLIED);
       at.store();
-      at = (Adresstyp) Einstellungen.getDBService().createObject(
-          Adresstyp.class, "2");
+      at = (Mitgliedstyp) Einstellungen.getDBService().createObject(
+          Mitgliedstyp.class, String.valueOf(Mitgliedstyp.SPENDER));
       at.setBezeichnung("Spender/in");
-      at.setJVereinid(2);
+      at.setJVereinid(Mitgliedstyp.SPENDER);
       at.store();
 
       GUI.getStatusBar().setSuccessText("Mitgliedstypen eingefügt.");

--- a/src/de/jost_net/JVerein/gui/action/MitgliedstypDeleteAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedstypDeleteAction.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.action;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
@@ -36,13 +36,13 @@ public class MitgliedstypDeleteAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof Adresstyp))
+    if (context == null || !(context instanceof Mitgliedstyp))
     {
       throw new ApplicationException("Kein Mitgliedstyp ausgewählt");
     }
     try
     {
-      Adresstyp at = (Adresstyp) context;
+      Mitgliedstyp at = (Mitgliedstyp) context;
       if (at.getJVereinid() > 0)
       {
         throw new ApplicationException(
@@ -54,7 +54,7 @@ public class MitgliedstypDeleteAction implements Action
       }
       DBIterator<Mitglied> it = Einstellungen.getDBService()
           .createList(Mitglied.class);
-      it.addFilter("adresstyp = ?", new Object[] { at.getID() });
+      it.addFilter(Mitglied.MITGLIEDSTYP + " = ?", new Object[] { at.getID() });
       it.setLimit(1);
       if (it.hasNext())
       {

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -51,6 +51,7 @@ import de.jost_net.JVerein.rmi.Lehrgang;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedfoto;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.SekundaereBeitragsgruppe;
 import de.jost_net.JVerein.rmi.Wiedervorlage;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
@@ -290,7 +291,8 @@ public class PersonalbogenAction implements Action
       kommunikation += "Email: " + m.getEmail();
     }
     rpt.addColumn(kommunikation, Element.ALIGN_LEFT);
-    if (m.getAdresstyp().getID().equals("1"))
+    if (m.getMitgliedstyp().getID()
+        .equals(String.valueOf(Mitgliedstyp.MITGLIED)))
     {
       rpt.addColumn("Eintritt", Element.ALIGN_LEFT);
       rpt.addColumn(m.getEintritt(), Element.ALIGN_LEFT);

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -45,7 +45,7 @@ import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.SuchSpendenart;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Eigenschaft;
@@ -89,11 +89,11 @@ public class FilterControl extends AbstractControl
 
   protected Settings settings = null;
 
-  protected Mitgliedstyp typ = Mitgliedstyp.NOT_USED;
+  protected Mitgliedstypen typ = Mitgliedstypen.NOT_USED;
 
   protected TreePart eigenschaftenAuswahlTree = null;
 
-  protected SelectInput suchadresstyp = null;
+  protected SelectInput suchmitgliedstyp = null;
 
   protected SelectInput status = null;
 
@@ -176,7 +176,7 @@ public class FilterControl extends AbstractControl
 
   protected SelectInput suchspendenart = null;
 
-  public enum Mitgliedstyp {
+  public enum Mitgliedstypen {
     MITGLIED,
     NICHTMITGLIED,
     NOT_USED,
@@ -223,23 +223,24 @@ public class FilterControl extends AbstractControl
   /**
    * Such Input Felder
    */
-  public SelectInput getSuchAdresstyp(Mitgliedstyp typ) throws RemoteException
+  public SelectInput getSuchMitgliedstyp(Mitgliedstypen typ) throws RemoteException
   {
-    if (suchadresstyp != null)
+    if (suchmitgliedstyp != null)
     {
-      return suchadresstyp;
+      return suchmitgliedstyp;
     }
     this.typ = typ;
 
-    DBIterator<Adresstyp> at = Einstellungen.getDBService()
-        .createList(Adresstyp.class);
+    DBIterator<Mitgliedstyp> at = Einstellungen.getDBService()
+        .createList(Mitgliedstyp.class);
     switch (typ)
     {
       case MITGLIED:
-        at.addFilter("jvereinid = 1");
+        at.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
         break;
       case NICHTMITGLIED:
-        at.addFilter("jvereinid != 1 or jvereinid is null");
+        at.addFilter(Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.MITGLIED
+            + " OR " + Mitgliedstyp.JVEREINID + " IS NULL");
         break;
       case NOT_USED:
       case ALLE:
@@ -247,39 +248,40 @@ public class FilterControl extends AbstractControl
     }
     at.setOrder("order by bezeichnung");
 
-    if (typ == Mitgliedstyp.MITGLIED)
+    if (typ == Mitgliedstypen.MITGLIED)
     {
-      Adresstyp def = (Adresstyp) Einstellungen.getDBService()
-          .createObject(Adresstyp.class, "1");
-      suchadresstyp = new SelectInput(at != null ? PseudoIterator.asList(at) : null, def);
+      Mitgliedstyp def = (Mitgliedstyp) Einstellungen.getDBService()
+          .createObject(Mitgliedstyp.class,
+              String.valueOf(Mitgliedstyp.MITGLIED));
+      suchmitgliedstyp = new SelectInput(at != null ? PseudoIterator.asList(at) : null, def);
     }
-    else if (typ == Mitgliedstyp.NICHTMITGLIED || typ == Mitgliedstyp.ALLE)
+    else if (typ == Mitgliedstypen.NICHTMITGLIED || typ == Mitgliedstypen.ALLE)
     {
-      Adresstyp def = null;
+      Mitgliedstyp def = null;
       try
       {
-        def = (Adresstyp) Einstellungen.getDBService().createObject(
-            Adresstyp.class, settings.getString(settingsprefix + "suchadresstyp", "2"));
+        def = (Mitgliedstyp) Einstellungen.getDBService().createObject(
+            Mitgliedstyp.class, settings.getString(settingsprefix + "suchadresstyp", "2"));
       }
       catch (Exception e)
       {
         def = null;
       }
-      suchadresstyp = new SelectInput(at != null ? PseudoIterator.asList(at) : null, def);
+      suchmitgliedstyp = new SelectInput(at != null ? PseudoIterator.asList(at) : null, def);
     }
     else
     {
-      suchadresstyp = new SelectInput(new ArrayList<>(), null);
+      suchmitgliedstyp = new SelectInput(new ArrayList<>(), null);
     }
-    suchadresstyp.setName("Mitgliedstyp");
-    suchadresstyp.setPleaseChoose(ALLE);
-    suchadresstyp.addListener(new FilterListener());
-    return suchadresstyp;
+    suchmitgliedstyp.setName("Mitgliedstyp");
+    suchmitgliedstyp.setPleaseChoose(ALLE);
+    suchmitgliedstyp.addListener(new FilterListener());
+    return suchmitgliedstyp;
   }
   
-  public boolean isSuchAdresstypActive()
+  public boolean isSuchMitgliedstypActive()
   {
-    return suchadresstyp != null;
+    return suchmitgliedstyp != null;
   }
   
   public Input getMitgliedStatus()
@@ -1271,8 +1273,8 @@ public class FilterControl extends AbstractControl
         settings.setAttribute("id", "");
         settings.setAttribute("profilname", "");
 
-        if (suchadresstyp != null && typ != Mitgliedstyp.MITGLIED)
-          suchadresstyp.setValue(null);
+        if (suchmitgliedstyp != null && typ != Mitgliedstypen.MITGLIED)
+          suchmitgliedstyp.setValue(null);
         if (status != null)
           status.setValue("Angemeldet");
         if (art != null)
@@ -1483,9 +1485,9 @@ public class FilterControl extends AbstractControl
    */
   public void saveFilterSettings() throws RemoteException
   {
-    if (suchadresstyp != null)
+    if (suchmitgliedstyp != null)
     {
-      Adresstyp tmp = (Adresstyp) suchadresstyp.getValue();
+      Mitgliedstyp tmp = (Mitgliedstyp) suchmitgliedstyp.getValue();
       if (tmp != null)
       {
         settings.setAttribute(settingsprefix + "suchadresstyp", tmp.getID());

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -29,6 +29,8 @@ import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.menu.LastschriftMenu;
 import de.jost_net.JVerein.gui.view.LastschriftDetailView;
 import de.jost_net.JVerein.rmi.Lastschrift;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -168,11 +170,13 @@ public class LastschriftControl extends FilterControl
         lastschriften.addFilter("mitglied.id = lastschrift.mitglied");
         if (tmpArt.equalsIgnoreCase("Mitglied"))
         {
-          lastschriften.addFilter("(adresstyp = 1)");
+          lastschriften
+              .addFilter(Mitglied.MITGLIEDSTYP + " = " + Mitgliedstyp.MITGLIED);
         }
         else if (tmpArt.equalsIgnoreCase("Nicht-Mitglied"))
         {
-          lastschriften.addFilter("(adresstyp > 1)");
+          lastschriften
+              .addFilter(Mitglied.MITGLIEDSTYP + " > " + Mitgliedstyp.MITGLIED);
         }
       }
     }
@@ -256,7 +260,8 @@ public class LastschriftControl extends FilterControl
     String text = "";
     if (getLastschrift().getKursteilnehmer() != null)
       text = "Kursteilnehmer";
-    else if (getLastschrift().getMitglied().getAdresstyp().getJVereinid() == 1)
+    else if (getLastschrift().getMitglied().getMitgliedstyp()
+        .getJVereinid() == Mitgliedstyp.MITGLIED)
       text = "Mitglied";
     else
       text = "Nicht-Mitglied";

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -177,7 +177,7 @@ public class MailControl extends FilterControl
     mitgliedmitmail.addColumn("EMail", "email");
     mitgliedmitmail.addColumn("Name", "name");
     mitgliedmitmail.addColumn("Vorname", "vorname");
-    mitgliedmitmail.addColumn("Mitgliedstyp", "adresstyp");
+    mitgliedmitmail.addColumn("Mitgliedstyp", Mitglied.MITGLIEDSTYP);
     mitgliedmitmail.setRememberOrder(true);
     mitgliedmitmail.setCheckable(true);
     mitgliedmitmail.removeFeature(FeatureSummary.class);

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -86,7 +86,7 @@ import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsrhythmus;
 import de.jost_net.JVerein.keys.Zahlungstermin;
 import de.jost_net.JVerein.keys.Zahlungsweg;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Eigenschaft;
@@ -153,7 +153,7 @@ public class MitgliedControl extends FilterControl
 
   private TablePart part;
 
-  private SelectNoScrollInput adresstyp;
+  private SelectNoScrollInput mitgliedstyp;
 
   private TextInput externemitgliedsnummer;
 
@@ -339,19 +339,20 @@ public class MitgliedControl extends FilterControl
     this.mitglied = mitglied;
   }
 
-  public SelectNoScrollInput getAdresstyp() throws RemoteException
+  public SelectNoScrollInput getMitgliedstyp() throws RemoteException
   {
-    if (adresstyp != null)
+    if (mitgliedstyp != null)
     {
-      return adresstyp;
+      return mitgliedstyp;
     }
-    DBIterator<Adresstyp> at = Einstellungen.getDBService()
-        .createList(Adresstyp.class);
-    at.addFilter("jvereinid != 1 or jvereinid is null");
+    DBIterator<Mitgliedstyp> at = Einstellungen.getDBService()
+        .createList(Mitgliedstyp.class);
+    at.addFilter(Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.MITGLIED
+        + " OR " + Mitgliedstyp.JVEREINID + " IS NULL");
     at.setOrder("order by bezeichnung");
-    adresstyp = new SelectNoScrollInput(at != null ? PseudoIterator.asList(at) : null, getMitglied().getAdresstyp());
-    adresstyp.setName("Mitgliedstyp");
-    return adresstyp;
+    mitgliedstyp = new SelectNoScrollInput(at != null ? PseudoIterator.asList(at) : null, getMitglied().getMitgliedstyp());
+    mitgliedstyp.setName("Mitgliedstyp");
+    return mitgliedstyp;
   }
 
   public TextInput getExterneMitgliedsnummer() throws RemoteException
@@ -2314,20 +2315,20 @@ public class MitgliedControl extends FilterControl
 
       }
 
-      if (adresstyp != null)
+      if (mitgliedstyp != null)
       {
-        Adresstyp at = (Adresstyp) getAdresstyp().getValue();
-        m.setAdresstyp(Integer.valueOf(at.getID()));
+        Mitgliedstyp at = (Mitgliedstyp) getMitgliedstyp().getValue();
+        m.setMitgliedstyp(Integer.valueOf(at.getID()));
       }
       else
       {
-        m.setAdresstyp(1);
+        m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
       }
       m.setAdressierungszusatz((String) getAdressierungszusatz().getValue());
       m.setAustritt((Date) getAustritt().getValue());
       m.setAnrede((String) getAnrede().getValue());
       GenericObject o = (GenericObject) getBeitragsgruppe(true).getValue();
-      if (adresstyp == null)
+      if (mitgliedstyp == null)
       {
         try
         {
@@ -2445,7 +2446,8 @@ public class MitgliedControl extends FilterControl
       m.setLetzteAenderung();
       m.store();
 
-      boolean ist_mitglied = m.getAdresstyp().getJVereinid() == 1;
+      boolean ist_mitglied = m.getMitgliedstyp()
+          .getJVereinid() == Mitgliedstyp.MITGLIED;
       if (Einstellungen.getEinstellung().getMitgliedfoto() && ist_mitglied)
       {
         Mitgliedfoto f = null;
@@ -2589,7 +2591,7 @@ public class MitgliedControl extends FilterControl
         }
       }
       String successtext = "";
-      if (m.getAdresstyp().getJVereinid() == 1)
+      if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
       {
         successtext = "Mitglied gespeichert";
       }
@@ -2773,7 +2775,7 @@ public class MitgliedControl extends FilterControl
       sort = (String) getSortierung().getValue();
     }
     ArrayList<Mitglied> list = null;
-    Adresstyp atyp = (Adresstyp) getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+    Mitgliedstyp atyp = (Mitgliedstyp) getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
     if (atyp == null)
     {
       GUI.getStatusBar().setErrorText("Bitte Mitgliedstyp auswählen");
@@ -3035,7 +3037,7 @@ public class MitgliedControl extends FilterControl
     {
       try
       {
-        Adresstyp at = (Adresstyp) getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+        Mitgliedstyp at = (Mitgliedstyp) getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
         if (at != null)
         {
           refreshMitgliedTable(Integer.parseInt(at.getID()));

--- a/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
@@ -21,7 +21,7 @@ import java.rmi.RemoteException;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.MitgliedstypAction;
 import de.jost_net.JVerein.gui.menu.MitgliedstypMenu;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractControl;
@@ -39,13 +39,13 @@ public class MitgliedstypControl extends AbstractControl
 {
   private de.willuhn.jameica.system.Settings settings;
 
-  private TablePart adresstypList;
+  private TablePart mitgliedstypList;
 
   private Input bezeichnung;
 
   private Input bezeichnungplural;
 
-  private Adresstyp adresstyp;
+  private Mitgliedstyp mitgliedstyp;
 
   public MitgliedstypControl(AbstractView view)
   {
@@ -54,14 +54,14 @@ public class MitgliedstypControl extends AbstractControl
     settings.setStoreWhenRead(true);
   }
 
-  public Adresstyp getAdresstyp()
+  public Mitgliedstyp getMitgliedstyp()
   {
-    if (adresstyp != null)
+    if (mitgliedstyp != null)
     {
-      return adresstyp;
+      return mitgliedstyp;
     }
-    adresstyp = (Adresstyp) getCurrentObject();
-    return adresstyp;
+    mitgliedstyp = (Mitgliedstyp) getCurrentObject();
+    return mitgliedstyp;
   }
 
   public Input getBezeichnung() throws RemoteException
@@ -70,7 +70,7 @@ public class MitgliedstypControl extends AbstractControl
     {
       return bezeichnung;
     }
-    bezeichnung = new TextInput(getAdresstyp().getBezeichnung(), 30);
+    bezeichnung = new TextInput(getMitgliedstyp().getBezeichnung(), 30);
     return bezeichnung;
   }
 
@@ -80,7 +80,7 @@ public class MitgliedstypControl extends AbstractControl
     {
       return bezeichnungplural;
     }
-    bezeichnungplural = new TextInput(getAdresstyp().getBezeichnungPlural(),
+    bezeichnungplural = new TextInput(getMitgliedstyp().getBezeichnungPlural(),
         30);
     return bezeichnungplural;
   }
@@ -92,7 +92,7 @@ public class MitgliedstypControl extends AbstractControl
   {
     try
     {
-      Adresstyp at = getAdresstyp();
+      Mitgliedstyp at = getMitgliedstyp();
       at.setBezeichnung((String) getBezeichnung().getValue());
       at.setBezeichnungPlural((String) getBezeichnungPlural().getValue());
       try
@@ -113,20 +113,21 @@ public class MitgliedstypControl extends AbstractControl
     }
   }
 
-  public Part getAdresstypList() throws RemoteException
+  public Part getMitgliedstypList() throws RemoteException
   {
     DBService service = Einstellungen.getDBService();
-    DBIterator<Adresstyp> adresstypen = service.createList(Adresstyp.class);
-    adresstypen.setOrder("ORDER BY bezeichnung");
+    DBIterator<Mitgliedstyp> mitgliedstypen = service.createList(Mitgliedstyp.class);
+    mitgliedstypen.setOrder("ORDER BY bezeichnung");
 
-    adresstypList = new TablePart(adresstypen, new MitgliedstypAction());
-    adresstypList.addColumn("Bezeichnung", "bezeichnung");
-    adresstypList.addColumn("Bezeichnung Plural", "bezeichnungplural");
-    adresstypList.addColumn("ID", "id");
-    adresstypList.setContextMenu(new MitgliedstypMenu());
-    adresstypList.setRememberColWidths(true);
-    adresstypList.setRememberOrder(true);
-    adresstypList.addFeature(new FeatureSummary());
-    return adresstypList;
+    mitgliedstypList = new TablePart(mitgliedstypen, new MitgliedstypAction());
+    mitgliedstypList.addColumn("Bezeichnung", Mitgliedstyp.BEZEICHNUNG);
+    mitgliedstypList.addColumn("Bezeichnung Plural",
+        Mitgliedstyp.BEZEICHNUNG_PLURAL);
+    mitgliedstypList.addColumn("ID", "id");
+    mitgliedstypList.setContextMenu(new MitgliedstypMenu());
+    mitgliedstypList.setRememberColWidths(true);
+    mitgliedstypList.setRememberOrder(true);
+    mitgliedstypList.addFeature(new FeatureSummary());
+    return mitgliedstypList;
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/SEPABugsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SEPABugsControl.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.io.ILastschrift;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.server.Bug;
 import de.jost_net.OBanToo.SEPA.BIC;
 import de.jost_net.OBanToo.SEPA.IBAN;
@@ -167,7 +168,7 @@ public class SEPABugsControl extends AbstractControl
     DBIterator<Mitglied> it = Einstellungen.getDBService()
         .createList(Mitglied.class);
     it.addFilter("(austritt is null or austritt > ?)", new Date());
-    it.addFilter("adresstyp = 1");
+    it.addFilter(Mitglied.MITGLIEDSTYP + " = " + Mitgliedstyp.MITGLIED);
     return it;
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.jost_net.JVerein.rmi.Eigenschaften;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.server.EigenschaftenNode;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
@@ -149,7 +150,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getAdresstyp().getJVereinid() == 1
+            if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED
                 && m.isAngemeldet(stichtag))
             {
               control.getMitgliedMitMail().setChecked(o, true);
@@ -174,7 +175,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getAdresstyp().getJVereinid() == 1
+            if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED
                 && !m.isAngemeldet(stichtag))
             {
               control.getMitgliedMitMail().setChecked(o, true);
@@ -198,7 +199,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getAdresstyp().getJVereinid() != 1)
+            if (m.getMitgliedstyp().getJVereinid() != Mitgliedstyp.MITGLIED)
             {
               control.getMitgliedMitMail().setChecked(o, true);
             }
@@ -222,8 +223,8 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getAdresstyp().getJVereinid() != 1
-                || (m.getAdresstyp().getJVereinid() == 1
+            if (m.getMitgliedstyp().getJVereinid() != Mitgliedstyp.MITGLIED
+                || (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED
                     && m.isAngemeldet(stichtag)))
             {
               control.getMitgliedMitMail().setChecked(o, true);

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -43,6 +43,7 @@ import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.MitgliedNextBGruppe;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.SekundaereBeitragsgruppe;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -110,7 +111,7 @@ public class MitgliedMenu extends ContextMenu
             {
               Logger.error("Fehler", e);
             }
-            m.setAdresstyp(1);
+            m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
             m.setEingabedatum();
             GUI.startView(MitgliedDetailView.class.getName(), m);
           }
@@ -146,7 +147,7 @@ public class MitgliedMenu extends ContextMenu
             {
               Logger.error("Fehler", e);
             }
-            m.setAdresstyp(2);
+            m.setMitgliedstyp(Mitgliedstyp.SPENDER);
             m.setEingabedatum();
             m.setBeitragsgruppe(null);
             m.setExterneMitgliedsnummer(null);

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -617,7 +617,7 @@ public abstract class AbstractMitgliedDetailView extends AbstractView
 
     if (!isMitgliedDetail())
     {
-      cols.addInput(control.getAdresstyp());
+      cols.addInput(control.getMitgliedstyp());
     }
     cols.addInput(control.getAnrede());
     if (control.getMitglied().getPersonenart().equalsIgnoreCase("n"))

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedSucheView.java
@@ -23,8 +23,8 @@ import java.sql.SQLException;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.MitgliederImportAction;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
@@ -86,7 +86,7 @@ public abstract class AbstractMitgliedSucheView extends AbstractView
     Long anzahl = (Long) service.execute(sql, new Object[] {}, rs);
     if (anzahl.longValue() > 0)
     {
-      Adresstyp at = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.MITGLIED).getValue();
+      Mitgliedstyp at = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.MITGLIED).getValue();
       if (at != null)
       {
       Logger.debug(at.getID() + ": " + at.getBezeichnung());

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -21,7 +21,7 @@ import java.rmi.RemoteException;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.DialogInput;
@@ -50,7 +50,7 @@ public class AuswertungNichtMitgliedView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
 
     left.addInput(control.getMailauswahl());
-    left.addInput(control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED));
+    left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED));
     DialogInput eigenschaftenInput = control.getEigenschaftenAuswahl();
     left.addInput(eigenschaftenInput);
     control.updateEigenschaftenAuswahlTooltip();

--- a/src/de/jost_net/JVerein/gui/view/FreieFormulareView.java
+++ b/src/de/jost_net/JVerein/gui/view/FreieFormulareView.java
@@ -5,7 +5,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.FreieFormulareControl;
 import de.jost_net.JVerein.keys.FormularArt;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.DialogInput;
@@ -30,7 +30,7 @@ public class FreieFormulareView extends AbstractView
 
     ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
     SimpleContainer left = new SimpleContainer(cl.getComposite());
-    left.addInput(control.getSuchAdresstyp(Mitgliedstyp.ALLE));
+    left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.ALLE));
     left.addInput(control.getMitgliedStatus());
     left.addInput(control.getBeitragsgruppeAusw());
     left.addInput(control.getMailauswahl());

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -45,7 +45,7 @@ public class KontoauszugView extends AbstractView
     {
       ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
       SimpleContainer left = new SimpleContainer(cl.getComposite());
-      left.addInput(control.getSuchAdresstyp(Mitgliedstyp.ALLE));
+      left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.ALLE));
       left.addInput(control.getMitgliedStatus());
       left.addInput(control.getBeitragsgruppeAusw());
       left.addInput(control.getMailauswahl());

--- a/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliederSucheView.java
@@ -28,7 +28,7 @@ import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 
 public class MitgliederSucheView extends AbstractMitgliedSucheView
 {
@@ -36,7 +36,7 @@ public class MitgliederSucheView extends AbstractMitgliedSucheView
   public MitgliederSucheView() throws RemoteException
   {
     control.init("mitglied.", "zusatzfeld.", "zusatzfelder.");
-    control.getSuchAdresstyp(Mitgliedstyp.MITGLIED).getValue();
+    control.getSuchMitgliedstyp(Mitgliedstypen.MITGLIED).getValue();
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/MitgliedstypenListView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedstypenListView.java
@@ -21,7 +21,7 @@ import de.jost_net.JVerein.gui.action.MitgliedstypAction;
 import de.jost_net.JVerein.gui.action.MitgliedstypDefaultAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MitgliedstypControl;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -37,16 +37,18 @@ public class MitgliedstypenListView extends AbstractView
 
     MitgliedstypControl control = new MitgliedstypControl(this);
 
-    control.getAdresstypList().paint(this.getParent());
+    control.getMitgliedstypList().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ADRESSTYPEN, false, "question-circle.png");
     buttons.addButton("Neu", new MitgliedstypAction(), null, false, "document-new.png");
 
-    DBIterator<Adresstyp> it = Einstellungen.getDBService()
-        .createList(Adresstyp.class);
-    it.addFilter("jvereinid >= 1 and jvereinid <= 2");
+    DBIterator<Mitgliedstyp> it = Einstellungen.getDBService()
+        .createList(Mitgliedstyp.class);
+    it.addFilter(Mitgliedstyp.JVEREINID + " >= " + Mitgliedstyp.MITGLIED
+        + " AND " + Mitgliedstyp.JVEREINID + " <= "
+        + Mitgliedstyp.SPENDER);
     if (it.size() == 0)
     {
       buttons.addButton("Default-Mitgliedstypen einrichten",

--- a/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
+++ b/src/de/jost_net/JVerein/gui/view/NichtMitgliederSucheView.java
@@ -28,14 +28,14 @@ import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 
 public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
 {
   public NichtMitgliederSucheView() throws RemoteException
   {
     control.init("nichtmitglied.", "nichtzusatzfeld.", "nichtzusatzfelder.");
-    control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+    control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
   }
 
   @Override
@@ -52,7 +52,7 @@ public class NichtMitgliederSucheView extends AbstractMitgliedSucheView
     
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
-    left.addInput(control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED));
+    left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED));
     DialogInput eigenschaftenInput = control.getEigenschaftenAuswahl();
     left.addInput(eigenschaftenInput);
     control.updateEigenschaftenAuswahlTooltip();

--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -18,11 +18,11 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.MitgliedMap;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.FreieFormulareControl;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.FormularArt;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.Dateiname;
@@ -64,11 +64,11 @@ public class FreiesFormularAusgabe
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
     }
-    Adresstyp adresstype = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.ALLE)
+    Mitgliedstyp mitgliedstyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.ALLE)
         .getValue();
     int type = -1;
-    if (adresstype != null)
-      type = Integer.parseInt(adresstype.getID());
+    if (mitgliedstyp != null)
+      type = Integer.parseInt(mitgliedstyp.getID());
     ArrayList<Mitglied> mitglieder = new MitgliedQuery(control).get(type, null);
 
     if (mitglieder.size() == 0)

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -36,14 +36,14 @@ import com.itextpdf.text.Element;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Queries.MitgliedQuery;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl;
 import de.jost_net.JVerein.gui.control.MitgliedskontoControl.DIFFERENZ;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Zahlungsweg;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.Dateiname;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -71,15 +71,15 @@ public class Kontoauszug
     this();
     ArrayList<Mitglied> mitglieder = new ArrayList<>();
 
-    if (object == null && control.isSuchAdresstypActive() && 
-        control.getSuchAdresstyp(Mitgliedstyp.ALLE).getValue() != null)
+    if (object == null && control.isSuchMitgliedstypActive() && 
+        control.getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue() != null)
     {
-      Adresstyp atyp = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.ALLE).getValue();
+      Mitgliedstyp atyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue();
       mitglieder = new MitgliedQuery(control).
           get(Integer.parseInt(atyp.getID()), null);
     }
-    else if (object == null && control.isSuchAdresstypActive() && 
-        control.getSuchAdresstyp(Mitgliedstyp.ALLE).getValue() == null)
+    else if (object == null && control.isSuchMitgliedstypActive() && 
+        control.getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue() == null)
     {
       mitglieder = new MitgliedQuery(control).get(-1, null);
     }

--- a/src/de/jost_net/JVerein/io/Migration.java
+++ b/src/de/jost_net/JVerein/io/Migration.java
@@ -47,6 +47,7 @@ import de.jost_net.JVerein.rmi.MailEmpfaenger;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedfoto;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.jost_net.JVerein.rmi.Wiedervorlage;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
@@ -588,7 +589,7 @@ public class Migration
       final Map<String, Integer> beitragsGruppen)
       throws RemoteException, SQLException, ApplicationException, ParseException
   {
-    m.setAdresstyp(1);
+    m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
 
     /*
      * necessary columns
@@ -892,24 +893,24 @@ public class Migration
       m.setZahlungsrhythmus(Integer.valueOf(12));
     }
 
-    String adresstyp = getResultFrom(results, InternalColumns.ADRESSTYP);
-    if (adresstyp.length() > 0)
+    String mitgliedstyp = getResultFrom(results, InternalColumns.ADRESSTYP);
+    if (mitgliedstyp.length() > 0)
     {
-      if (adresstyp.matches("[0-9]+"))
+      if (mitgliedstyp.matches("[0-9]+"))
       {
-        m.setAdresstyp(Integer.parseInt(adresstyp));
+        m.setMitgliedstyp(Integer.parseInt(mitgliedstyp));
       }
       else
       {
         progMonitor.log(String.format(
             "Mitgliedstyp bei: %s ist entweder leer oder besteht nicht nur aus Zahlen, setze auf 1 (Mitglied)",
             Adressaufbereitung.getNameVorname(m)));
-        m.setAdresstyp(Integer.valueOf(1));
+        m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
       }
     }
     else
     { // Default value
-      m.setAdresstyp(Integer.valueOf(1));
+      m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
     }
 
     m.setVermerk1(getResultFrom(results, InternalColumns.VERMERKA));

--- a/src/de/jost_net/JVerein/io/MitgliedAdresslistePDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAdresslistePDF.java
@@ -26,10 +26,10 @@ import com.itextpdf.text.Paragraph;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.view.IAuswertung;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.GUI;
@@ -42,7 +42,7 @@ public class MitgliedAdresslistePDF implements IAuswertung
 
   private MitgliedControl control;
 
-  private Adresstyp adresstyp;
+  private Mitgliedstyp mitgliedstyp;
 
   private String subtitle = "";
   
@@ -61,16 +61,16 @@ public class MitgliedAdresslistePDF implements IAuswertung
     zusatzfeld = control.getAdditionalparamprefix1();
     zusatzfelder = control.getAdditionalparamprefix2();
     
-    if (control.isSuchAdresstypActive())
+    if (control.isSuchMitgliedstypActive())
     {
-      adresstyp = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+      mitgliedstyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
     }
     else
     {
-      DBIterator<Adresstyp> it = Einstellungen.getDBService()
-          .createList(Adresstyp.class);
-      it.addFilter("jvereinid=1");
-      adresstyp = (Adresstyp) it.next();
+      DBIterator<Mitgliedstyp> it = Einstellungen.getDBService()
+          .createList(Mitgliedstyp.class);
+      it.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
+      mitgliedstyp = (Mitgliedstyp) it.next();
     }
     String ueberschrift = (String) control.getAuswertungUeberschrift()
         .getValue();
@@ -88,7 +88,7 @@ public class MitgliedAdresslistePDF implements IAuswertung
     {
       FileOutputStream fos = new FileOutputStream(file);
 
-      Reporter report = new Reporter(fos, adresstyp.getBezeichnungPlural(),
+      Reporter report = new Reporter(fos, mitgliedstyp.getBezeichnungPlural(),
           subtitle, list.size(), 20, 20, 20, 25);
 
       report.addHeaderColumn("Name", Element.ALIGN_CENTER, 60,
@@ -140,7 +140,7 @@ public class MitgliedAdresslistePDF implements IAuswertung
       report.closeTable();
 
       report.add(new Paragraph(String.format("Anzahl %s: %d",
-          adresstyp.getBezeichnungPlural(), list.size()), Reporter.getFreeSans(8)));
+          mitgliedstyp.getBezeichnungPlural(), list.size()), Reporter.getFreeSans(8)));
 
       report.close();
       GUI.getStatusBar().setSuccessText(

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -29,11 +29,11 @@ import com.itextpdf.text.Paragraph;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.view.IAuswertung;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.server.Tools.EigenschaftenTool;
@@ -48,7 +48,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
 
   private MitgliedControl control;
 
-  private Adresstyp adresstyp;
+  private Mitgliedstyp mitgliedstyp;
 
   private String subtitle = "";
 
@@ -71,16 +71,16 @@ public class MitgliedAuswertungPDF implements IAuswertung
     zusatzfeld = control.getAdditionalparamprefix1();
     zusatzfelder = control.getAdditionalparamprefix2();
     
-    if (control.isSuchAdresstypActive())
+    if (control.isSuchMitgliedstypActive())
     {
-      adresstyp = (Adresstyp) control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED).getValue();
+      mitgliedstyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
     }
     else
     {
-      DBIterator<Adresstyp> it = Einstellungen.getDBService()
-          .createList(Adresstyp.class);
-      it.addFilter("jvereinid=1");
-      adresstyp = (Adresstyp) it.next();
+      DBIterator<Mitgliedstyp> it = Einstellungen.getDBService()
+          .createList(Mitgliedstyp.class);
+      it.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
+      mitgliedstyp = (Mitgliedstyp) it.next();
     }
 
     if (control.isMitgliedStatusAktiv())
@@ -194,7 +194,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
     {
       FileOutputStream fos = new FileOutputStream(file);
 
-      Reporter report = new Reporter(fos, adresstyp.getBezeichnungPlural(),
+      Reporter report = new Reporter(fos, mitgliedstyp.getBezeichnungPlural(),
           subtitle, list.size(), 50, 10, 20, 25);
 
       report.addHeaderColumn("Name", Element.ALIGN_CENTER, 100,
@@ -203,7 +203,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
           130, BaseColor.LIGHT_GRAY);
       report.addHeaderColumn("Geburts- datum", Element.ALIGN_CENTER, 30,
           BaseColor.LIGHT_GRAY);
-      if (adresstyp.getJVereinid() == 1)
+      if (mitgliedstyp.getJVereinid() == Mitgliedstyp.MITGLIED)
       {
         report.addHeaderColumn("Eintritt / \nAustritt / \nKündigung"
             + (Einstellungen.getEinstellung().getSterbedatum()
@@ -270,7 +270,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
         {
           zelle += "\n" + new JVDateFormatTTMMJJJJ().format(m.getSterbetag());
         }
-        if (adresstyp.getJVereinid() == 1)
+        if (mitgliedstyp.getJVereinid() == Mitgliedstyp.MITGLIED)
         {
           report.addColumn(zelle, Element.ALIGN_LEFT);
         }
@@ -309,7 +309,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
       report.closeTable();
 
       report.add(new Paragraph(String.format("Anzahl %d: %s", list.size(),
-          adresstyp.getBezeichnungPlural()), Reporter.getFreeSans(8)));
+          mitgliedstyp.getBezeichnungPlural()), Reporter.getFreeSans(8)));
 
       report.add(new Paragraph("Parameter", Reporter.getFreeSans(12)));
 

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -21,7 +21,7 @@ import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsrhythmus;
 import de.jost_net.JVerein.keys.Zahlungstermin;
 import de.jost_net.JVerein.keys.Zahlungsweg;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.SekundaereBeitragsgruppe;
 import de.jost_net.JVerein.rmi.Felddefinition;
@@ -134,28 +134,28 @@ public class MitgliederImport implements Importer
 
         try
         {
-          String adresstyp = results.getString("adresstyp");
-          if (adresstyp != null && adresstyp.length() != 0)
+          String mitgliedstyp = results.getString("adresstyp");
+          if (mitgliedstyp != null && mitgliedstyp.length() != 0)
           {
             try
             {
-              Adresstyp at = (Adresstyp) Einstellungen.getDBService()
-                  .createObject(Adresstyp.class, adresstyp);
-              m.setAdresstyp(Integer.valueOf(at.getID()));
+              Mitgliedstyp at = (Mitgliedstyp) Einstellungen.getDBService()
+                  .createObject(Mitgliedstyp.class, mitgliedstyp);
+              m.setMitgliedstyp(Integer.valueOf(at.getID()));
             }
             catch (ObjectNotFoundException e)
             {
               throw new ApplicationException(
-                  "Adresstyp nicht vorhanden: " + adresstyp);
+                  "Adresstyp nicht vorhanden: " + mitgliedstyp);
             }
           }
           else
-            m.setAdresstyp(1);
+            m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
         }
         catch (SQLException e)
         {
           // Wenn Adresstyp nicht vorhanden speichern wir es als Mitglied
-          m.setAdresstyp(1);
+          m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
         }
 
         try
@@ -185,7 +185,7 @@ public class MitgliederImport implements Importer
           // Optionaler parameter, ignorieren wir
         }
 
-        if (m.getAdresstyp().getJVereinid() == 1)
+        if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
         {
           try
           {
@@ -252,7 +252,7 @@ public class MitgliederImport implements Importer
         try
         {
           // Beitragsgruppe nur bei Mitgliedern möglich
-          if (m.getAdresstyp().getJVereinid() == 1)
+          if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             String beitragsgruppe = results.getString("beitragsgruppe");
             DBIterator<Beitragsgruppe> it = Einstellungen.getDBService()
@@ -407,7 +407,7 @@ public class MitgliederImport implements Importer
             m.setMandatDatum(Datum.toDate(mandatdatum));
           }
           else if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException(
                 "Zeile " + anz + ": Mandatdatum fehlt");
@@ -417,7 +417,7 @@ public class MitgliederImport implements Importer
         {
           // Nur bei Zahlungsweg Lastschrift pflicht
           if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException("Mandatdatum fehlt");
           }
@@ -431,7 +431,7 @@ public class MitgliederImport implements Importer
             m.setMandatVersion(Integer.parseInt(mandatversion));
           }
           else if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             m.setMandatVersion(0);
           }
@@ -440,7 +440,7 @@ public class MitgliederImport implements Importer
         {
           // Nur bei Zahlungsweg Lastschrift nötig. 0 als default nehmen
           if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             m.setMandatVersion(0);
           }
@@ -466,7 +466,7 @@ public class MitgliederImport implements Importer
             }
           }
           else if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException("Zeile " + anz + ": IBAN fehlt");
           }
@@ -475,7 +475,7 @@ public class MitgliederImport implements Importer
         {
           // Nur bei Zahlungsweg Lastschrift nötig
           if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException("IBAN fehlt");
           }
@@ -559,14 +559,14 @@ public class MitgliederImport implements Importer
             m.setGeburtsdatum(Datum.toDate(geburtsdatum));
           }
           else if (Einstellungen.getEinstellung().getGeburtsdatumPflicht()
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
             throw new ApplicationException(
                 "Zeile " + anz + ": Geburtsdatum fehlt");
         }
         catch (SQLException e)
         {
           if (Einstellungen.getEinstellung().getGeburtsdatumPflicht()
-              && m.getAdresstyp().getJVereinid() == 1)
+              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
             throw new ApplicationException("Geburtsdatum fehlt");
         }
 
@@ -1054,7 +1054,7 @@ public class MitgliederImport implements Importer
           }
         }
         // Sekundaere-Beitragsgruppe nur bei Mitgliedern möglich
-        if (m.getAdresstyp().getJVereinid() == 1)
+        if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
         {
           for (Beitragsgruppe bg : sekundaerList)
           {

--- a/src/de/jost_net/JVerein/rmi/Mitglied.java
+++ b/src/de/jost_net/JVerein/rmi/Mitglied.java
@@ -28,6 +28,11 @@ import de.willuhn.util.ApplicationException;
 
 public interface Mitglied extends DBObject, ILastschrift
 {
+  public static final String TABLE_NAME = "mitglied";
+
+  public static final String PRIMARY_ATTRIBUTE = "namevorname";
+
+  public static final String MITGLIEDSTYP = "adresstyp";
 
   public void setExterneMitgliedsnummer(String extnr) throws RemoteException;
 
@@ -35,9 +40,9 @@ public interface Mitglied extends DBObject, ILastschrift
 
   public void setID(String id) throws RemoteException;
 
-  public void setAdresstyp(Integer adresstyp) throws RemoteException;
+  public void setMitgliedstyp(Integer mitgliedstyp) throws RemoteException;
 
-  public Adresstyp getAdresstyp() throws RemoteException;
+  public Mitgliedstyp getMitgliedstyp() throws RemoteException;
 
   public void setPersonenart(String personenart) throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Mitgliedstyp.java
+++ b/src/de/jost_net/JVerein/rmi/Mitgliedstyp.java
@@ -20,8 +20,23 @@ import java.rmi.RemoteException;
 
 import de.willuhn.datasource.rmi.DBObject;
 
-public interface Adresstyp extends DBObject
+public interface Mitgliedstyp extends DBObject
 {
+  public static final String TABLE_NAME = "adresstyp";
+
+  public static final String PRIMARY_ATTRIBUTE = "bezeichnung";
+
+  public static final String BEZEICHNUNG = "bezeichnung";
+
+  public static final String BEZEICHNUNG_PLURAL = "bezeichnungplural";
+
+  public static final String JVEREINID = "jvereinid";
+
+  public static final int MITGLIED = 1;
+
+  public static final int SPENDER = 2;
+
+
   public String getBezeichnung() throws RemoteException;
 
   public void setBezeichnung(String bezeichnung) throws RemoteException;

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -34,7 +34,7 @@ import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsrhythmus;
 import de.jost_net.JVerein.keys.Zahlungstermin;
 import de.jost_net.JVerein.keys.Zahlungsweg;
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Mitglied;
@@ -83,13 +83,13 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   @Override
   protected String getTableName()
   {
-    return "mitglied";
+    return TABLE_NAME;
   }
 
   @Override
   public String getPrimaryAttribute()
   {
-    return "namevorname";
+    return PRIMARY_ATTRIBUTE;
   }
 
   @Override
@@ -149,13 +149,13 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     {
       throw new ApplicationException("Bitte Vornamen eingeben");
     }
-    if (getAdresstyp().getJVereinid() == 1 && getPersonenart().equalsIgnoreCase(
+    if (getMitgliedstyp().getJVereinid() == 1 && getPersonenart().equalsIgnoreCase(
         "n") && getGeburtsdatum().getTime() == Einstellungen.NODATE.getTime() && Einstellungen.getEinstellung()
         .getGeburtsdatumPflicht())
     {
       throw new ApplicationException("Bitte Geburtsdatum eingeben");
     }
-    if (getAdresstyp().getJVereinid() == 1 && getPersonenart().equalsIgnoreCase(
+    if (getMitgliedstyp().getJVereinid() == 1 && getPersonenart().equalsIgnoreCase(
         "n") && Einstellungen.getEinstellung().getGeburtsdatumPflicht())
     {
       Calendar cal1 = Calendar.getInstance();
@@ -188,7 +188,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       }
     }
 
-    if (getAdresstyp().getJVereinid() == 1 && getEintritt().getTime() == Einstellungen.NODATE.getTime() && Einstellungen.getEinstellung()
+    if (getMitgliedstyp().getJVereinid() == 1 && getEintritt().getTime() == Einstellungen.NODATE.getTime() && Einstellungen.getEinstellung()
         .getEintrittsdatumPflicht())
     {
       throw new ApplicationException("Bitte Eintrittsdatum eingeben");
@@ -320,7 +320,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   private void checkExterneMitgliedsnummer()
       throws RemoteException, ApplicationException
   {
-    if (getAdresstyp().getJVereinid() != 1)
+    if (getMitgliedstyp().getJVereinid() != 1)
       return;
     if (Einstellungen.getEinstellung().getExterneMitgliedsnummer() == false)
       return;
@@ -367,23 +367,23 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     {
       return Mitgliedfoto.class;
     }
-    if ("adresstyp".equals(field))
+    if (MITGLIEDSTYP.equals(field))
     {
-      return Adresstyp.class;
+      return Mitgliedstyp.class;
     }
     return null;
   }
 
   @Override
-  public void setAdresstyp(Integer adresstyp) throws RemoteException
+  public void setMitgliedstyp(Integer mitgliedstyp) throws RemoteException
   {
-    setAttribute("adresstyp", adresstyp);
+    setAttribute(MITGLIEDSTYP, mitgliedstyp);
   }
 
   @Override
-  public Adresstyp getAdresstyp() throws RemoteException
+  public Mitgliedstyp getMitgliedstyp() throws RemoteException
   {
-    return (Adresstyp) getAttribute("adresstyp");
+    return (Mitgliedstyp) getAttribute(MITGLIEDSTYP);
   }
 
   @Override
@@ -1456,7 +1456,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
 
     private final static Map<String, String> VARIABLEN = new HashMap<>();
 
-    private final static Adresstyp ADRESSTYP = new Adresstyp()
+    private final static Mitgliedstyp ADRESSTYP = new Mitgliedstyp()
     {
       @Override
       public void transactionBegin() throws RemoteException
@@ -1724,7 +1724,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     }
 
     @Override
-    public Adresstyp getAdresstyp() throws RemoteException
+    public Mitgliedstyp getMitgliedstyp() throws RemoteException
     {
       return ADRESSTYP;
     }

--- a/src/de/jost_net/JVerein/server/MitgliedUtils.java
+++ b/src/de/jost_net/JVerein/server/MitgliedUtils.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.rmi.DBIterator;
 
 public class MitgliedUtils
@@ -40,13 +41,14 @@ public class MitgliedUtils
 
   public static void setMitglied(DBIterator<Mitglied> it) throws RemoteException
   {
-    it.addFilter("adresstyp = 1");
+    it.addFilter(Mitglied.MITGLIEDSTYP + " = " + Mitgliedstyp.MITGLIED);
   }
 
   public static void setMitgliedOderSpender(DBIterator<Mitglied> it)
       throws RemoteException
   {
-    it.addFilter("(adresstyp = 1 or adresstyp = 2)");
+    it.addFilter("(" + Mitglied.MITGLIEDSTYP + " = " + Mitgliedstyp.MITGLIED
+        + " OR " + Mitglied.MITGLIEDSTYP + " = " + Mitgliedstyp.SPENDER + ")");
   }
 
   public static void setMitgliedNatuerlichePerson(DBIterator<Mitglied> it)

--- a/src/de/jost_net/JVerein/server/MitgliedstypImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedstypImpl.java
@@ -18,17 +18,17 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
-import de.jost_net.JVerein.rmi.Adresstyp;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class AdresstypImpl extends AbstractDBObject implements Adresstyp
+public class MitgliedstypImpl extends AbstractDBObject implements Mitgliedstyp
 {
 
   private static final long serialVersionUID = 500102542884220658L;
 
-  public AdresstypImpl() throws RemoteException
+  public MitgliedstypImpl() throws RemoteException
   {
     super();
   }
@@ -36,13 +36,13 @@ public class AdresstypImpl extends AbstractDBObject implements Adresstyp
   @Override
   protected String getTableName()
   {
-    return "adresstyp";
+    return TABLE_NAME;
   }
 
   @Override
   public String getPrimaryAttribute()
   {
-    return "bezeichnung";
+    return PRIMARY_ATTRIBUTE;
   }
 
   @Override
@@ -96,32 +96,32 @@ public class AdresstypImpl extends AbstractDBObject implements Adresstyp
   @Override
   public String getBezeichnung() throws RemoteException
   {
-    return (String) getAttribute("bezeichnung");
+    return (String) getAttribute(BEZEICHNUNG);
   }
 
   @Override
   public void setBezeichnung(String bezeichnung) throws RemoteException
   {
-    setAttribute("bezeichnung", bezeichnung);
+    setAttribute(BEZEICHNUNG, bezeichnung);
   }
 
   @Override
   public String getBezeichnungPlural() throws RemoteException
   {
-    return (String) getAttribute("bezeichnungplural");
+    return (String) getAttribute(BEZEICHNUNG_PLURAL);
   }
 
   @Override
   public void setBezeichnungPlural(String bezeichnungplural)
       throws RemoteException
   {
-    setAttribute("bezeichnungplural", bezeichnungplural);
+    setAttribute(BEZEICHNUNG_PLURAL, bezeichnungplural);
   }
 
   @Override
   public int getJVereinid() throws RemoteException
   {
-    Integer i = (Integer) getAttribute("jvereinid");
+    Integer i = (Integer) getAttribute(JVEREINID);
     if (i == null)
       return 0;
     return i.intValue();
@@ -130,7 +130,7 @@ public class AdresstypImpl extends AbstractDBObject implements Adresstyp
   @Override
   public void setJVereinid(int jvereinid) throws RemoteException
   {
-    setAttribute("jvereinid", Integer.valueOf(jvereinid));
+    setAttribute(JVEREINID, Integer.valueOf(jvereinid));
   }
 
   @Override

--- a/src/de/jost_net/JVerein/util/Spaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/Spaltenauswahl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
@@ -59,13 +60,14 @@ public abstract class Spaltenauswahl
         formatter, align, nurMitglied));
   }
 
-  public void setColumns(TablePart part, int adresstyp)
+  public void setColumns(TablePart part, int mitgliedstyp)
   {
     for (Spalte spalte : spalten)
     {
       if (spalte.isChecked())
       {
-        if ((adresstyp == 1) || adresstyp != 1 && spalte.isNurAdressen())
+        if ((mitgliedstyp == Mitgliedstyp.MITGLIED)
+            || mitgliedstyp != Mitgliedstyp.MITGLIED && spalte.isNurAdressen())
         {
           part.addColumn(spalte.getSpaltenbezeichnung(),
               spalte.getSpaltenname(), spalte.getFormatter());


### PR DESCRIPTION
Wie in #480 besprochen habe ich mit den Umbenennungen gestartet.

Diese Übergabe enthält die Umbenennungen für den Adresstyp. Ich habe beim Mitglied ein define für das Attribut adresstyp eingeführt. Es heißt schon MITGLIEDSTYP. Wenn wir dann in 4.0.0 das Attribut in der Tabelle ändern müssen wir nur noch das define abändern.
Das Gleiche habe ich bei der Klasse Mitgliedstyp gemacht und en Tabellennamen in ein define verlegt.

Ich möchte dann noch mit der Umbenennung von Mitgliedskonto weiter machen. Dies hier ist nur, damit ihr schon mal schauen könnt ob das passt und um notfalls noch Anregungen zu geben.