### PR TITLE
Alle Felder als Spalte ermöglichen, Eigenschaften Gruppen Variablen

### DIFF
--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -16,13 +16,21 @@
  **********************************************************************/
 package de.jost_net.JVerein.Variable;
 
+import java.io.IOException;
+import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.io.BeitragsUtil;
 import de.jost_net.JVerein.io.VelocityTool;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Eigenschaft;
+import de.jost_net.JVerein.rmi.EigenschaftGruppe;
 import de.jost_net.JVerein.rmi.Eigenschaften;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Mitglied;
@@ -36,13 +44,6 @@ import de.jost_net.OBanToo.SEPA.BankenDaten.Banken;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
-
-import java.io.IOException;
-import java.rmi.RemoteException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
 public class MitgliedMap
 {
@@ -297,6 +298,17 @@ public class MitgliedMap
         val = "X";
       }
       map.put("mitglied_eigenschaft_" + eig.getBezeichnung(), val);
+    }
+
+    DBIterator<EigenschaftGruppe> eigenschaftGruppeIt = Einstellungen
+        .getDBService()
+        .createList(EigenschaftGruppe.class);
+    while (eigenschaftGruppeIt.hasNext())
+    {
+      EigenschaftGruppe eg = (EigenschaftGruppe) eigenschaftGruppeIt.next();
+
+      String key = "eigenschaften_" + eg.getBezeichnung();
+      map.put("mitglied_" + key, mitglied.getAttribute(key));
     }
 
     for (String varname : mitglied.getVariablen().keySet())

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -25,10 +25,13 @@ import de.jost_net.JVerein.gui.formatter.ZahlungsrhythmusFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungsterminFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.keys.Datentyp;
+import de.jost_net.JVerein.keys.Staat;
+import de.jost_net.JVerein.rmi.EigenschaftGruppe;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.logging.Logger;
@@ -59,6 +62,7 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     add("Straße", "strasse", true, true);
     add("PLZ", "plz", false, true);
     add("Ort", "ort", true, true);
+    add("Staat", "staat", false, new StaatFormatter(), Column.ALIGN_LEFT, true);
     add("Zahlungsweg", "zahlungsweg", false, new ZahlungswegFormatter(),
         Column.ALIGN_LEFT, false);
     add("Zahlungsrhytmus", "zahlungsrhytmus", false,
@@ -68,8 +72,6 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     add("Datum des Mandats", "mandatdatum", false, false);
     add("BIC", "bic", false, true);
     add("IBAN", "iban", false, new IbanFormatter(), Column.ALIGN_LEFT, true);
-    add("BLZ", "blz", false, true);
-    add("Konto", "konto", false, true);
     add("Kontoinhaber Anrede", "ktoianrede", false, true);
     add("Kontoinhaber Name", "ktoiname", false, true);
     add("Kontoinhaber Titel", "ktoititel", false, true);
@@ -79,8 +81,10 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
         true);
     add("Kontoinhaber PLZ", "ktoiplz", false, true);
     add("Kontoinhaber Ort", "ktoiort", false, true);
-    add("Kontoinhaber Staat", "ktoistaat", false, true);
+    add("Kontoinhaber Staat", "ktoistaat", false, new StaatFormatter(),
+        Column.ALIGN_LEFT, true);
     add("Kontoinhaber Email", "ktoiemail", false, true);
+    add("Kontoinhaber Geschlecht", "ktoigeschlecht", false, true);
     add("Mandat Version", "mandatversion", false, true);
     add("Geburtsdatum", "geburtsdatum", true,
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO, true);
@@ -101,8 +105,14 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     add("Kündigung", "kuendigung", false,
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
         false);
+    add("Leitweg ID", "leitwegid", false, true);
+    add("Zahler ID", "zahlerid", false, true);
     try
     {
+      if (Einstellungen.getEinstellung().getIndividuelleBeitraege())
+      {
+        add("Individueller Beitrag", "individuellerbeitrag", false, true);
+      }
       if (Einstellungen.getEinstellung().getSterbedatum())
       {
         add("Sterbedatum", "sterbetag", false,
@@ -146,10 +156,42 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
             break;
         }
       }
+
+      DBIterator<EigenschaftGruppe> eigenschaftGruppeit = Einstellungen
+          .getDBService().createList(EigenschaftGruppe.class);
+      while (eigenschaftGruppeit.hasNext())
+      {
+        EigenschaftGruppe eg = (EigenschaftGruppe) eigenschaftGruppeit.next();
+
+        add(eg.getBezeichnung(), "eigenschaften_" + eg.getBezeichnung(), false,
+            true);
+
+      }
     }
     catch (RemoteException e)
     {
       Logger.error("Fehler", e);
+    }
+  }
+
+  class StaatFormatter implements Formatter
+  {
+
+    @Override
+    public String format(Object o)
+    {
+      if (o == null)
+      {
+        return "";
+      }
+      try
+      {
+        return Staat.getStaat((String) o);
+      }
+      catch (RemoteException e)
+      {
+        return "";
+      }
     }
   }
 }


### PR DESCRIPTION
Ich habe alle Möglichkeiten bei der Spaltenauswahl für Mitglieder hinzugefügt, inkl. Eigenschaftengruppen.
Außerdem habe ich in der Mitgliedmap eigenschaften_xxx Vraiablen eingeführt, die aus dieser Gruppe alle Ausgewählten Eigenschaften  des Mitglieds Kommagetrennt auflistet. 

Fix #667 
Implement #658 