### PR TITLE
Eingabedatum und Eintrittsdatum bei Abrechnung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -107,6 +107,8 @@ public class AbrechnungSEPAControl extends AbstractControl
 
   private DateInput rechnungsdatum;
 
+  private DateInput voneingabedatum;
+
   public AbrechnungSEPAControl(AbstractView view)
   {
     super(view);
@@ -143,11 +145,15 @@ public class AbrechnungSEPAControl extends AbstractControl
         {
           vondatum.setValue(null);
           vondatum.setEnabled(false);
+          voneingabedatum.setValue(null);
+          voneingabedatum.setEnabled(false);
         }
         else
         {
           vondatum.setEnabled(true);
           vondatum.setValue(new Date());
+          voneingabedatum.setValue(new Date());
+          voneingabedatum.setEnabled(true);
         }
         if (m.intValue() != Abrechnungsmodi.ABGEMELDETEMITGLIEDER)
         {
@@ -214,8 +220,21 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.vondatum = new DateInput(null, new JVDateFormatTTMMJJJJ());
     this.vondatum.setTitle("Anfangsdatum Abrechnung");
     this.vondatum.setText("Bitte Anfangsdatum der Abrechnung wählen");
-    this.vondatum.setEnabled(false);
+    this.vondatum.setEnabled(
+        (Integer) modus.getValue() == Abrechnungsmodi.EINGETRETENEMITGLIEDER);
     return vondatum;
+  }
+
+  public DateInput getVonEingabedatum()
+  {
+    if (voneingabedatum != null)
+    {
+      return voneingabedatum;
+    }
+    this.voneingabedatum = new DateInput(null, new JVDateFormatTTMMJJJJ());
+    this.voneingabedatum.setEnabled(
+        (Integer) modus.getValue() == Abrechnungsmodi.EINGETRETENEMITGLIEDER);
+    return voneingabedatum;
   }
 
   public DateInput getBisdatum()
@@ -228,7 +247,8 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.bisdatum.setTitle("Enddatum Abrechnung");
     this.bisdatum
         .setText("Bitte maximales Austrittsdatum für die Abrechnung wählen");
-    this.bisdatum.setEnabled(false);
+    this.bisdatum.setEnabled(
+        (Integer) modus.getValue() == Abrechnungsmodi.EINGETRETENEMITGLIEDER);
     return bisdatum;
   }
 
@@ -487,7 +507,8 @@ public class AbrechnungSEPAControl extends AbstractControl
     if (modus != Abrechnungsmodi.KEINBEITRAG)
     {
       vondatum = (Date) getVondatum().getValue();
-      if (modus == Abrechnungsmodi.EINGETRETENEMITGLIEDER && vondatum == null)
+      if (modus == Abrechnungsmodi.EINGETRETENEMITGLIEDER && vondatum == null
+          && getVonEingabedatum().getValue() == null)
       {
         throw new ApplicationException("von-Datum fehlt");
       }

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -52,6 +52,7 @@ public class AbrechnungSEPAView extends AbstractView
     }
     left.addLabelPair("Stichtag¹", control.getStichtag());
     left.addLabelPair("Von Eintrittsdatum", control.getVondatum());
+    left.addLabelPair("Von Eingabedatum", control.getVonEingabedatum());
     left.addLabelPair("Bis Austrittsdatum", control.getBisdatum());
     left.addLabelPair("Zahlungsgrund für Beiträge",
         control.getZahlungsgrund());

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -63,9 +63,9 @@ import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mitglied;
-import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.rmi.SekundaereBeitragsgruppe;
+import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.rmi.ZusatzbetragAbrechnungslauf;
@@ -392,6 +392,11 @@ public class AbrechnungSEPA
       {
         list.addFilter("eintritt >= ?",
             new java.sql.Date(param.vondatum.getTime()));
+      }
+      if (param.voneingabedatum != null)
+      {
+        list.addFilter("eingabedatum >= ?",
+            new java.sql.Date(param.voneingabedatum.getTime()));
       }
       if (Einstellungen.getEinstellung()
           .getBeitragsmodel() == Beitragsmodel.MONATLICH12631)

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPAParam.java
@@ -87,6 +87,8 @@ public class AbrechnungSEPAParam
   
   private String text = "";
 
+  public Date voneingabedatum;
+
   public AbrechnungSEPAParam(AbrechnungSEPAControl ac, File sepafileRCUR, SepaVersion sepaVersion, String pdffileRCUR)
       throws ApplicationException, RemoteException
   {
@@ -98,6 +100,7 @@ public class AbrechnungSEPAParam
     abbuchungsausgabe = (Abrechnungsausgabe) ac.getAbbuchungsausgabe()
         .getValue();
     vondatum = (Date) ac.getVondatum().getValue();
+    voneingabedatum = (Date) ac.getVonEingabedatum().getValue();
     bisdatum = (Date) ac.getBisdatum().getValue();
     verwendungszweck = (String) ac.getZahlungsgrund().getValue();
     zusatzbetraege = (Boolean) ac.getZusatzbetrag().getValue();


### PR DESCRIPTION
Wie in #664 besprochen habe ich ein zusätzliches Feld für das Eingabedatum bei der Abrechnung von eingetretenen Mitgliedern angelegt. Es kann entweder Eingabedatum oder Eintrittsdatum oder auch beide verwendet werden.
Momentan werden noch beide automatisch gefüllt, da habe ich die Frage, ob wir nur eines der beiden automatisch füllen sollen? Dann wäre es vielleicht leichter verständlich dass nicht beide verwendet werden müssen.

Der neue Parameter müsste noch in der DB beim Abrechnungslauf gespeichert werden. Dort sind aber auch sonst noch nicht alle Parameter drin, daher würde ich es in einem extra PR machen.