### PR TITLE
Renovate einbinden zur Verwaltung der Abhängigkeiten

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, reopened, synchronize, edited]
     paths:
       - 'plugin.xml'
+      - 'plugin.dependencies'
       - 'build/**'
       - 'lib/**'
       - 'lib.src/**'

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -29,7 +29,8 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.repository_id }}
+        key: ${{ hashFiles('plugin.dependencies') }}
+
 
     - name: Build openjverein plugin
       working-directory: ./

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -31,11 +31,6 @@ jobs:
           hibiscus
         key: ${{ runner.os }}-${{ github.repository_id }}
 
-    - name: Checkout openjverein
-      uses: actions/checkout@v4
-      with:
-        path: jverein
-
     - name: Build openjverein plugin
       working-directory: ./
       run: ant -noinput -buildfile jverein/build/build.xml compile

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -29,7 +29,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ hashFiles('plugin.dependencies') }}
+        key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
 
     - name: Build openjverein plugin

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -5,7 +5,7 @@ name: OpenJVerein build check
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, edited]
+    types: [ opened, reopened, synchronize, edited ]
     paths:
       - 'plugin.xml'
       - 'plugin.dependencies'
@@ -21,17 +21,22 @@ jobs:
     needs: call-reusable-workflow
     runs-on: ubuntu-latest
     steps:
-    - name: Restore cached tags and jars
-      id: cache-tags-jars
-      uses: actions/cache@v4
-      with:
-        path: |
-          ./cached-tags
-          jameica
-          hibiscus
-        key: ${{ hashFiles('jverein/plugin.dependencies') }}
+      - name: Check out jverein
+        uses: actions/checkout@v4
+        with:
+          path: jverein
+
+      - name: Restore cached tags and jars
+        id: cache-tags-jars
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./cached-tags
+            jameica
+            hibiscus
+          key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
 
-    - name: Build openjverein plugin
-      working-directory: ./
-      run: ant -noinput -buildfile jverein/build/build.xml compile
+      - name: Build openjverein plugin
+        working-directory: ./
+        run: ant -noinput -buildfile jverein/build/build.xml compile

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.repository_id }}
+        key: ${{ hashFiles('plugin.dependencies') }}
 
     - name: Build openjverein plugin
       id: openjverein

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -18,59 +18,64 @@ jobs:
     needs: call-reusable-workflow
     runs-on: ubuntu-latest
     steps:
-    - name: Restore cached tags and jars
-      id: cache-tags-jars
-      uses: actions/cache@v4
-      with:
-        path: |
-          ./cached-tags
-          jameica
-          hibiscus
-        key: ${{ hashFiles('jverein/plugin.dependencies') }}
+      - name: Check out jverein
+        uses: actions/checkout@v4
+        with:
+          path: jverein
 
-    - name: Build openjverein plugin
-      id: openjverein
-      working-directory: ./
-      run: |
-        ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml nightly)
-        echo ${ant_output}
+      - name: Restore cached tags and jars
+        id: cache-tags-jars
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./cached-tags
+            jameica
+            hibiscus
+          key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
-        ssa="SELECTED_VERSION="
-        ssb=".zip"
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+      - name: Build openjverein plugin
+        id: openjverein
+        working-directory: ./
+        run: |
+          ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml nightly)
+          echo ${ant_output}
+          
+          ssa="SELECTED_VERSION="
+          ssb=".zip"
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          
+          ssa="SELECTED_FILENAME="
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          
+          ssa="SELECTED_PATH="
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          
+          echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+          echo "selected_filename=${tmp_filename}" >> $GITHUB_OUTPUT
+          echo "selected_path=${tmp_path}" >> $GITHUB_OUTPUT
+          
+          builddatetime=$(date +'%Y-%m-%d %H:%M')
+          echo "### Version: ${tmp_version} | filename: ${tmp_filename} | build datetime: ${builddatetime}" >> $GITHUB_STEP_SUMMARY
 
