### PR TITLE
Fix SollbuchungNeuAction und BuchungSollbuchungZuordnungAction

### DIFF
--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -188,7 +188,7 @@ public class MitgliedMap
     map.put(MitgliedVar.VORNAME.getName(), mitglied.getVorname());
     map.put(MitgliedVar.VORNAMENAME.getName(),
         Adressaufbereitung.getVornameName(mitglied));
-    map.put(MitgliedVar.ZAHLERID.getName(), mitglied.getZahlerID());
+    map.put(MitgliedVar.ZAHLERID.getName(), mitglied.getVollZahlerID());
     map.put(MitgliedVar.ZAHLUNGSRHYTMUS.getName(),
         mitglied.getZahlungsrhythmus() + "");
     map.put(MitgliedVar.ZAHLUNGSRHYTHMUS.getName(),

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -99,15 +99,7 @@ public class BuchungSollbuchungZuordnungAction implements Action
           mk.setBetrag(betrag);
           mk.setDatum(b[0].getDatum());
           mk.setMitglied(m);
-          Long zahlerId = m.getZahlerID();
-          if (zahlerId != null)
-          {
-            mk.setZahlerId(zahlerId);
-          }
-          else
-          {
-            mk.setZahler(m);
-          }
+          mk.setZahlerId(m.getZahlerID());
           mk.setZahlungsweg(Zahlungsweg.ÜBERWEISUNG);
           mk.setZweck1(b[0].getZweck());
           mk.store();

--- a/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedLastschriftAction.java
@@ -51,11 +51,11 @@ public class MitgliedLastschriftAction implements Action
       m = (Mitglied) context;
 
       // pruefe wer der Zahler ist
-      if (m.getZahlungsweg() == Zahlungsweg.VOLLZAHLER && m.getZahlerID() != null)
+      if (m.getZahlungsweg() == Zahlungsweg.VOLLZAHLER && m.getVollZahlerID() != null)
       {
         // Mitglied ist Familienangehoeriger, hat also anderen Zahler
         mZ = (Mitglied) Einstellungen.getDBService().createObject(
-            Mitglied.class, m.getZahlerID() + "");
+            Mitglied.class, m.getVollZahlerID() + "");
 
         if (!AbrechnungSEPAControl.confirmDialog("Familienangehöriger",
             "Dieses Mitglied ist ein Familienangehöriger.\n\n"

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -345,7 +345,7 @@ public class PersonalbogenAction implements Action
           .getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER)
       {
         Mitglied mfa = (Mitglied) Einstellungen.getDBService()
-            .createObject(Mitglied.class, m.getZahlerID() + "");
+            .createObject(Mitglied.class, m.getVollZahlerID() + "");
         rpt.addColumn("Vollzahlendes Familienmitglied", Element.ALIGN_LEFT);
         rpt.addColumn(Adressaufbereitung.getNameVorname(mfa),
             Element.ALIGN_LEFT);

--- a/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
+++ b/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
@@ -300,7 +300,7 @@ public class MitgliedNextBGruppeChecker extends AbstractBox
     //Wenn es bisher ein angehöriger war und jetzt nicht mehr zahlerid entfernen
     if(mitglied.getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER && beitragsGruppe.getBeitragsArt() != ArtBeitragsart.FAMILIE_ANGEHOERIGER)
     {
-      mitglied.setZahlerID(null);
+      mitglied.setVollZahlerID(null);
       //Bei Zahlung über Vollzahler Zahlungsweg umstellen
       if(mitglied.getZahlungsweg() == Zahlungsweg.VOLLZAHLER)
         mitglied.setZahlungsweg(Einstellungen.getEinstellung().getZahlungsweg());

--- a/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
+++ b/src/de/jost_net/JVerein/gui/control/FamilienbeitragNode.java
@@ -78,9 +78,9 @@ public class FamilienbeitragNode implements GenericObjectNode
     while(angIt.hasNext())
     {
       Mitglied a = angIt.next();
-      if(!set.contains(a.getZahlerID().toString()))
+      if(!set.contains(a.getVollZahlerID().toString()))
       {
-        set.add(a.getZahlerID().toString());
+        set.add(a.getVollZahlerID().toString());
       }
     }
     while (it.hasNext())

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1159,7 +1159,7 @@ public class MitgliedControl extends FilterControl
             {
               getZukuenftigeBeitraegeView().setVisible(true);
             }
-            getMitglied().setZahlerID(null);
+            getMitglied().setVollZahlerID(null);
             if (zahler != null)
             {
               zahler.setValue(Einstellungen.getDBService()
@@ -1169,7 +1169,7 @@ public class MitgliedControl extends FilterControl
           }
           else
           {
-            getMitglied().setZahlerID(null);
+            getMitglied().setVollZahlerID(null);
             if (zahler != null)
             {
               zahler.setPreselected(null);
@@ -1355,9 +1355,9 @@ public class MitgliedControl extends FilterControl
     zhl.setOrder("ORDER BY name, vorname");
 
     String suche = "";
-    if (getMitglied().getZahlerID() != null)
+    if (getMitglied().getVollZahlerID() != null)
     {
-      suche = getMitglied().getZahlerID().toString();
+      suche = getMitglied().getVollZahlerID().toString();
     }
     Mitglied zahlmitglied = (Mitglied) Einstellungen.getDBService()
         .createObject(Mitglied.class, suche);
@@ -1380,11 +1380,11 @@ public class MitgliedControl extends FilterControl
           Mitglied m = (Mitglied) zahler.getValue();
           if (m != null && m.getID() != null)
           {
-            getMitglied().setZahlerID(Long.valueOf(m.getID()));
+            getMitglied().setVollZahlerID(Long.valueOf(m.getID()));
           }
           else
           {
-            getMitglied().setZahlerID(null);
+            getMitglied().setVollZahlerID(null);
           }
           refreshFamilienangehoerigeTable();
         }
@@ -1678,8 +1678,8 @@ public class MitgliedControl extends FilterControl
     DBService service = Einstellungen.getDBService();
     DBIterator<Mitglied> famiter = service.createList(Mitglied.class);
     famiter.addFilter("zahlerid = ? or zahlerid = ? or id = ? or id = ?",
-        getMitglied().getID(), getMitglied().getZahlerID(),
-        getMitglied().getID(), getMitglied().getZahlerID());
+        getMitglied().getID(), getMitglied().getVollZahlerID(),
+        getMitglied().getID(), getMitglied().getVollZahlerID());
     famiter.setOrder("ORDER BY name, vorname");
     while (famiter.hasNext())
     {
@@ -2335,7 +2335,7 @@ public class MitgliedControl extends FilterControl
           m.setBeitragsgruppe(Integer.valueOf(bg.getID()));
           if (bg.getBeitragsArt() != ArtBeitragsart.FAMILIE_ANGEHOERIGER)
           {
-            m.setZahlerID(null);
+            m.setVollZahlerID(null);
           }
         }
         catch (NullPointerException e)

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -232,7 +232,7 @@ public class MitgliedskontoControl extends DruckMailControl
     }
     boolean mitVollzahler = false;
     if (getMitglied().getValue() != null
-        && ((Mitglied) getMitglied().getValue()).getZahlerID() != null)
+        && ((Mitglied) getMitglied().getValue()).getVollZahlerID() != null)
       mitVollzahler = true;
     ArrayList<Zahlungsweg> weg = Zahlungsweg.getArray(mitVollzahler);
 
@@ -901,12 +901,12 @@ public class MitgliedskontoControl extends DruckMailControl
         list.remove(new Zahlungsweg(Zahlungsweg.VOLLZAHLER));
         Mitglied m = (Mitglied) getMitglied().getValue();
         Mitglied z = (Mitglied) getZahler().getValue();
-        if (m.getZahlerID() != null)
+        if (m.getVollZahlerID() != null)
         {
           list.add(new Zahlungsweg(Zahlungsweg.VOLLZAHLER));
           if (z == null)
           {
-            getZahler().setValue(m.getZahler());
+            getZahler().setValue(m.getVollZahler());
           }
         }
         else

--- a/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
@@ -103,7 +103,7 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
               .getValue();
           m.setBeitragsgruppe(Integer.valueOf(bg.getID()));
           // m.setKontoinhaber((String) control.getKontoinhaber().getValue());
-          m.setZahlerID(null);
+          m.setVollZahlerID(null);
           m.setLetzteAenderung();
           m.setIban(control.getIban().getValue().toString());
           m.setBic(control.getBic().getValue().toString());

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -154,7 +154,7 @@ public class MitgliedMenu extends ContextMenu
             m.setEintritt("");
             m.setAustritt("");
             m.setKuendigung("");
-            m.setZahlerID(null);
+            m.setVollZahlerID(null);
             DBService service = Einstellungen.getDBService();
             // Sekundäre Beitragsgruppen löschen
             DBIterator<SekundaereBeitragsgruppe> sit = service

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -514,13 +514,13 @@ public class AbrechnungSEPA
     if (m.getZahlungsweg() != null
         && m.getZahlungsweg() == Zahlungsweg.VOLLZAHLER)
     {
-      if (m.getZahlerID() == null)
+      if (m.getVollZahlerID() == null)
       {
         throw new ApplicationException("Kein Vollzahler vorhanden: "
             + Adressaufbereitung.getNameVorname(m));
       }
       mZahler = Einstellungen.getDBService().createObject(Mitglied.class,
-          m.getZahlerID().toString());
+          m.getVollZahlerID().toString());
     }
     if ((Einstellungen.getEinstellung()
         .getBeitragsmodel() == Beitragsmodel.FLEXIBEL)
@@ -653,7 +653,7 @@ public class AbrechnungSEPA
             && m.getZahlungsweg() == Zahlungsweg.VOLLZAHLER)
         {
           mZahler = Einstellungen.getDBService().createObject(Mitglied.class,
-              m.getZahlerID().toString());
+              m.getVollZahlerID().toString());
         }
         Integer zahlungsweg;
         if (z.getZahlungsweg() != null

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -269,7 +269,7 @@ public class MitgliederImport implements Importer
             m.setBeitragsgruppe(Integer.parseInt(bg.getID()));
             if (bg.getBeitragsArt() != ArtBeitragsart.FAMILIE_ANGEHOERIGER)
             {
-              m.setZahlerID(null);
+              m.setVollZahlerID(null);
             }
           }
         }

