### PR TITLE
Kontosaldo auch Buchungen ohne Buchungsart

### DIFF
--- a/src/de/jost_net/JVerein/io/SaldoZeile.java
+++ b/src/de/jost_net/JVerein/io/SaldoZeile.java
@@ -284,3 +284,4 @@ public class SaldoZeile implements GenericObject
   }
   
 }
+


### PR DESCRIPTION
Im Kontosaldo werden Buchungen ohne Buchungsart bisher nicht berücksichtigt. Das fand ich immer wieder verwirrend, da der Kontostand nicht gestimmt hat.
Mit diesem PR habe ich sie nun einbezogen, in der Bemerkung steht dann: "Summe Buchungen ohne Buchungsart: xxx.xx".