### PR TITLE
Sollbuchung Neu Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
@@ -17,11 +17,13 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.dialogs.SollbuchungNeuDialog;
 import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.util.ApplicationException;
 
 public class SollbuchungNeuAction implements Action
@@ -44,24 +46,43 @@ public class SollbuchungNeuAction implements Action
     {
       sollb = (Sollbuchung) Einstellungen.getDBService()
           .createObject(Sollbuchung.class, null);
-      sollb.setBetrag(0.0);
       if (m != null)
       {
         if (m.getID() == null)
         {
           throw new ApplicationException(
-              "Neues Mitglied bitte erst speichern. Dann können Zusatzbeträge aufgenommen werden.");
+              "Neues Mitglied bitte erst speichern. Dann können Sollbuchungen aufgenommen werden.");
         }
         sollb.setMitglied(m);
         sollb.setZahlungsweg(m.getZahlungsweg());
-        sollb.setZahler(m.getZahler());
+        if (m.getZahler() != null)
+        {
+          sollb.setZahler(m.getZahler());
+        }
+        else
+        {
+          sollb.setZahler(m);
+        }
       }
+      SollbuchungNeuDialog sollbd = new SollbuchungNeuDialog(sollb);
+      if (sollbd.open())
+      {
+        // Anzeigen ausgewählt
+        GUI.startView(SollbuchungDetailView.class.getName(), sollb);
+      }
+      else
+      {
+        GUI.getCurrentView().reload();
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw new OperationCanceledException(oce);
     }
     catch (Exception e)
     {
       throw new ApplicationException(
           "Fehler bei der Erzeugung einer neuen Sollbuchung", e);
     }
-    GUI.startView(new SollbuchungDetailView(), sollb);
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -154,6 +154,14 @@ public class SollbuchungControl extends DruckMailControl
     settings.setStoreWhenRead(true);
   }
 
+  public SollbuchungControl(AbstractView view, Sollbuchung sollb)
+  {
+    super(view);
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+    sollbuchung = sollb;
+  }
+
   public Sollbuchung getSollbuchung()
   {
     if (sollbuchung != null)
@@ -162,6 +170,11 @@ public class SollbuchungControl extends DruckMailControl
     }
     sollbuchung = (Sollbuchung) getCurrentObject();
     return sollbuchung;
+  }
+
+  public void setSollbuchung(Sollbuchung sollb)
+  {
+    sollbuchung = sollb;
   }
 
   public Settings getSettings()
@@ -305,7 +318,7 @@ public class SollbuchungControl extends DruckMailControl
     return suchname2;
   }
 
-  public void handleStore()
+  public boolean handleStore()
   {
     try
     {
@@ -334,6 +347,7 @@ public class SollbuchungControl extends DruckMailControl
 
       sollb.store();
       GUI.getStatusBar().setSuccessText("Sollbuchung gespeichert");
+      return true;
     }
     catch (ApplicationException e)
     {
@@ -345,6 +359,7 @@ public class SollbuchungControl extends DruckMailControl
       Logger.error(fehler, e);
       GUI.getStatusBar().setErrorText(fehler);
     }
+    return false;
   }
 
   public Part getMitgliedskontoTree(Mitglied mitglied) throws RemoteException
@@ -880,7 +895,7 @@ public class SollbuchungControl extends DruckMailControl
         list.remove(new Zahlungsweg(Zahlungsweg.VOLLZAHLER));
         Mitglied m = (Mitglied) getMitglied().getValue();
         Mitglied z = (Mitglied) getZahler().getValue();
-        if (m.getZahlerID() != null)
+        if (m != null && m.getZahlerID() != null)
         {
           list.add(new Zahlungsweg(Zahlungsweg.VOLLZAHLER));
           if (z == null)

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
@@ -27,7 +27,6 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
-import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
 import de.jost_net.JVerein.keys.SteuersatzBuchungsart;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
@@ -65,6 +64,13 @@ public class SollbuchungPositionControl extends AbstractControl
   public SollbuchungPositionControl(AbstractView view)
   {
     super(view);
+  }
+
+  public SollbuchungPositionControl(AbstractView view,
+      SollbuchungPosition sollbPos)
+  {
+    super(view);
+    position = sollbPos;
   }
 
   public SollbuchungPosition getPosition()
@@ -184,7 +190,7 @@ public class SollbuchungPositionControl extends AbstractControl
     return steuersatz;
   }
 