--- a/src/de/jost_net/JVerein/rmi/Mitglied.java
+++ b/src/de/jost_net/JVerein/rmi/Mitglied.java
@@ -175,11 +175,15 @@ public interface Mitglied extends DBObject, ILastschrift
   public void setIndividuellerBeitrag(Double individuellerbeitrag)
       throws RemoteException;
 
+  public Mitglied getVollZahler() throws RemoteException;
+
+  public Long getVollZahlerID() throws RemoteException;
+
+  public void setVollZahlerID(Long id) throws RemoteException;
+
   public Mitglied getZahler() throws RemoteException;
 
   public Long getZahlerID() throws RemoteException;
-
-  public void setZahlerID(Long id) throws RemoteException;
 
   public Date getAustritt() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -258,12 +258,12 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       }
     }
     // Ist das Mitglied Teil eines Familienverbandes?
-    if (getBeitragsgruppe() != null && getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER && getZahlerID() != null)
+    if (getBeitragsgruppe() != null && getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER && getVollZahlerID() != null)
     {
       // ja, suche Vollzahler. Er darf nicht, bzw nicht früher, ausgetreten sein!
       DBIterator<Mitglied> zahler = Einstellungen.getDBService()
           .createList(Mitglied.class);
-      zahler.addFilter("id = " + getZahlerID());
+      zahler.addFilter("id = " + getVollZahlerID());
       if (getAustritt() != null)
         zahler.addFilter("(austritt is not null and austritt < ?)",
             getAustritt());
@@ -296,7 +296,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
             "Dieses Mitglied ist Vollzahler in einem Familienverband.. Zunächst Beitragsart der Angehörigen ändern!");
       }
     }