-        ssa="SELECTED_FILENAME="
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+      # Update tag
+      - name: Tag repo
+        uses: richardsimko/update-tag@v1
+        with:
+          tag_name: ${{ steps.openjverein.outputs.selected_version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        ssa="SELECTED_PATH="
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
-
-        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
-        echo "selected_filename=${tmp_filename}" >> $GITHUB_OUTPUT
-        echo "selected_path=${tmp_path}" >> $GITHUB_OUTPUT
-
-        builddatetime=$(date +'%Y-%m-%d %H:%M')
-        echo "### Version: ${tmp_version} | filename: ${tmp_filename} | build datetime: ${builddatetime}" >> $GITHUB_STEP_SUMMARY
-
-    # Update tag
-    - name: Tag repo
-      uses: richardsimko/update-tag@v1
-      with:
-        tag_name: ${{ steps.openjverein.outputs.selected_version }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ steps.openjverein.outputs.selected_version }}
-        prerelease: true
-        name: Release ${{ steps.openjverein.outputs.selected_version }}
-        files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
-        generate_release_notes: false
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.openjverein.outputs.selected_version }}
+          prerelease: true
+          name: Release ${{ steps.openjverein.outputs.selected_version }}
+          files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
+          generate_release_notes: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,11 +28,6 @@ jobs:
           hibiscus
         key: ${{ runner.os }}-${{ github.repository_id }}
 
-    - name: Checkout openjverein
-      uses: actions/checkout@v4
-      with:
-        path: jverein
-
     - name: Build openjverein plugin
       id: openjverein
       working-directory: ./

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ hashFiles('plugin.dependencies') }}
+        key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
     - name: Build openjverein plugin
       id: openjverein

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.repository_id }}
+        key: ${{ hashFiles('plugin.dependencies') }}
 
     - name: Build openjverein plugin
       id: openjverein

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,52 +13,57 @@ jobs:
     needs: call-reusable-workflow
     runs-on: ubuntu-latest
     steps:
-    - name: Restore cached tags and jars
-      id: cache-tags-jars
-      uses: actions/cache@v4
-      with:
-        path: |
-          ./cached-tags
-          jameica
-          hibiscus
-        key: ${{ hashFiles('jverein/plugin.dependencies') }}
+      - name: Check out jverein
+        uses: actions/checkout@v4
+        with:
+          path: jverein
 
-    - name: Build openjverein plugin
-      id: openjverein
-      working-directory: ./
-      run: |
-        ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml)
-        echo ${ant_output}
+      - name: Restore cached tags and jars
+        id: cache-tags-jars
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./cached-tags
+            jameica
+            hibiscus
+          key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
-        ssa="SELECTED_VERSION="
-        ssb=".zip"
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
-        tmp_version=$tmp_version
+      - name: Build openjverein plugin
+        id: openjverein
+        working-directory: ./
+        run: |
+          ant_output=$(ant -e -q -noinput -buildfile jverein/build/build.xml)
+          echo ${ant_output}
+          
+          ssa="SELECTED_VERSION="
+          ssb=".zip"
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          tmp_version=$tmp_version
+          
+          ssa="SELECTED_FILENAME="
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          
+          ssa="SELECTED_PATH="
+          text="${ant_output#*${ssa}}"
+          text="${text%${ssb}*}.zip"
+          tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+          
+          echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
+          echo "selected_filename=${tmp_filename}" >> $GITHUB_OUTPUT
+          echo "selected_path=${tmp_path}" >> $GITHUB_OUTPUT
+          
+          builddatetime=$(date +'%Y-%m-%d %H:%M')
+          echo "### Version: ${tmp_version} | filename: ${tmp_filename} | build datetime: ${builddatetime}" >> $GITHUB_STEP_SUMMARY
 
-        ssa="SELECTED_FILENAME="
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
-
-        ssa="SELECTED_PATH="
-        text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
-        tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
-
-        echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
-        echo "selected_filename=${tmp_filename}" >> $GITHUB_OUTPUT
-        echo "selected_path=${tmp_path}" >> $GITHUB_OUTPUT
-
-        builddatetime=$(date +'%Y-%m-%d %H:%M')
-        echo "### Version: ${tmp_version} | filename: ${tmp_filename} | build datetime: ${builddatetime}" >> $GITHUB_STEP_SUMMARY
-
-    - name: Release
-      uses: softprops/action-gh-release@v2
-      with:
-        tag_name: ${{ steps.openjverein.outputs.selected_version }}
-        prerelease: false
-        name: Release ${{ steps.openjverein.outputs.selected_version }}
-        files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
-        generate_release_notes: true
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.openjverein.outputs.selected_version }}
+          prerelease: false
+          name: Release ${{ steps.openjverein.outputs.selected_version }}
+          files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ hashFiles('plugin.dependencies') }}
+        key: ${{ hashFiles('jverein/plugin.dependencies') }}
 
     - name: Build openjverein plugin
       id: openjverein

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,6 @@ jobs:
           hibiscus
         key: ${{ runner.os }}-${{ github.repository_id }}
 