-  public void handleStore()
+  public boolean handleStore()
   {
     try
     {
@@ -224,9 +230,7 @@ public class SollbuchungPositionControl extends AbstractControl
       }
       sollb.setBetrag(betrag);
       sollb.store();
-
-      GUI.startView(SollbuchungDetailView.class.getName(), sollb);
-      GUI.getStatusBar().setSuccessText("Sollbuchungsposition gespeichert");
+      return true;
     }
     catch (RemoteException e)
     {
@@ -238,6 +242,7 @@ public class SollbuchungPositionControl extends AbstractControl
     {
       GUI.getStatusBar().setErrorText(e.getMessage());
     }
+    return false;
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
@@ -1,0 +1,252 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.dialogs;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.SollbuchungControl;
+import de.jost_net.JVerein.gui.control.SollbuchungPositionControl;
+import de.jost_net.JVerein.gui.input.MitgliedSearchInput;
+import de.jost_net.JVerein.gui.view.DokumentationUtil;
+import de.jost_net.JVerein.rmi.Sollbuchung;
+import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.ColumnLayout;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.SimpleContainer;
+
+/**
+ * Dialog zur Bearbeitung einer Splitbuchung.
+ */
+public class SollbuchungNeuDialog extends AbstractDialog<Boolean>
+{
+
+  private SollbuchungControl sollbControl;
+
+  private SollbuchungPositionControl sollbPosControl;
+
+  private Sollbuchung sollbuchung;
+
+  private SollbuchungPosition sollbuchungPosition;
+
+  private Boolean edit = false;
+
+  public SollbuchungNeuDialog(Sollbuchung sollbuchung)
+  {
+    super(AbstractDialog.POSITION_CENTER);
+    setTitle("Neue Sollbuchung");
+    this.sollbuchung = sollbuchung;
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    sollbuchungPosition = (SollbuchungPosition) Einstellungen.getDBService()
+        .createObject(SollbuchungPosition.class, null);
+
+    sollbControl = new SollbuchungControl(null, sollbuchung);
+    sollbPosControl = new SollbuchungPositionControl(null, sollbuchungPosition);
+
+    LabelGroup group = new LabelGroup(parent, null);
+    ColumnLayout cols = new ColumnLayout(group.getComposite(), 2);
+    // Sollbuchung
+    SimpleContainer left = new SimpleContainer(cols.getComposite());
+    left.addHeadline("Sollbuchung");
+    left.addLabelPair("Mitglied", sollbControl.getMitglied());
+    left.addLabelPair("Zahler", sollbControl.getZahler());
+    left.addLabelPair("Datum", sollbControl.getDatum());
+    left.addLabelPair("Verwendungszweck", sollbControl.getZweck1());
+    left.addLabelPair("Zahlungsweg", sollbControl.getZahlungsweg());
+
+    // Sollbuchungsposition, Datum und Zweck wird von Sollbuchung genommen
+    SimpleContainer right = new SimpleContainer(cols.getComposite());
+    right.addHeadline("Sollbuchungsposition");
+    right.addLabelPair("Betrag", sollbPosControl.getBetrag());
+    DateInput date = sollbPosControl.getDatum();
+    date.setMandatory(false);
+    right.addLabelPair("Datum", date);
+    Input zweck = sollbPosControl.getZweck();
+    zweck.setMandatory(false);
+    right.addLabelPair("Zweck", zweck);
+    right.addLabelPair("Buchungsart", sollbPosControl.getBuchungsart());
+    if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
+    {
+      right.addLabelPair("Buchungsklasse", sollbPosControl.getBuchungsklasse());
+    }
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.MITGLIEDSKONTO_UEBERSICHT, false,
+        "question-circle.png");
+
+    // Speichern und zurück zum View
+    buttons.addButton("Speichern", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        if (!handleStore())
+        {
+          return;
+        }
+        edit = false;
+        close();
+      }
+    }, null, true, "document-save.png");
+
+    // Speichern und Sollbuchung anzeigen
+    buttons.addButton("Speichern und Anzeigen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        if (!handleStore())
+        {
+          return;
+        }
+        edit = true;
+        close();
+      }
+    }, null, false, "document-save.png");
+
+    // Speichern und neue Sollbuchung erzeugen
+    // Es wird nur angeboten wenn es nicht im Mitgliedskonto Tab eines Mitglieds
+    // aufgerufen wurde
+    if (sollbControl.getMitglied().getValue() == null)
+    {
+      buttons.addButton("Speichern und Neu", new Action()
+      {
+
+        @Override
+        public void handleAction(Object context)
+        {
+          if (!handleStore())
+          {
+            return;
+          }
+          try
+          {
+            Sollbuchung sollb = (Sollbuchung) Einstellungen.getDBService()
+                .createObject(Sollbuchung.class, null);
+            sollbControl.setSollbuchung(sollb);
+            Input mitgliedInput = sollbControl.getMitglied();
+            if (mitgliedInput instanceof SelectInput)
+            {
+              ((SelectInput) mitgliedInput).setPreselected(null);
+            }
+            else if (mitgliedInput instanceof MitgliedSearchInput)
+            {
+              ((MitgliedSearchInput) mitgliedInput)
+                  .setValue("Zum Suchen tippen");
+            }
+            Input zahlerInput = sollbControl.getZahler();
+            if (zahlerInput instanceof SelectInput)
+            {
+              ((SelectInput) zahlerInput).setPreselected(null);
+            }
+            else if (zahlerInput instanceof MitgliedSearchInput)
+            {
+              ((MitgliedSearchInput) zahlerInput).setValue("Zum Suchen tippen");
+            }
+          }
+          catch (Exception e)
+          {
+            String fehler = "Fehler beim erzeugen der Sollbuchung";
+            GUI.getStatusBar().setErrorText(fehler);
+          }
+        }
+      }, null, false, "go-next.png");
+    }
+
+    // Aktion abbrechen
+    buttons.addButton("Abbrechen", new Action()
+    {
+
+      @Override
+      public void handleAction(Object context)
+      {
+        edit = false;
+        close();
+      }
+    }, null, false, "process-stop.png");
+    buttons.paint(parent);
+
+    getShell().setMinimumSize(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT));
+
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  @Override
+  public Boolean getData() throws Exception
+  {
+    return edit;
+  }
+
+  private boolean handleStore()
+  {
+    try
+    {
+      DBTransaction.starten();
+      sollbControl.getBetrag().setValue(sollbPosControl.getBetrag().getValue());
+      if (sollbPosControl.getDatum().getValue() == null)
+      {
+        sollbPosControl.getDatum().setValue(sollbControl.getDatum().getValue());
+      }
+      String zweck = (String) sollbPosControl.getZweck().getValue();
+      if (zweck == null || zweck.isEmpty())
+      {
+        sollbPosControl.getZweck()
+            .setValue(sollbControl.getZweck1().getValue());
+      }
+      if (!sollbControl.handleStore())
+      {
+        DBTransaction.rollback();
+        return false;
+      }
+      sollbuchungPosition.setSollbuchung(sollbuchung.getID());
+      if (!sollbPosControl.handleStore())
+      {
+        DBTransaction.rollback();
+        return false;
+      }
+      DBTransaction.commit();
+      return true;
+    }
+    catch (Exception e)
+    {
+      String fehler = "Fehler beim speichern der Sollbuchung";
+      GUI.getStatusBar().setErrorText(fehler);
+      DBTransaction.rollback();
+      return false;
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungPositionView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungPositionView.java
@@ -16,6 +16,8 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.rmi.RemoteException;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.SollbuchungPositionControl;
@@ -56,7 +58,19 @@ public class SollbuchungPositionView extends AbstractView
       @Override
       public void handleAction(Object context)
       {
-        control.handleStore();
+        if (control.handleStore())
+        {
+          try
+          {
+            GUI.startView(SollbuchungDetailView.class.getName(),
+                control.getPosition().getSollbuchung());
+          }
+          catch (RemoteException e)
+          {
+            //
+          }
+          GUI.getStatusBar().setSuccessText("Sollbuchungsposition gespeichert");
+        }
       }
     }, null, true, "document-save.png");
     buttons.paint(this.getParent());