-    if (getBeitragsgruppe() != null && getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER && getZahlerID() == null)
+    if (getBeitragsgruppe() != null && getBeitragsgruppe().getBeitragsArt() == ArtBeitragsart.FAMILIE_ANGEHOERIGER && getVollZahlerID() == null)
     {
       throw new ApplicationException("Bitte Vollzahler auswählen!");
     }
@@ -1103,7 +1103,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   }
 
   @Override
-  public Mitglied getZahler() throws RemoteException
+  public Mitglied getVollZahler() throws RemoteException
   {
     Object o = (Object) super.getAttribute("zahlerid");
     if (o == null)
@@ -1117,16 +1117,36 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
   }
 
   @Override
-  public Long getZahlerID() throws RemoteException
+  public Long getVollZahlerID() throws RemoteException
   {
     Long zahlerid = (Long) getAttribute("zahlerid");
     return zahlerid;
   }
 
   @Override
-  public void setZahlerID(Long id) throws RemoteException
+  public void setVollZahlerID(Long id) throws RemoteException
   {
     setAttribute("zahlerid", id);
+  }
+
+  @Override
+  public Mitglied getZahler() throws RemoteException
+  {
+    if (getZahlungsweg() == Zahlungsweg.VOLLZAHLER && getVollZahlerID() != null)
+    {
+      return getVollZahler();
+    }
+    return this;
+  }
+
+  @Override
+  public Long getZahlerID() throws RemoteException
+  {
+    if (getZahlungsweg() == Zahlungsweg.VOLLZAHLER && getVollZahlerID() != null)
+    {
+      return (Long) getAttribute("zahlerid");
+    }
+    return Long.valueOf(getID());
   }
 
   @Override
