### PR TITLE
Update zu Fix Auswertung Nichtmitglieder

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -272,7 +272,7 @@ public class FilterControl extends AbstractControl
       suchadresstyp = new SelectInput(new ArrayList<>(), null);
     }
     suchadresstyp.setName("Mitgliedstyp");
-    suchadresstyp.setPleaseChoose("Bitte auswählen");
+    suchadresstyp.setPleaseChoose(ALLE);
     suchadresstyp.addListener(new FilterListener());
     return suchadresstyp;
   }

--- a/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
+++ b/src/de/jost_net/JVerein/gui/view/AuswertungNichtMitgliedView.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.DialogInput;
+import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -50,7 +51,10 @@ public class AuswertungNichtMitgliedView extends AbstractView
     SimpleContainer left = new SimpleContainer(cl.getComposite());
 
     left.addInput(control.getMailauswahl());
-    left.addInput(control.getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED));
+    SelectInput adressTyp = control
+        .getSuchAdresstyp(Mitgliedstyp.NICHTMITGLIED);
+    adressTyp.setPleaseChoose("Bitte auswählen");
+    left.addInput(adressTyp);
     DialogInput eigenschaftenInput = control.getEigenschaftenAuswahl();
     left.addInput(eigenschaftenInput);
     control.updateEigenschaftenAuswahlTooltip();


### PR DESCRIPTION
Ich habe gesehen, dass #714 auch bewirkt hat, dass im Nicht-Mitglied View jetzt auch "Bitte wählen" statt "Alle" angezeigt wird. Hier ist "Alle" aber richtig.

Ich habe die alte Änderung rückgängig gemacht und die Kotrrektur nur im Auswertung View für Nicht-Mitglieder gemacht. Das kann man ja zurücknehmen wenn jemand den Report entsprechend erweitert.

Wegen des zu erwertenden Merge Konflikt nach feature-3.1.0 mache ich dort einen eigenen PR.