### PR TITLE
Fix RechnungMap und MailVorschau Dialog

### DIFF
--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -132,7 +132,7 @@ public class RechnungMap
     map.put(RechnungVar.ANREDE.getName(), re.getAnrede());
     map.put(RechnungVar.ANREDE_DU.getName(),
         Adressaufbereitung.getAnredeDu(re));
-    map.put(RechnungVar.ANREDE_DU.getName(),
+    map.put(RechnungVar.ANREDE_FOERMLICH.getName(),
         Adressaufbereitung.getAnredeFoermlich(re));
     map.put(RechnungVar.TITEL.getName(), re.getTitel());
     map.put(RechnungVar.NAME.getName(), re.getName());

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorschauDialog.java
@@ -125,7 +125,7 @@ public class MailVorschauDialog extends AbstractDialog<Object>
     container.addLabelPair("Betreff", betreff);
     TextAreaInput body = new TextAreaInput(em.evalText(text));
     body.setEnabled(false);
-    container.addInput(body);
+    container.addLabelPair("Text", body);
 
     if (control instanceof MailControl && ((MailControl) control).getAnhang()
         .getItems().size() > 0)


### PR DESCRIPTION
In der RechnungMap wurde ANREDE_DU doppelt gesetzt statt ANREDE_FOERMLICH.
Beim MailVorschau Dialog fehlte die Beschriftung beim Textfeld.