### PR TITLE
Build nightly feature branch instead of main

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,7 +6,7 @@ name: OpenJVerein nightly release
 on:
   push:
     branches:
-      - master
+      - feature-3.1.0
     tags-ignore:
       - '**'
 
@@ -17,6 +17,7 @@ jobs:
     - name: Checkout openjverein
       uses: actions/checkout@v4
       with:
+        ref: 'feature-3.1.0'
         path: jverein
 
     - name: Setup


### PR DESCRIPTION
Wie in https://github.com/openjverein/jverein/discussions/702 besprochen soll der feature branch als nightly zur Verfügung gestellt werden.