### PR TITLE
Fix Bugs in Backup und BuchungImpl

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
@@ -64,6 +64,7 @@ import de.jost_net.JVerein.server.QIFImportHeadImpl;
 import de.jost_net.JVerein.server.QIFImportPosImpl;
 import de.jost_net.JVerein.server.RechnungImpl;
 import de.jost_net.JVerein.server.SekundaereBeitragsgruppeImpl;
+import de.jost_net.JVerein.server.SollbuchungPositionImpl;
 import de.jost_net.JVerein.server.SpendenbescheinigungImpl;
 import de.jost_net.JVerein.server.SuchprofilImpl;
 import de.jost_net.JVerein.server.VersionImpl;
@@ -270,6 +271,10 @@ public class BackupCreateAction implements Action
 
           monitor.setStatusText("Speichere Mitgliedskonten");
           backup(MitgliedskontoImpl.class, writer, monitor);
+          monitor.addPercentComplete(1);
+
+          monitor.setStatusText("Speichere Sollbuchungpositionen");
+          backup(SollbuchungPositionImpl.class, writer, monitor);
           monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Spendenbescheinigungen");

--- a/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BackupCreateAction.java
@@ -62,6 +62,7 @@ import de.jost_net.JVerein.server.MitgliedskontoImpl;
 import de.jost_net.JVerein.server.ProjektImpl;
 import de.jost_net.JVerein.server.QIFImportHeadImpl;
 import de.jost_net.JVerein.server.QIFImportPosImpl;
+import de.jost_net.JVerein.server.RechnungImpl;
 import de.jost_net.JVerein.server.SekundaereBeitragsgruppeImpl;
 import de.jost_net.JVerein.server.SpendenbescheinigungImpl;
 import de.jost_net.JVerein.server.SuchprofilImpl;
@@ -261,6 +262,10 @@ public class BackupCreateAction implements Action
           monitor.setStatusText(
               "Speichere Informationen über zukünftige Beitragsgruppen");
           backup(MitgliedNextBGruppeImpl.class, writer, monitor);
+          monitor.addPercentComplete(1);
+
+          monitor.setStatusText("Speichere Rechnungen");
+          backup(RechnungImpl.class, writer, monitor);
           monitor.addPercentComplete(1);
 
           monitor.setStatusText("Speichere Mitgliedskonten");

--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -288,7 +288,7 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsklasse");
+    Object l = (Object) super.getAttribute("buchungsklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet
@@ -348,7 +348,7 @@ public class BeitragsgruppeImpl extends AbstractDBObject implements
   @Override
   public Buchungsart getBuchungsart() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsart");
+    Object l = (Object) super.getAttribute("buchungsart");
     if (l == null)
     {
       return null; // Keine Buchungsart zugeordnet

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -544,7 +544,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Long getProjektID() throws RemoteException
   {
-    return (Long) super.getAttribute("project");
+    return (Long) super.getAttribute("projekt");
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -136,10 +136,11 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new ApplicationException("Buchungsdatum liegt mehr als 10 Jahre in der Zukunft");
     }
-    cal2.add(Calendar.YEAR, -20);
+    cal2.add(Calendar.YEAR, -50);
     if (cal1.before(cal2))
     {
-      throw new ApplicationException("Buchungsdatum liegt mehr als 10 Jahre zurück");
+      throw new ApplicationException(
+          "Buchungsdatum liegt mehr als 50 Jahre zurück");
     }
 
     /* Prüfung des Projektes */
@@ -442,7 +443,15 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Long getAbrechnungslaufID() throws RemoteException
   {
-    return (Long) super.getAttribute("abrechnungslauf");
+    Abrechnungslauf lauf = getAbrechnungslauf();
+    if (lauf != null)
+    {
+      return Long.parseLong(lauf.getID());
+    }
+    else
+    {
+      return null;
+    }
   }
 
   @Override
@@ -544,7 +553,15 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Long getProjektID() throws RemoteException
   {
-    return (Long) super.getAttribute("projekt");
+    Projekt projekt = getProjekt();
+    if (projekt != null)
+    {
+      return Long.parseLong(projekt.getID());
+    }
+    else
+    {
+      return null;
+    }
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -136,7 +136,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
     {
       throw new ApplicationException("Buchungsdatum liegt mehr als 10 Jahre in der Zukunft");
     }
-    cal2.add(Calendar.YEAR, -50);
+    cal2.add(Calendar.YEAR, -60);
     if (cal1.before(cal2))
     {
       throw new ApplicationException(

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -387,7 +387,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Buchungsart getBuchungsart() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsart");
+    Object l = (Object) super.getAttribute("buchungsart");
     if (l == null)
     {
       return null; // Keine Buchungsart zugeordnet
@@ -412,7 +412,7 @@ public class BuchungImpl extends AbstractDBObject implements Buchung
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsklasse");
+    Object l = (Object) super.getAttribute("buchungsklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -156,7 +156,7 @@ public class BuchungsartImpl extends AbstractDBObject implements Buchungsart
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsklasse");
+    Object l = (Object) super.getAttribute("buchungsklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet

--- a/src/de/jost_net/JVerein/server/KontoImpl.java
+++ b/src/de/jost_net/JVerein/server/KontoImpl.java
@@ -266,7 +266,7 @@ public class KontoImpl extends AbstractDBObject implements Konto
   @Override
   public Buchungsart getBuchungsart() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsart");
+    Object l = (Object) super.getAttribute("buchungsart");
     if (l == null)
     {
       return null; // Keine Buchungsart zugeordnet
@@ -337,7 +337,7 @@ public class KontoImpl extends AbstractDBObject implements Konto
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("anlagenklasse");
+    Object l = (Object) super.getAttribute("anlagenklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -291,7 +291,7 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsklasse");
+    Object l = (Object) super.getAttribute("buchungsklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet

--- a/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
@@ -197,7 +197,7 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject
   @Override
   public Buchungsklasse getBuchungsklasse() throws RemoteException
   {
-    Long l = (Long) super.getAttribute("buchungsklasse");
+    Object l = (Object) super.getAttribute("buchungsklasse");
     if (l == null)
     {
       return null; // Keine Buchungsklasse zugeordnet


### PR DESCRIPTION
Es wurden Rechnungen nicht im Diagnose Backup exportiert und dann war noch ein Typo in BuchungImpl.

Es gibt auch noch eine Fehler beim Import der Diagnosedaten bei den Buchungen.
"1 fehlerhaft class java.lang.Integer cannot be cast to class java.lang.Long (java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap'), überspringe"
Das passiert wenn eine Spendenbescheinigung referenziert ist. Ich verstehe aber nicht woher das kommt. 
Es passiert in Zeile 174 bei getBuchungsart()