### PR TITLE
Mitgliedsname eindeutig machen

### DIFF
--- a/src/de/jost_net/JVerein/io/Adressbuch/Adressaufbereitung.java
+++ b/src/de/jost_net/JVerein/io/Adressbuch/Adressaufbereitung.java
@@ -18,8 +18,10 @@ package de.jost_net.JVerein.io.Adressbuch;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.IAdresse;
+import de.jost_net.JVerein.rmi.Mitglied;
 
 public class Adressaufbereitung
 {
@@ -58,6 +60,23 @@ public class Adressaufbereitung
     }
     ret += adr.getVorname();
     return ret;
+  }
+
+  /**
+   * Gibt den Namen aufbereitet zurück, Nr. - Meier, Dr. Willi
+   */
+  public static String getIdNameVorname(Mitglied mitglied)
+      throws RemoteException
+  {
+    if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
+    {
+      return mitglied.getExterneMitgliedsnummer() + " - "
+          + getNameVorname(mitglied);
+    }
+    else
+    {
+      return mitglied.getID() + " - " + getNameVorname(mitglied);
+    }
   }
 
   /**

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -89,7 +89,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   @Override
   public String getPrimaryAttribute()
   {
-    return "namevorname";
+    return "idnamevorname";
   }
 
   @Override
@@ -1245,6 +1245,10 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     if (fieldName.equals("idint"))
     {
       return Integer.valueOf(getID());
+    }
+    if (fieldName.equals("idnamevorname"))
+    {
+      return Adressaufbereitung.getIdNameVorname(this);
     }
     if (fieldName.equals("namevorname"))
     {


### PR DESCRIPTION
Laut #695 und auch im Forum https://jverein-forum.de/viewtopic.php?t=7403 gibt es Probleme wenn zwei Mitglieder den gleichen Namen haben z.B. bei der Zuordnung von Sollbuchungen.

Mein Vorschlag hier ist bei den Spalten in Tabellen für Mitglieder die Mitgliedsnummer bzw. je nach Einstellung die Externe Mitgliedsnummer voranzustellen. Damit werden die Einträge eindeutig.
Durch die Lösung hier passiert das automatisch in allen Tabellen und Combo Boxen.
![Bildschirmfoto_20250220_171405](https://github.com/user-attachments/assets/0cf86e81-cffa-444f-aba8-c867aaa9bae3)
oder 
![Bildschirmfoto_20250220_172222](https://github.com/user-attachments/assets/4903c7f4-8bd0-4053-909a-98b487855279)
