### PR TITLE
Individuelle Mandats-ID

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -84,6 +84,7 @@ import de.jost_net.JVerein.io.MitgliedAuswertungPDF;
 import de.jost_net.JVerein.io.MitgliederStatistik;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.keys.Datentyp;
+import de.jost_net.JVerein.keys.SepaMandatIdSource;
 import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsrhythmus;
 import de.jost_net.JVerein.keys.Zahlungstermin;
@@ -636,12 +637,14 @@ public class MitgliedControl extends FilterControl
           {
             if (((Zahlungsweg) getZahlungsweg().getValue()).getKey() != Zahlungsweg.BASISLASTSCHRIFT)
             {
+              mandatid.setMandatory(false);
               mandatdatum.setMandatory(false);
               mandatversion.setMandatory(false);
               iban.setMandatory(false);
             }
             else
             {
+              mandatid.setMandatory(true);
               mandatdatum.setMandatory(true);
               mandatversion.setMandatory(true);
               iban.setMandatory(true);
@@ -769,7 +772,20 @@ public class MitgliedControl extends FilterControl
     }
     mandatid = new TextInput(getMitglied().getMandatID());
     mandatid.setName("Mandats-ID");
-    mandatid.disable();
+    if (((Zahlungsweg) getZahlungsweg().getValue())
+        .getKey() != Zahlungsweg.BASISLASTSCHRIFT)
+    {
+      mandatid.setMandatory(false);
+    }
+    else
+    {
+      mandatid.setMandatory(true);
+    }
+    if (Einstellungen.getEinstellung()
+        .getSepaMandatIdSource() != SepaMandatIdSource.INDIVIDUELL)
+    {
+      mandatid.disable();
+    }
     return mandatid;
   }
 
@@ -2323,6 +2339,7 @@ public class MitgliedControl extends FilterControl
       {
         m.setZahlungstermin(zt.getKey());
       }
+      m.setMandatID((String) getMandatID().getValue());
       m.setMandatDatum((Date) getMandatDatum().getValue());
       m.setMandatVersion((Integer) getMandatVersion().getValue());
       m.setBic((String) getBic().getValue());

--- a/src/de/jost_net/JVerein/keys/SepaMandatIdSource.java
+++ b/src/de/jost_net/JVerein/keys/SepaMandatIdSource.java
@@ -29,6 +29,8 @@ public class SepaMandatIdSource
 
   public static final int EXTERNE_MITGLIEDSNUMMER = 2;
 
+  public static final int INDIVIDUELL = 3;
+
   private int mandatIDSource;
 
   public SepaMandatIdSource(int key)
@@ -54,6 +56,8 @@ public class SepaMandatIdSource
         return "Mitgliedsnummer (default)";
       case SepaMandatIdSource.EXTERNE_MITGLIEDSNUMMER:
         return "Externe Mitgliedsnummer";
+      case SepaMandatIdSource.INDIVIDUELL:
+        return "Individuelle ID";
       default:
         return null;
     }
@@ -64,6 +68,7 @@ public class SepaMandatIdSource
     ArrayList<SepaMandatIdSource> ret = new ArrayList<>();
     ret.add(new SepaMandatIdSource(DBID));
     ret.add(new SepaMandatIdSource(EXTERNE_MITGLIEDSNUMMER));
+    ret.add(new SepaMandatIdSource(INDIVIDUELL));
     return ret;
   }
 

--- a/src/de/jost_net/JVerein/rmi/Mitglied.java
+++ b/src/de/jost_net/JVerein/rmi/Mitglied.java
@@ -235,4 +235,7 @@ public interface Mitglied extends DBObject, ILastschrift
 
   public boolean checkSEPA() throws RemoteException, ApplicationException;
 
+  public String getMandatID() throws RemoteException;
+
+  public void setMandatID(String mandatid) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0466.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0466.java
@@ -31,6 +31,6 @@ public class Update0466 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     execute(addColumn("mitglied",
-        new Column("mandatid", COLTYPE.VARCHAR, 20, null, false, false)));
+        new Column("mandatid", COLTYPE.VARCHAR, 35, null, false, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0466.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0466.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0466 extends AbstractDDLUpdate
+{
+  public Update0466(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("mitglied",
+        new Column("mandatid", COLTYPE.VARCHAR, 20, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -199,6 +199,10 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte IBAN eingeben");
       }
+      if (getMandatID() == null || getMandatID().isEmpty())
+      {
+        throw new ApplicationException("Bitte Mandats-ID eingeben");
+      }
       if (getMandatDatum() == Einstellungen.NODATE)
       {
         throw new ApplicationException("Bitte Datum des Mandat eingeben");
@@ -664,10 +668,20 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     {
       return getExterneMitgliedsnummer() + "-" + getMandatVersion();
     }
-    else
+    else if (sepaMandatIdSource == SepaMandatIdSource.DBID)
     {
       return getID() + "-" + getMandatVersion();
     }
+    else
+    {
+      return (String) getAttribute("mandatid");
+    }
+  }
+
+  @Override
+  public void setMandatID(String mandatid) throws RemoteException
+  {
+    setAttribute("mandatid", mandatid);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -203,6 +203,10 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte Mandats-ID eingeben");
       }
+      else if (getMandatID().length() > 20)
+      {
+        throw new ApplicationException("Mandats-ID hat mehr als 20 Stellen");
+      }
       if (getMandatDatum() == Einstellungen.NODATE)
       {
         throw new ApplicationException("Bitte Datum des Mandat eingeben");

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -203,9 +203,9 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte Mandats-ID eingeben");
       }
-      else if (getMandatID().length() > 20)
+      else if (getMandatID().length() > 35)
       {
-        throw new ApplicationException("Mandats-ID hat mehr als 20 Stellen");
+        throw new ApplicationException("Mandats-ID hat mehr als 35 Stellen");
       }
       if (getMandatDatum() == Einstellungen.NODATE)
       {


### PR DESCRIPTION
Das Feature unterstützt eine individuelle Mandats-ID für SEPA Lastschriften. Bisher war nur Mitgliedsnummer oder Externe Mitgliedsnummmer möglich.
Siehe Wunsch aus #661 
![Bildschirmfoto_20250220_173259](https://github.com/user-attachments/assets/8db1d638-521c-4681-8ea0-fa167600449a)

Benutzt 35 Stellen wie Hibiscus
