### PR TITLE
Fix drop not null in H2DB

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
@@ -197,13 +197,27 @@ public abstract class AbstractDDLUpdate implements IDDLUpdate
     return "";
   }
 
-  public String alterColumnNotNull(String table, Column col)
+  public String alterColumnSetNotNull(String table, Column col)
   {
     switch (drv)
     {
       case H2:
         return "ALTER TABLE " + table + " ALTER COLUMN " + col.getName()
             + " SET NOT NULL;\n";
+      case MYSQL:
+        return "ALTER TABLE " + table + " MODIFY COLUMN " + col.getName() + " "
+            + getType(col) + ";\n";
+    }
+    return "";
+  }
+
+  public String alterColumnDropNotNull(String table, Column col)
+  {
+    switch (drv)
+    {
+      case H2:
+        return "ALTER TABLE " + table + " ALTER COLUMN " + col.getName()
+            + " DROP NOT NULL;\n";
       case MYSQL:
         return "ALTER TABLE " + table + " MODIFY COLUMN " + col.getName() + " "
             + getType(col) + ";\n";

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0380.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0380.java
@@ -34,7 +34,7 @@ public class Update0380 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     // Liquibase id=112
-    execute(alterColumnNotNull("mailempfaenger",
+    execute(alterColumnSetNotNull("mailempfaenger",
         new Column("versand", COLTYPE.TIMESTAMP, 0, null, true, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0381.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0381.java
@@ -34,7 +34,7 @@ public class Update0381 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     // Liquibase id=113
-    execute(alterColumnNotNull("mail",
+    execute(alterColumnSetNotNull("mail",
         new Column("versand", COLTYPE.TIMESTAMP, 0, null, true, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0382.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0382.java
@@ -34,7 +34,7 @@ public class Update0382 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     // Liquibase id=114
-    execute(alterColumnNotNull("kursteilnehmer",
+    execute(alterColumnSetNotNull("kursteilnehmer",
         new Column("blz", COLTYPE.VARCHAR, 8, null, true, false)));
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0447.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0447.java
@@ -31,10 +31,10 @@ public class Update0447 extends AbstractDDLUpdate
   @Override
   public void run() throws ApplicationException
   {
-    execute(alterColumn("mail",
+    execute(alterColumnDropNotNull("mail",
         new Column("versand", COLTYPE.TIMESTAMP, 0, "NULL", false, false)));
 
-    execute(alterColumn("mailempfaenger",
+    execute(alterColumnDropNotNull("mailempfaenger",
         new Column("versand", COLTYPE.TIMESTAMP, 0, "NULL", false, false)));
 
     execute(dropForeignKey("fkAnfangsbestand1", "anfangsbestand"));

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0452.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0452.java
@@ -34,6 +34,6 @@ public class Update0452 extends AbstractDDLUpdate
     
     Column betrag = new Column("betrag", COLTYPE.DOUBLE, 0, null, true,
         false);
-    execute(alterColumnNotNull("mitgliedskonto", betrag));
+    execute(alterColumnSetNotNull("mitgliedskonto", betrag));
   }
 }


### PR DESCRIPTION
Ich habe festgestellt, wenn man auf main eine neue Datenbank anlegt, dann ist bei mail und mailempfaenger das Attribut versand auf "NOT NULL".
Ich habe bestehende Datenbanken, da ist es nicht so. 
Man kann darum jetzt bei neuen H2DB Datenbanken keine Mail mehr speichern die nicht versendet wurde.

Ich habe den Grund gefunden.
In den Update0380 und Update0381 werden die Attribute mit "NOT NULL" erzeugt.
Es wird die Methode alterColumnNotNull benutzt, die hatte früher einen Fehler, dass sie das NOT NULL nicht gesetzt hat. Darum war es nie gesetzt. Nach dem Fix in #538 wird es jetzt richtig gemacht und auf NOT NULL gesetzt.

In Update0447 soll bei den Attributen das "NOT NULL" entfernt werden. Das funktioniert aber bei H2DB nicht so wie der Code implementiert ist. Ich habe das jetzt korrigiert. Damit passt es wenn man eine neue DB erzeugt.

Man braucht aber auch eine Migration für den Fall, dass man schon eine neue DB erzeugt hat. Diese kann ich aber nicht im main machen weil wir im feature branch schon weiter sind. Die Migration geht also nur dort.