### PR TITLE
Abhängigkeiten mit renovate aktualisieren

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -20,6 +20,8 @@ project.zipfilename             = ${plugin.name}.${plugin.version}.zip
 project.zipfilename.nightly     = ${plugin.name}.${plugin.version}-nightly.zip
 
 jameica.url                     = https://github.com/willuhn/jameica/archive/refs/tags
+# renovate: depName=willuhn/jameica
 jameica.version                 = V_2_10_5_BUILD_488
 hibiscus.url                    = https://github.com/willuhn/hibiscus/archive/refs/tags
+# renovate: depName=willuhn/hibiscus
 hibiscus.version                = V_2_10_24_BUILD_388

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "build.properties"
+        "^build\\.properties$"
       ],
       "matchStrings": [
         "# renovate: depName=(?<depName>.*?)\\s*\\w\\.version\\s+=\\s?(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^build\\.properties$"
+        "^build/build\\.properties$"
       ],
       "matchStrings": [
         "# renovate: depName=(?<depName>.*?)\\s*\\w\\.version\\s+=\\s?(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "forkProcessing": "enabled",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "build.properties"
+      ],
+      "matchStrings": [
+        "# renovate: depName=(?<depName>.*?)\\s*\\w\\.version\\s+=\\s?(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
+    }
   ]
 }
+

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
         "^build/build\\.properties$"
       ],
       "matchStrings": [
-        "# renovate: depName=(?<depName>.*?)\\s*\\w\\.version\\s+=\\s?(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
+        "# renovate: depName=(?<depName>.*?)\\s*\\S+\\.version\\s*=\\s*(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
       ],
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"


### PR DESCRIPTION
Die Version der github actions von Jameica und Hibisus werden nun mit renovate überwacht. Sollten neue Versionen verfügbar sein, werden diese als PR gegen den default branch gestellt.