### PR TITLE
Fix Altersstaffel

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
@@ -435,7 +435,7 @@ public class BeitragsgruppeControl extends AbstractControl
               {
                 a = (Altersstaffel)Einstellungen.getDBService().createObject(Altersstaffel.class, null);
                 a.setBeitragsgruppe(beitrag);
-                a.setBetrag(d);
+                a.setBetrag(betrag);
                 a.setNummer((Integer)i.getData("nummer"));
               }
               a.store();


### PR DESCRIPTION
Beim Speichern der Beitragsgruppe wurde der falsche Betrag in der Altersstaffel gespeichert.

Es ist ein Fix für #674 