### PR TITLE
Sollbuchung Zuordnen in BuchungDetailView wiederhergestellt

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -54,6 +54,7 @@ import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.IBANInput;
 import de.jost_net.JVerein.gui.input.KontoauswahlInput;
+import de.jost_net.JVerein.gui.input.SollbuchungAuswahlInput;
 import de.jost_net.JVerein.gui.menu.BuchungMenu;
 import de.jost_net.JVerein.gui.menu.SplitBuchungMenu;
 import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
@@ -74,6 +75,7 @@ import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.rmi.Konto;
+import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Projekt;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
@@ -150,7 +152,7 @@ public class BuchungsControl extends AbstractControl
 
   private Input art;
 
-  private TextInput sollbuchung;
+  private DialogInput sollbuchung;
 
   private TextAreaInput kommentar;
 
@@ -570,22 +572,41 @@ public class BuchungsControl extends AbstractControl
     return verzicht;
   }
 
-  public TextInput getSollbuchung() throws RemoteException
+  public DialogInput getSollbuchung() throws RemoteException
   {
-
-    if (sollbuchung != null && !sollbuchung.getControl().isDisposed())
-    {
-      return sollbuchung;
-    }
-
-    Sollbuchung sollb = getBuchung().getSollbuchung();
-    sollbuchung = new TextInput(
-        sollb != null
-            ? Adressaufbereitung.getNameVorname(sollb.getMitglied()) + ", "
-                + new JVDateFormatTTMMJJJJ().format(sollb.getDatum()) + ", "
-                + Einstellungen.DECIMALFORMAT.format(sollb.getBetrag())
-            : "");
-    sollbuchung.disable();
+    sollbuchung = new SollbuchungAuswahlInput(getBuchung())
+        .getSollbuchungAuswahl();
+    sollbuchung.addListener(event ->
+      {
+        try
+        {
+          String name = (String) getName().getValue();
+          String zweck1 = (String) getZweck().getValue();
+          if (sollbuchung.getValue() != null && name.length() == 0
+              && zweck1.length() == 0)
+          {
+            if (sollbuchung.getValue() instanceof Sollbuchung)
+            {
+              Sollbuchung sb = (Sollbuchung) sollbuchung.getValue();
+              getName().setValue(
+                  Adressaufbereitung.getNameVorname(sb.getMitglied()));
+              getBetrag().setValue(sb.getBetrag());
+              getZweck().setValue(sb.getZweck1());
+              getDatum().setValue(sb.getDatum());
+            }
+            if (sollbuchung.getValue() instanceof Mitglied)
+            {
+              Mitglied m2 = (Mitglied) sollbuchung.getValue();
+              getName().setValue(Adressaufbereitung.getNameVorname(m2));
+              getDatum().setValue(new Date());
+            }
+          }
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+    });
     return sollbuchung;
   }
 

--- a/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
+++ b/src/de/jost_net/JVerein/gui/input/SollbuchungAuswahlInput.java
@@ -1,0 +1,159 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.input;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.dialogs.SollbuchungAuswahlDialog;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Sollbuchung;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.input.DialogInput;
+import de.willuhn.logging.Logger;
+
+public class SollbuchungAuswahlInput
+{
+
+  private DialogInput sollbuchungAuswahl = null;
+
+  private Buchung[] buchungen = null;
+
+  private Sollbuchung sollbuchung = null;
+
+  private Mitglied mitglied = null;
+
+  public SollbuchungAuswahlInput(Buchung buchung) throws RemoteException
+  {
+    buchungen = new Buchung[1];
+    buchungen[0] = buchung;
+    this.sollbuchung = buchungen[0].getSollbuchung();
+  }
+
+  /**
+   * Liefert ein Auswahlfeld fuer die Sollbuchung.
+   * 
+   * @return Auswahl-Feld.
+   * @throws RemoteException
+   */
+  public DialogInput getSollbuchungAuswahl() throws RemoteException
+  {
+    if (sollbuchungAuswahl != null
+        && !sollbuchungAuswahl.getControl().isDisposed())
+    {
+      return sollbuchungAuswahl;
+    }
+    SollbuchungAuswahlDialog d = new SollbuchungAuswahlDialog(
+        buchungen[0]);
+    d.addCloseListener(new SollbuchungListener());
+
+    sollbuchungAuswahl = new DialogInput(sollbuchung != null
+        ? Adressaufbereitung.getNameVorname(sollbuchung.getMitglied()) + ", "
+            + new JVDateFormatTTMMJJJJ().format(sollbuchung.getDatum()) + ", "
+            + Einstellungen.DECIMALFORMAT.format(sollbuchung.getBetrag())
+        : "", d);
+    sollbuchungAuswahl.disableClientControl();
+    sollbuchungAuswahl.setValue(buchungen[0].getSollbuchung());
+    return sollbuchungAuswahl;
+  }
+
+  /**
+   * Listener, der die Auswahl der Sollbuchung ueberwacht und die
+   * Waehrungsbezeichnung hinter dem Betrag abhaengig vom ausgewaehlten Konto
+   * anpasst.
+   */
+  private class SollbuchungListener implements Listener
+  {
+
+    /**
+     * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
+     */
+    @Override
+    public void handleEvent(Event event)
+    {
+
+      if (event == null)
+      {
+        return;
+      }
+
+      if (event.data == null)
+      {
+        try
+        {
+          if (event.detail != SWT.CANCEL)
+            getSollbuchungAuswahl().setText("");
+          return;
+        }
+        catch (RemoteException er)
+        {
+          String error = "Fehler bei Auswahl der Sollbuchung";
+          Logger.error(error, er);
+          GUI.getStatusBar().setErrorText(error);
+        }
+      }
+      try
+      {
+        String b = "";
+        if (event.data instanceof Sollbuchung)
+        {
+          sollbuchung = (Sollbuchung) event.data;
+          b = Adressaufbereitung.getNameVorname(sollbuchung.getMitglied())
+              + ", " + new JVDateFormatTTMMJJJJ().format(sollbuchung.getDatum())
+              + ", "
+              + Einstellungen.DECIMALFORMAT.format(sollbuchung.getBetrag());
+          String name = buchungen[0].getName();
+          String zweck1 = buchungen[0].getZweck();
+          if ((name == null || name.length() == 0)
+              && (zweck1 == null || zweck1.length() == 0))
+          {
+            buchungen[0].setName(Adressaufbereitung.getNameVorname(sollbuchung
+                .getMitglied()));
+            buchungen[0].setZweck(sollbuchung.getZweck1());
+            buchungen[0].setBetrag(sollbuchung.getBetrag());
+            buchungen[0].setDatum(new Date());
+            buchungen[0].setBuchungsartId(sollbuchung
+                .getSollbuchungPositionList().get(0).getBuchungsartId());
+            buchungen[0].setBuchungsklasseId(sollbuchung
+                .getSollbuchungPositionList().get(0).getBuchungsklasseId());
+          }
+        }
+        else if (event.data instanceof Mitglied)
+        {
+          mitglied = (Mitglied) event.data;
+          b = Adressaufbereitung.getNameVorname(mitglied)
+              + ", Sollbuchung erzeugen";
+        }
+        getSollbuchungAuswahl().setText(b);
+      }
+      catch (RemoteException er)
+      {
+        String error = "Fehler bei Zuordnung des Mitgliedskontos";
+        Logger.error(error, er);
+        GUI.getStatusBar().setErrorText(error);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Wie im Forum und in #686 gefordert habe ich die Sollbuchungszuornung im BuchungsDetailView wiederhergestellt. Hier wird die Buchung nur der Sollbuchung zugeordnet, eine automatische Splitttung findet nicht statt. Darauf würde ich in der DoKu verweisen.