### PR TITLE
use DEPLOY_KEY to push to protected branches

### DIFF
--- a/.github/workflows/merge-master-into-feature.yml
+++ b/.github/workflows/merge-master-into-feature.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set Git config
         run: |


### PR DESCRIPTION
Benutzt den neu erstellten DEPLOY_KEY (siehe https://github.com/openjverein/jverein/pull/705#issuecomment-2684937540), um master in die aktuelle feature branch zu mergen.