### PR TITLE
Mittelverwendung Fixes

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -192,6 +192,25 @@ public class MittelverwendungControl extends SaldoControl
       return;
     }
 
+    // Der aktuelle Mittelverwendungsreport ist ein Jahr nach dem letzten
+    // Jahresabschluss, wir erlauben das Rücksetzen z.B. wegen
+    // Unterschreiten der 45.000 EUR Einnahmen Grenze
+    if (abschlussvon.equals(jahresabschluesse[0].getVon()))
+    {
+      configButton.setEnabled(true);
+      editDatumvon = abschlussvon;
+      jaId = jahresabschluesse[0].getID();
+      if (jahresabschluesse.length == 1)
+      {
+        vorJaId = null;
+      }
+      else
+      {
+        vorJaId = jahresabschluesse[1].getID();
+      }
+      return;
+    }
+
     for (int i = 0; i < jahresabschluesse.length; i++)
     {
       if (jahresabschluesse[i].getVon().equals(abschlussvon))

--- a/src/de/jost_net/JVerein/gui/dialogs/MittelverwendungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MittelverwendungDialog.java
@@ -125,6 +125,10 @@ public class MittelverwendungDialog extends AbstractDialog<Boolean>
       return nameInput;
     }
     nameInput = new TextInput(name, 50);
+    if (name != null && !name.isEmpty())
+    {
+      nameInput.setEnabled(false);
+    }
     return nameInput;
   }
 

--- a/src/de/jost_net/JVerein/gui/parts/MittelverwendungFlowList.java
+++ b/src/de/jost_net/JVerein/gui/parts/MittelverwendungFlowList.java
@@ -157,8 +157,8 @@ public class MittelverwendungFlowList extends MittelverwendungList
             Kontoart.RUECKLAGE_SONSTIG.getKey() },
         rsd);
 
-    bezeichnung = "Verwendungsrückstand(+)/-überhang(-) am Ende des letzten GJ "
-        + letztesGJ;
+    bezeichnung = "Verwendungsrückstand(+)/-überhang(-) zu Beginn des aktuellen GJ "
+        + aktuellesGJ;
     addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
         vorhandeneMittel, null, BLANK);
 
@@ -180,7 +180,7 @@ public class MittelverwendungFlowList extends MittelverwendungList
     addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
         rueckstandVorVorjahr, null, BLANK);
     bezeichnung = BLANKS
-        + "- Darin enthaltene zwanghafte satzungsgemäße Weitergabe von Mitteln";
+        + "- Überfällige zwanghafte satzungsgemäße Weitergabe von Mitteln aus den letzten GJ";
     addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
         zwanghafteWeitergabeVorjahr, null, BLANK);
 
@@ -294,23 +294,29 @@ public class MittelverwendungFlowList extends MittelverwendungList
     zwanghafteWeitergabeVorjahr = (zwanghafteWeitergabeVorjahr == null) ? 0.0
         : zwanghafteWeitergabeVorjahr;
     Double ausgaben = Math.max(verwendung - summeEntRuecklagen, 0);
-    Double rueckstandVorjahr = vorhandeneMittel - rueckstandVorVorjahr
-        - zwanghafteWeitergabeVorjahr;
+    Double rueckstandVorjahr = Math.max(
+        vorhandeneMittel - rueckstandVorVorjahr - zwanghafteWeitergabeVorjahr,
+        0);
     zwanghafteWeitergabeNeu = 0.0;
     rueckstandVorjahrNeu = 0.0; // Rest aus Rückstand Vorjahr
     // Der Rückstand aus dem vorletzten Jahr muss ganz aufgebraucht werden,
     // ansonsten unterliegt der Restbetrag der zwanghaften satzungsgemäßen
     // Weitergabe von Mitteln
 
-    if (rueckstandVorVorjahr > ausgaben)
+    if (zwanghafteWeitergabeVorjahr > ausgaben)
     {
-      zwanghafteWeitergabeNeu = rueckstandVorVorjahr - ausgaben;
+      zwanghafteWeitergabeNeu = rueckstandVorVorjahr;
+      rueckstandVorjahrNeu = rueckstandVorjahr;
+    }
+    else if (rueckstandVorVorjahr + zwanghafteWeitergabeVorjahr > ausgaben)
+    {
+      zwanghafteWeitergabeNeu = rueckstandVorVorjahr - ausgaben
+          + zwanghafteWeitergabeVorjahr;
       rueckstandVorjahrNeu = rueckstandVorjahr;
     }
     else
     {
-      rueckstandVorjahrNeu = Math
-          .max(vorhandeneMittel - ausgaben - zwanghafteWeitergabeVorjahr, 0);
+      rueckstandVorjahrNeu = Math.max(vorhandeneMittel - ausgaben, 0);
     }
     bezeichnung = BLANKS
         + "- Darin enthaltener Verwendungsrückstand aus dem letzten GJ "
@@ -318,7 +324,7 @@ public class MittelverwendungFlowList extends MittelverwendungList
     addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
         rueckstandVorjahrNeu, null, BLANK);
     bezeichnung = BLANKS
-        + "- Darin enthaltene zwanghafte satzungsgemäße Weitergabe von Mitteln";
+        + "- Überfällige zwanghafte satzungsgemäße Weitergabe von Mitteln";
     addZeile(zeilen, MittelverwendungZeile.EINNAHME, pos++, bezeichnung,
         zwanghafteWeitergabeNeu, null, BLANK);
 

--- a/src/de/jost_net/JVerein/keys/Kontoart.java
+++ b/src/de/jost_net/JVerein/keys/Kontoart.java
@@ -34,7 +34,7 @@ public enum Kontoart
   RUECKLAGE_FREI(106, "Freie Rücklage nach § 62 Abs. 1 Nr. 3 AO"),
   RUECKLAGE_ERWERB(107, "Rücklage für Gesellschaftsrechte nach § 62 Abs. 1 Nr. 4 AO"),
   VERMOEGEN(108, "Vermögen nach § 62 Abs. 3 und 4 AO"),
-  RUECKLAGE_SONSTIG(109, "Sonstige Rücklage");
+  RUECKLAGE_SONSTIG(109, "Sonstige Rücklagen und Vermögen");
 
   private final String text;
 


### PR DESCRIPTION
Aus der Diskussion im Forum zum Thema Mittelverwendung habe ich hier einige Korrekturen:
* Einige Texte zur Klarheit angepasst
* Einen Fehler bei der Berechnung der zwanghaften Weitergabe und des Rückstand Vorjahr für den Fall, dass es noch eine überfällige zwanghafte Weitergabe gibt. Eine solche sollte es nicht geben, aber wenn doch war die weitere Rechnung falsch. Ausgaben müssen erst für den Abbau dieser zwanghaften Weitergabe verwendet werden
* Dann habe ich noch den Button zum setzen der Startwerte im GJ nach dem jetzten Jahresabschluss frei geschaltet. Das ist nötig wenn ein Verein in einem Jahr die 45T € Grenze unterschreitet. Dann unterliegt er nicht mehr der Pflicht der zeitnahen Verwendung von Mitteln. Darum kann man alte Verwendungsrückstände löschen, also die Startwerte zurücksetzten
* Bei Kontoart habe ich die Art "Sonstige Rücklagen" in "Sonstige Rücklagen und Vermögen" umbenannt weil nicht alle Vermögen nach § 62 Abs. 3 und 4 AO sind


Der PR ist nicht so dringend, dass gleich eine neue 3.0.3 erzeugt werden müsste. Die kann man machen wenn weitere Fixes kommen sollten.