### PR TITLE
Geldspendenbescheinigung über Buchungsmenü erzeugen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -55,7 +55,7 @@ public class SpendenbescheinigungAction implements Action
   {
     try
     {
-      if (context != null && context instanceof Spendenbescheinigung)
+      if (context instanceof Spendenbescheinigung)
       {
         spb = (Spendenbescheinigung) context;
       }
@@ -77,7 +77,7 @@ public class SpendenbescheinigungAction implements Action
             handleMitglied(m);
           }
         }
-        else if (context != null && (context instanceof MitgliedskontoNode))
+        else if (context instanceof MitgliedskontoNode)
         {
           MitgliedskontoNode mkn = (MitgliedskontoNode) context;
 
@@ -123,6 +123,27 @@ public class SpendenbescheinigungAction implements Action
               handleMitglied(spb.getMitglied());
             }
           }
+        }
+        else if (context instanceof Buchung)
+        {
+          Buchung b = (Buchung) context;
+          if (b.getSpendenbescheinigung() != null)
+          {
+            throw new ApplicationException(
+                "Die Buchung ist bereits auf einer Spendenbescheinigung eingetragen!");
+          }
+          if (b.getSollbuchung() != null)
+          {
+            // Zahler aus Sollbuchung lesen
+            Mitglied zahler = b.getSollbuchung().getZahler();
+            if (zahler != null)
+            {
+              SpbAdressaufbereitung.adressaufbereitung(zahler, spb);
+            }
+          }
+          spb.setBuchung(b);
+          spb.setSpendedatum(b.getDatum());
+          spb.setAutocreate(Boolean.TRUE);
         }
         else
         {

--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAction.java
@@ -127,6 +127,11 @@ public class SpendenbescheinigungAction implements Action
         else if (context instanceof Buchung)
         {
           Buchung b = (Buchung) context;
+          if (b.getBuchungsart() == null || !b.getBuchungsart().getSpende())
+          {
+            throw new ApplicationException(
+                "Die Buchung hat keine Buchungsart die als Spende deklariert ist!");
+          }
           if (b.getSpendenbescheinigung() != null)
           {
             throw new ApplicationException(

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -474,6 +474,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     {
       Spendenbescheinigung spb = getSpendenbescheinigung();
       Spendenart spa = (Spendenart) getSpendenart().getValue();
+      spb.setMitglied((Mitglied) getMitglied().getValue());
       spb.setSpendenart(spa.getKey());
       spb.setZeile1((String) getZeile1(false).getValue());
       spb.setZeile2((String) getZeile2().getValue());
@@ -1179,6 +1180,10 @@ public class SpendenbescheinigungControl extends DruckMailControl
           zeile5.setValue(spendenbescheinigung.getZeile5());
           zeile6.setValue(spendenbescheinigung.getZeile6());
           zeile7.setValue(spendenbescheinigung.getZeile7());
+        }
+        else
+        {
+          spendenbescheinigung.setMitglied(null);
         }
       }
       catch (Exception e)

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -1183,7 +1183,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
       }
       catch (Exception e)
       {
-        e.printStackTrace();
+        Logger.error("Fehler beim Setzen des Mitglieds:", e);
       }
     }
   }

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -29,11 +29,13 @@ import de.jost_net.JVerein.gui.action.BuchungKontoauszugZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungSollbuchungZuordnungAction;
 import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
+import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
 import de.jost_net.JVerein.gui.action.SplitbuchungBulkAufloesenAction;
 import de.jost_net.JVerein.gui.action.SyntaxExportAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.willuhn.jameica.gui.Action;
@@ -84,6 +86,9 @@ public class BuchungMenu extends ContextMenu
               new MitgliedDetailAction(), "user-friends.png"));
       addItem(new SingleGegenBuchungItem("Neues Anlagenkonto", new AnlagenkontoNeuAction(),
           "document-new.png"));
+      addItem(new SpendenbescheinigungMenuItem("Geldspendenbescheinigung",
+          new SpendenbescheinigungAction(Spendenart.GELDSPENDE),
+          "file-invoice.png"));
     }
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(), "view-refresh.png"));
@@ -322,6 +327,38 @@ public class BuchungMenu extends ContextMenu
         }
       }
       return true;
+    }
+  }
+
+  private static class SpendenbescheinigungMenuItem
+      extends CheckedSingleContextMenuItem
+  {
+    private SpendenbescheinigungMenuItem(String text, Action action,
+        String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      try
+      {
+        if (o instanceof Buchung)
+        {
+          Buchung b = (Buchung) o;
+          if (b.getBuchungsart() != null)
+          {
+            return b.getBuchungsart().getSpende()
+                && b.getSpendenbescheinigung() == null;
+          }
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+      }
+      return false;
     }
   }
 }


### PR DESCRIPTION
Mit diesem Feature kann man eine Geldspendenbescheinigung über das Buchungsmenü erzeugen.
![Bildschirmfoto_20250310_171117](https://github.com/user-attachments/assets/519f3637-640c-4adc-a42f-e18047c47c26)

Der Menüpunkt ist freigeschaltet wenn die Buchungsart vom Typ Spende ist und noch keine Spendenbescheinigung für die Buchung existiert.
Ist die Buchung einer Sollbuchung zugeordnet wird der Spender aus der Sollbuchung übernommen.
Ist die Buchung keiner Sollbuchung zugeordnet, kann man den Spender selbst auswählen oder nur die Adressdaten eingeben so wie bei einer Sachspende wenn sie aus dem Spendenbescheinigung Liste View erzeugt wird. Hier kann man jetzt auch den Spender direkt auswählen.

Damit kann man auch Spendenbescheinigungen erzeugen ohne dass eine Zuordnung der Buchung zu einer Sollbuchung existiert. Man kann die Buchung aber auch später noch einer Sollbuchung zuweisen.
PS: Auch heute gäbe es schon die Möglichkeit einer Buchung mit Spendenbescheinigung die keiner Sollbuchung zugeordnet ist. Man muss einfach nur nach Erstellen der Spendenbescheinigung die Buchung von der Sollbuchung lösen.