-    - name: Checkout openjverein
-      uses: actions/checkout@v4
-      with:
-        path: jverein
-
     - name: Build openjverein plugin
       id: openjverein
       working-directory: ./

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         jameica_tag=V_2_10_4_BUILD_487
         echo "jameica_tag=${jameica_tag}" >> $GITHUB_ENV
-        hibiscus_tag=$(git ls-remote --refs --tags --sort="-v:refname" https://github.com/willuhn/hibiscus.git V_\* | head -1 | cut -f 2 | cut -d / -f 3)
+        hibiscus_tag=V_2_10_24_BUILD_388
         echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_ENV
         echo "### jameica_tag: ${jameica_tag} | hibiscus_tag: ${hibiscus_tag}"
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -33,7 +33,7 @@ jobs:
           ./cached-tags
           jameica
           hibiscus
-        key: ${{ runner.os }}-${{ github.repository_id }}
+        key: ${{ hashFiles('plugin.dependencies') }}
 
     - name: Load cached tags
       id: load-cache
@@ -96,4 +96,4 @@ jobs:
             ./cached-tags
             jameica
             hibiscus
-        key: ${{ runner.os }}-${{ github.repository_id }}
+        key: ${{ hashFiles('plugin.dependencies') }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -17,11 +17,9 @@ jobs:
     - name: Set env
       id: setenvs
       run: |
-        jameica_tag=V_2_10_4_BUILD_487
-        echo "jameica_tag=${jameica_tag}" >> $GITHUB_ENV
-        hibiscus_tag=V_2_10_24_BUILD_388
-        echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_ENV
-        echo "### jameica_tag: ${jameica_tag} | hibiscus_tag: ${hibiscus_tag}"
+        cat plugin.dependencies >> $GITHUB_ENV
+        echo "### plugin.dependencies"
+        cat plugin.dependencies
 
     - name: Restore cached tags and folders
       id: cache-tags-jars

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -7,93 +7,94 @@ jobs:
   setup-java-and-cache:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up JDK for x64
-      uses: actions/setup-java@v4
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        architecture: x64
+      - name: Set up JDK for x64
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          architecture: x64
 
-    - name: Check out jverein
-      uses: actions/checkout@v4
-      with:
-        path: jverein
-    - name: Set env
-      id: setenvs
-      run: |
-        cat jverein/plugin.dependencies >> $GITHUB_ENV
-        echo "### plugin.dependencies"
-        cat jverein/plugin.dependencies
+      - name: Check out jverein
+        uses: actions/checkout@v4
+        with:
+          path: jverein
 
-    - name: Restore cached tags and folders
-      id: cache-tags-jars
-      uses: actions/cache@v4
-      with:
-        path: |
-          ./cached-tags
-          jameica
-          hibiscus
-        key: ${{ hashFiles('plugin.dependencies') }}
+      - name: Set env
+        id: setenvs
+        run: |
+          cat jverein/plugin.dependencies >> $GITHUB_ENV
+          echo "### plugin.dependencies"
+          cat jverein/plugin.dependencies
 
-    - name: Load cached tags
-      id: load-cache
-      run: |
-        if [ -f ./cached-tags/jameica_tag ]; then
-          cached_jameica_tag=$(cat ./cached-tags/jameica_tag)
-          echo "cached_jameica_tag=${cached_jameica_tag}" >> $GITHUB_ENV
-        else
-          echo "cached_jameica_tag=" >> $GITHUB_ENV
-        fi
-        if [ -f ./cached-tags/hibiscus_tag ]; then
-          cached_hibiscus_tag=$(cat ./cached-tags/hibiscus_tag)
-          echo "cached_hibiscus_tag=${cached_hibiscus_tag}" >> $GITHUB_ENV
-        else
-          echo "cached_hibiscus_tag=" >> $GITHUB_ENV
-        fi
-        echo "### cached_jameica_tag: ${cached_jameica_tag} | cached_hibiscus_tag: ${cached_hibiscus_tag}"
-
-    - name: Checkout jameica
-      if: ${{ env.cached_jameica_tag != env.jameica_tag }}
-      uses: actions/checkout@v4
-      with:
-        repository: willuhn/jameica
-        path: jameica
-        ref: ${{ env.jameica_tag }}
-
-    - name: Build jameica jar
-      if: ${{ env.cached_jameica_tag != env.jameica_tag }}
-      working-directory: ./ 
-      run: |
-        ant -noinput -buildfile jameica/build/build.xml jar
-        find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
-
-    - name: Checkout hibiscus
-      if: ${{ env.cached_hibiscus_tag != env.hibiscus_tag }}
-      uses: actions/checkout@v4
-      with:
-        repository: willuhn/hibiscus
-        path: hibiscus
-        ref: ${{ env.hibiscus_tag }}
-
-    - name: Build hibiscus jar
-      if: ${{ env.cached_hibiscus_tag != env.hibiscus_tag }}
-      working-directory: ./ 
-      run: |
-        ant -noinput -buildfile hibiscus/build/build.xml jar
-        find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
-
-    - name: Create cache files and needed folders
-      run: |
-        mkdir -p ./cached-tags
-        echo "${{ env.jameica_tag }}" > ./cached-tags/jameica_tag
-        echo "${{ env.hibiscus_tag }}" > ./cached-tags/hibiscus_tag
-
-    - name: Cache tags and folders
-      uses: actions/cache@v4
-      if: always()
-      with:
-        path: |
+      - name: Restore cached tags and folders
+        id: cache-tags-jars
+        uses: actions/cache@v4
+        with:
+          path: |
             ./cached-tags
             jameica
             hibiscus
-        key: ${{ hashFiles('jverein/plugin.dependencies') }}
+          key: ${{ hashFiles('jverein/plugin.dependencies') }}
+
+      - name: Load cached tags
+        id: load-cache
+        run: |
+          if [ -f ./cached-tags/jameica_tag ]; then
+            cached_jameica_tag=$(cat ./cached-tags/jameica_tag)
+            echo "cached_jameica_tag=${cached_jameica_tag}" >> $GITHUB_ENV
+          else
+            echo "cached_jameica_tag=" >> $GITHUB_ENV
+          fi
+          if [ -f ./cached-tags/hibiscus_tag ]; then
+            cached_hibiscus_tag=$(cat ./cached-tags/hibiscus_tag)
+            echo "cached_hibiscus_tag=${cached_hibiscus_tag}" >> $GITHUB_ENV
+          else
+            echo "cached_hibiscus_tag=" >> $GITHUB_ENV
+          fi
+          echo "### cached_jameica_tag: ${cached_jameica_tag} | cached_hibiscus_tag: ${cached_hibiscus_tag}"
+
+      - name: Checkout jameica
+        if: ${{ env.cached_jameica_tag != env.jameica_tag }}
+        uses: actions/checkout@v4
+        with:
+          repository: willuhn/jameica
+          path: jameica
+          ref: ${{ env.jameica_tag }}
+
+      - name: Build jameica jar
+        if: ${{ env.cached_jameica_tag != env.jameica_tag }}
+        working-directory: ./
+        run: |
+          ant -noinput -buildfile jameica/build/build.xml jar
+          find jameica/releases/ -type f -name jameica.jar -exec cp {} jameica/releases/jameica-lib.jar \;
+
+      - name: Checkout hibiscus
+        if: ${{ env.cached_hibiscus_tag != env.hibiscus_tag }}
+        uses: actions/checkout@v4
+        with:
+          repository: willuhn/hibiscus
+          path: hibiscus
+          ref: ${{ env.hibiscus_tag }}
+
+      - name: Build hibiscus jar
+        if: ${{ env.cached_hibiscus_tag != env.hibiscus_tag }}
+        working-directory: ./
+        run: |
+          ant -noinput -buildfile hibiscus/build/build.xml jar
+          find hibiscus/releases/ -type f -name hibiscus.jar -exec cp {} hibiscus/releases/hibiscus-lib.jar \;
+
+      - name: Create cache files and needed folders
+        run: |
+          mkdir -p ./cached-tags
+          echo "${{ env.jameica_tag }}" > ./cached-tags/jameica_tag
+          echo "${{ env.hibiscus_tag }}" > ./cached-tags/hibiscus_tag
+
+      - name: Cache tags and folders
+        uses: actions/cache@v4
+        if: always()
+        with:
+          path: |
+            ./cached-tags
+            jameica
+            hibiscus
+          key: ${{ hashFiles('jverein/plugin.dependencies') }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -14,12 +14,16 @@ jobs:
         distribution: 'temurin'
         architecture: x64
 
+    - name: Check out jverein
+      uses: actions/checkout@v4
+      with:
+        path: jverein
     - name: Set env
       id: setenvs
       run: |
-        cat plugin.dependencies >> $GITHUB_ENV
+        cat jverein/plugin.dependencies >> $GITHUB_ENV
         echo "### plugin.dependencies"
-        cat plugin.dependencies
+        cat jverein/plugin.dependencies
 
     - name: Restore cached tags and folders
       id: cache-tags-jars

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -96,4 +96,4 @@ jobs:
             ./cached-tags
             jameica
             hibiscus
-        key: ${{ hashFiles('plugin.dependencies') }}
+        key: ${{ hashFiles('jverein/plugin.dependencies') }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set env
       id: setenvs
       run: |
-        jameica_tag=$(git ls-remote --refs --tags --sort="-v:refname" https://github.com/willuhn/jameica.git V_\* | head -1 | cut -f 2 | cut -d / -f 3)
+        jameica_tag=V_2_10_4_BUILD_487
         echo "jameica_tag=${jameica_tag}" >> $GITHUB_ENV
         hibiscus_tag=$(git ls-remote --refs --tags --sort="-v:refname" https://github.com/willuhn/hibiscus.git V_\* | head -1 | cut -f 2 | cut -d / -f 3)
         echo "hibiscus_tag=${hibiscus_tag}" >> $GITHUB_ENV

--- a/plugin.dependencies
+++ b/plugin.dependencies
@@ -1,0 +1,2 @@
+jameica_tag=V_2_10_4_BUILD_487
+hibiscus_tag=V_2_10_24_BUILD_388

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.github/workflows/reusable-build.yml$"
+        "^plugin.dependencies$"
       ],
       "matchStrings": [
         "jameica_tag=(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
@@ -19,7 +19,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.github/workflows/reusable-build.yml$"
+        "^plugin.dependencies$"
       ],
       "matchStrings": [
         "hibiscus_tag=(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,10 @@
         "^.github/workflows/reusable-build.yml$"
       ],
       "matchStrings": [
-        "jameica_tag=(?<currentValue>[V_\\d+_\\d+_\\d+_BUILD_\\d+])"
+        "jameica_tag=(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "willuhn/hibiscus",
+      "depNameTemplate": "willuhn/jameica",
       "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.github/workflows/reusable-build.yml$"
+      ],
+      "matchStrings": [
+        "jameica_tag=(?<currentValue>[V_\\d+_\\d+_\\d+_BUILD_\\d+])"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "willuhn/hibiscus",
+      "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:recommended"
   ],
+  "forkProcessing": "enabled",
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "matchStrings": [
         "jameica_tag=(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
       ],
-      "datasourceTemplate": "github-releases",
+      "datasourceTemplate": "github-tags",
       "depNameTemplate": "willuhn/jameica",
       "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,19 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "willuhn/jameica",
       "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.github/workflows/reusable-build.yml$"
+      ],
+      "matchStrings": [
+        "hibiscus_tag=(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "willuhn/hibiscus",
+      "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
     }
+
   ]
 }


### PR DESCRIPTION
Mit der Einbindung von renovate können Abhängigkeiten automatisch aktualisiert werden. Sobald Renovate eine neue Version entdeckt, erstellt es einen pull request. Dieser wird automatisch gebaut. Die builds gehen damit auf fest definierte Versionen statt auf die letzte Version. Dennoch bemerken wir sofort, wenn eine neue Version verfügbar ist und können anhand des Buildergebnisses einem merge Zustimmen.

Hierzu benötigen wir Hilfe von @phschoen oder @willuhn , da nur diese genügend Rechte haben in der Organisation renovate als Github app einzubinden. Das Verfahren dazu ist [hier](https://docs.renovatebot.com/getting-started/installing-onboarding/#hosted-githubcom-app) beschrieben.

In meinem fork kann man sich die prs und das issue zum Verwalten von renovate beispiehaft anschauen:
- https://github.com/tobidope/jverein/pull/2
- https://github.com/tobidope/jverein/issues/1