### PR DESCRIPTION
Implementiert #709 

Beim Erzeugen einer neuen Sollbuchung wird jetzt ein Dialog geöffnet mit dem man eine Sollbuchung inkl. einer ersten SollbuchungPosition erzeugen kann.

![Bildschirmfoto_20250227_131649](https://github.com/user-attachments/assets/9aafa708-129d-42f0-ad7e-9d88e22e0189)

Das Datum und der Zweck bei der Sollbuchungposition sind optional. Wenn nichts gesetzt ist werden die Daten von der Sollbuchung übernommen.

Mit den Buttons hat man folgende Möglichkeiten:
* Speichern: Speichert die Sollbuchung, schliest den Dialog und bleibt beim aktuellen View
* Speichern und Anzeigen: Speichert die Sollbuchung, schliest den Dialog und zeigt die Sollbuchung an
* Speichern und Neu:  Speichert die Sollbuchung, der Dialog bleibt offen und eine neue Sollbuchung wird angezeigt. Dabei wird das Mitglied und dar Zahler gelöscht. Dieses bietet sich an wenn man manuell die gleiche Sollbuchung für mehrere Mitglieder erstellen will. Man muss nur das Mitglied und Zahler neu eingeben, die anderen Daten bleiben erhalten. Dieser Button ist nicht verfügbar wenn man die Sollbuchung aus dem Mitgliedskonto Tab es Mitglieds erzeugt. Hier ist das Mitglied nicht editierbar.