### PR TITLE
Fix für 687 zu 3.1.x

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0464.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0464.java
@@ -34,6 +34,6 @@ public class Update0464 extends AbstractDDLUpdate
         new Column("geprueft", COLTYPE.BOOLEAN, 0, null, false, false)));
 
     execute(addColumn("einstellung", new Column("geprueftsynchronisieren",
-        COLTYPE.BOOLEAN, 0, "1", true, false)));
+        COLTYPE.BOOLEAN, 0, "1", false, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2213,7 +2213,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   @Override
   public boolean getSplitPositionZweck() throws RemoteException
   {
-    return (Boolean) getAttribute("splitpositionzweck");
+    return Util.getBoolean(getAttribute("splitpositionzweck"));
   }
 
   @Override
@@ -2225,7 +2225,7 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   @Override
   public boolean getGeprueftSynchronisieren() throws RemoteException
   {
-    return (Boolean) getAttribute("geprueftsynchronisieren");
+    return Util.getBoolean(getAttribute("geprueftsynchronisieren"));
   }
 
   @Override


### PR DESCRIPTION
Nun der Fix für von #687 für 3.1.0. 
Ich musste auch noch das NOT NULL ändern, sonst gab es wieder eine Exception wenn man speichert ohne vorher das Flag angeklickt zu haben.