### PR TITLE
Fix Diagnose Backup Import von Sollbuchungen ohne Zahler

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -329,6 +329,11 @@ public class MitgliedskontoControl extends DruckMailControl
         }
       }
 
+      if (getZahler().getValue() == null)
+      {
+        throw new ApplicationException("Zahler fehlt");
+      }
+
       if (mkto.getRechnung() != null)
         throw new ApplicationException(
             "Sollbuchung kann nicht geändert werden, es existiert eine Rechnung darüber.");

--- a/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedskontoImpl.java
@@ -94,10 +94,6 @@ public class MitgliedskontoImpl extends AbstractDBObject
   {
     try
     {
-      if (getZahler() == null)
-      {
-        throw new ApplicationException("Zahler fehlt");
-      }
       if (getDatum() == null)
       {
         throw new ApplicationException("Datum fehlt");


### PR DESCRIPTION
Eine Sollbuchung kann man nur mit gesetztem Zahler erzeugen. Es ist aber möglich, dass der Zahler später gelöscht wird. Dann ist der Zahler null, aber das ist ok.

Ein Diagnose Backup Import führt allerdings die plausi Checks durch und würde eine solche Sollbuchung damit nicht importieren. Ich habe jetzt den Check auf Zahler in die handleStore() Methode verschoben, damit wird sie beim Speichern geprüft aber nicht mehr im plausi.

Ich weiß, dass ist nicht sehr schön, aber mir fällt gerade auch nichts besseres ein.