### PR TITLE
Add workflow to merge master into feature

### DIFF
--- a/.github/workflows/merge-master-into-feature.yml
+++ b/.github/workflows/merge-master-into-feature.yml
@@ -25,16 +25,13 @@ jobs:
           git checkout feature-3.1.0
           git pull
           git merge master --no-ff --no-commit
+          # Abort previous merge check
+          git merge --abort
+          git reset --hard HEAD
         continue-on-error: true
 
       - name: Merge master into feature-3.1.0
         run: |
-          # Abort previous merge check
-          git merge --abort
-          git reset --hard HEAD
           # Merge master branch into feature with feature as king (ours)
           git merge -X ours master -m "Auto-merge master into feature-3.1.0" --stat
           git push origin
-
-      - name: Set workflow status
-        run: exit 0


### PR DESCRIPTION
Ein schneller workflow (nicht perfekt) welcher den master branch, bei Änderungen (push), automatisch in den feature-3.1.0 merged. Dabei ist der 3.1.0 priorisiert und bei einem merge Konflikt wird der Inhalt des feature branch akzeptiert (Beispiel plugin.xml).

Es gibt einen merge check step, bei dem eventuelle Konflikte ausgegeben werden. Fehler lassen den workflow aber weiterlaufen.

Solange der step "Merge master into feature-3.1.0" nicht fehl schlägt, wird der workflow als erfolgreich abgeschlossen markiert (grüner Haken).

Test: https://github.com/dippeal/jverein/actions/runs/13482929805/job/37670450343

Diskussion: https://github.com/openjverein/jverein/discussions/482#discussioncomment-12278059