@@ -1905,7 +1925,7 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
     }
 
     @Override
-    public Long getZahlerID() throws RemoteException
+    public Long getVollZahlerID() throws RemoteException
     {
       return ZAHLERID;
     }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -108,7 +108,7 @@ public class ZusatzbetragImpl extends AbstractDBObject implements Zusatzbetrag
         if (getMitglied().getZahlungsweg() == Zahlungsweg.VOLLZAHLER)
         {
           Mitglied m = Einstellungen.getDBService().createObject(
-              MitgliedImpl.class, getMitglied().getZahlerID().toString());
+              MitgliedImpl.class, getMitglied().getVollZahlerID().toString());
           if (m.getIban().length() == 0
               || m.getMandatDatum().equals(Einstellungen.NODATE))
           {


### PR DESCRIPTION
Bei den oben genannten Actions wurde bei der Sollbuchung als Zahler der Vollzahler gesetzt auch wenn der Zahlungsweg nicht Vollzahler war. Mich hatte da getZahler() verwirrt.

Ich habe jetzt beim Mitglied den getZahler(), setZahler() und setZahlerID() umbenannt in jeweils VollZahler. Dann weiß man, dass man den Vollzahler liest.
Dann habe ich getZahler() und getZahlerID() neu eingeführt. Es liefert den Vollzahler wenn Vollzahler als Zahlungsweg gewählt ist und sonst das Mitglied selbst. Dann muss man den Check auf Zahlungsweg nicht immer selbst implementieren.

Ob das mit der Migration nach 3.1.0 funktioniert muss man sehen. Sonst mache ich das dort halt auch noch.