### PR TITLE
Fix Spendenbescheinigung Mailversand und Konto Buchungsartauswahl

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="https://www.willuhn.de/schema/jameica-plugin"
         xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.willuhn.de/schema/jameica-plugin https://www.willuhn.de/schema/jameica-plugin-1.5.xsd"
-        name="jverein" version="3.0.1" class="de.jost_net.JVerein.JVereinPlugin">
+        name="jverein" version="3.0.2" class="de.jost_net.JVerein.JVereinPlugin">
 
   <description>OpenSource-Vereinsverwaltung</description>
   <url>https://openjverein.github.io/jameica-repository/[PLUGIN_ZIP]</url>

--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -37,6 +37,7 @@ import de.jost_net.JVerein.gui.input.IntegerNullInput;
 import de.jost_net.JVerein.gui.input.KontoInput;
 import de.jost_net.JVerein.gui.menu.KontoMenu;
 import de.jost_net.JVerein.gui.view.KontoView;
+import de.jost_net.JVerein.keys.AbstractInputAuswahl;
 import de.jost_net.JVerein.keys.AfaMode;
 import de.jost_net.JVerein.keys.Anlagenzweck;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
@@ -73,6 +74,8 @@ import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 import de.willuhn.jameica.hbci.Settings;
+import de.willuhn.jameica.plugin.Version;
+import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 //import de.jost_net.JVerein.keys.ArtBuchungsart;
@@ -643,9 +646,19 @@ public class KontoControl extends FilterControl
     {
       return anlagenart;
     }
-    anlagenart = new BuchungsartInput().getBuchungsartInput( anlagenart,
-        getKonto().getAnlagenart(), buchungsarttyp.ANLAGENART,
-        Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
+    Version version = Application.getManifest().getVersion();
+    if (version.compareTo(new Version("2.10.5")) < 0)
+    {
+      anlagenart = new BuchungsartInput().getBuchungsartInput(anlagenart,
+          getKonto().getAnlagenart(), buchungsarttyp.ANLAGENART,
+          AbstractInputAuswahl.ComboBox);
+    }
+    else
+    {
+      anlagenart = new BuchungsartInput().getBuchungsartInput(anlagenart,
+          getKonto().getAnlagenart(), buchungsarttyp.ANLAGENART,
+          Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
+    }
     anlagenart.addListener(new AnlagenartListener());
     if (getKontoArt().getValue() == Kontoart.ANLAGE)
     {
@@ -726,9 +739,19 @@ public class KontoControl extends FilterControl
     {
       return afaart;
     }
-    afaart = new BuchungsartInput().getBuchungsartInput( afaart,
-        getKonto().getAfaart(), buchungsarttyp.AFAART,
-        Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
+    Version version = Application.getManifest().getVersion();
+    if (version.compareTo(new Version("2.10.5")) < 0)
+    {
+      afaart = new BuchungsartInput().getBuchungsartInput(afaart,
+          getKonto().getAfaart(), buchungsarttyp.AFAART,
+          AbstractInputAuswahl.ComboBox);
+    }
+    else
+    {
+      afaart = new BuchungsartInput().getBuchungsartInput(afaart,
+          getKonto().getAfaart(), buchungsarttyp.AFAART,
+          Einstellungen.getEinstellung().getBuchungBuchungsartAuswahl());
+    }
     afaart.addListener(new AnlagenartListener());
     if (getKontoArt().getValue() == Kontoart.ANLAGE)
     {

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -951,7 +951,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
               MailAnhang anh = (MailAnhang) Einstellungen.getDBService()
                   .createObject(MailAnhang.class, null);
               String fileName = new Dateiname(m,
-                  spba[i].getBescheinigungsdatum(), "Spendenbescheinigung",
+                  spba[i].getSpendedatum(), "Spendenbescheinigung",
                   Einstellungen.getEinstellung().getDateinamenmusterSpende(),
                   "pdf").get();
               anh.setDateiname(fileName);


### PR DESCRIPTION
Der Fix behebt zwei Fehler die im Forum gemeldet wurden:
* Bei Spendenbescheinigungen wurde in #630 im Dateinamen das Spendendatum verwendet. Beim Mailversand wurde es nicht geändert und darum werden die generierten Dateien beim Mailversand nicht gefunden. Der Fix ändert den Dateinamen auch beim Versand
* Im Konto Dialog gibt es die Inputs für Anlagen Buchungsart und AfA Buchungsart. Wegen des Bugs in Jameica vor der Release 2.10.5 funktioniert dort die Suchauswahl nicht. Der Fix hier frägt die Jameica Version ab und setzt bei alten Jameica Versionen fest die Combobox Auswahl.
PS: Der Bug in Jameica war, dass nach Disable des Inputs bei Enable kein Editieren mehr möglich ist

Wegen der Fehlers sollten wir wohl eine 3.0.2 herausgeben.