### PR TITLE
Fix Zahlungswege für Sollbuchungen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SollbuchungNeuAction.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
+import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedskonto;
 import de.willuhn.jameica.gui.Action;
@@ -53,7 +54,7 @@ public class SollbuchungNeuAction implements Action
               "Neues Mitglied bitte erst speichern. Dann können Zusatzbeträge aufgenommen werden.");
         }
         mk.setMitglied(m);
-        mk.setZahlungsweg(m.getZahlungsweg());
+        mk.setZahlungsweg(Zahlungsweg.ÜBERWEISUNG);
         mk.setZahler(m.getZahler());
       }
     }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -230,11 +230,7 @@ public class MitgliedskontoControl extends DruckMailControl
     {
       z = getMitgliedskonto().getZahlungsweg();
     }
-    boolean mitVollzahler = false;
-    if (getMitglied().getValue() != null
-        && ((Mitglied) getMitglied().getValue()).getVollZahlerID() != null)
-      mitVollzahler = true;
-    ArrayList<Zahlungsweg> weg = Zahlungsweg.getArray(mitVollzahler);
+    ArrayList<Zahlungsweg> weg = Zahlungsweg.getArray(false);
 
     zahlungsweg = new SelectInput(weg,
         z == null


### PR DESCRIPTION
Bei SollbuchungDetailView keinen Vollzahler als Zahlungsweg erlauben.
Bei Sollbuchung Neu den Zahlungsweg auf Überweisung initialisieren. Wenn sie manuell erzeugt wurde gab es ja keinen Abrechnungslauf und Lastschrift. Da ist Überweisung wahrscheinlich der beste Defaultwert.