### PR TITLE
Aus Druck und Mail View Vorlagen erzeugen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
@@ -18,8 +18,8 @@ package de.jost_net.JVerein.gui.action;
 
 import java.util.Map;
 
+import de.jost_net.JVerein.gui.control.IMailControl;
 import de.jost_net.JVerein.gui.dialogs.MailTextVorschauDialog;
-import de.jost_net.JVerein.gui.view.IMailText;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -40,9 +40,9 @@ public class MailTextVorschauAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context instanceof IMailText)
+    if (context instanceof IMailControl)
     {
-      new MailTextVorschauDialog((IMailText) context, map,
+      new MailTextVorschauDialog((IMailControl) context, map,
           MailTextVorschauDialog.POSITION_CENTER, mitMitglied);
     }
     else

--- a/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
@@ -18,8 +18,8 @@ package de.jost_net.JVerein.gui.action;
 
 import java.util.Map;
 
-import de.jost_net.JVerein.gui.control.DruckMailControl;
 import de.jost_net.JVerein.gui.dialogs.MailTextVorschauDialog;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -40,9 +40,9 @@ public class MailTextVorschauAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context instanceof DruckMailControl)
+    if (context instanceof IMailText)
     {
-      new MailTextVorschauDialog((DruckMailControl) context, map,
+      new MailTextVorschauDialog((IMailText) context, map,
           MailTextVorschauDialog.POSITION_CENTER, mitMitglied);
     }
     else

--- a/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
@@ -17,7 +17,7 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.view.IMailText;
+import de.jost_net.JVerein.gui.control.IMailControl;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
@@ -36,15 +36,15 @@ public class MailVorlageUebernehmenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (!(context instanceof IMailText))
+    if (!(context instanceof IMailControl))
     {
       throw new ApplicationException("Keine Mail Information vorhanden!");
     }
 
     try
     {
-      String betreff = ((IMailText) context).getBetreffString();
-      String text = ((IMailText) context).getTxtString();
+      String betreff = ((IMailControl) context).getBetreffString();
+      String text = ((IMailControl) context).getTxtString();
       if (betreff == null || betreff.isEmpty())
       {
         throw new ApplicationException("Bitte Betreff eingeben!");

--- a/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.DruckMailControl;
+import de.jost_net.JVerein.rmi.MailVorlage;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Übernahme einer MailVorlage
+ */
+public class MailVorlageUebernehmenAction implements Action
+{
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (!(context instanceof DruckMailControl))
+    {
+      throw new ApplicationException("Keine Mail Information vorhanden!");
+    }
+    String betreff = ((DruckMailControl) context).getBetreffString();
+    String text = ((DruckMailControl) context).getTxtString();
+    if (betreff == null || betreff.isEmpty())
+    {
+      throw new ApplicationException("Bitte Betreff eingeben!");
+    }
+    try
+    {
+      DBIterator<MailVorlage> vorlagen = Einstellungen.getDBService()
+          .createList(MailVorlage.class);
+      vorlagen.addFilter("betreff = ?", betreff);
+      if (!vorlagen.hasNext())
+      {
+        MailVorlage v = (MailVorlage) Einstellungen.getDBService()
+            .createObject(MailVorlage.class, null);
+        v.setBetreff(betreff);
+        v.setTxt(text);
+        v.store();
+        GUI.getStatusBar().setSuccessText("Mail-Vorlage erzeugt");
+      }
+      else
+      {
+        YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+        d.setTitle("Als Vorlage übernehmen");
+        d.setText(
+            "Es existiert bereits eine Vorlage mit diesem Betreff.\nSoll sie überschrieben werden?");
+
+        Boolean choice = (Boolean) d.open();
+        if (!choice.booleanValue())
+        {
+          return;
+        }
+        MailVorlage v = vorlagen.next();
+        v.setTxt(text);
+        v.store();
+        GUI.getStatusBar().setSuccessText("Mail-Vorlage überschrieben");
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (ApplicationException e)
+    {
+      throw new ApplicationException(e.getMessage());
+    }
+    catch (Exception e)
+    {
+      String fehler = "Fehler beim Erzeugen der Mail-Vorlage";
+      GUI.getStatusBar().setErrorText(fehler);
+      Logger.error(fehler, e);
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailVorlageUebernehmenAction.java
@@ -17,7 +17,7 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.control.DruckMailControl;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.Action;
@@ -36,18 +36,19 @@ public class MailVorlageUebernehmenAction implements Action
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
-    if (!(context instanceof DruckMailControl))
+    if (!(context instanceof IMailText))
     {
       throw new ApplicationException("Keine Mail Information vorhanden!");
     }
-    String betreff = ((DruckMailControl) context).getBetreffString();
-    String text = ((DruckMailControl) context).getTxtString();
-    if (betreff == null || betreff.isEmpty())
-    {
-      throw new ApplicationException("Bitte Betreff eingeben!");
-    }
+
     try
     {
+      String betreff = ((IMailText) context).getBetreffString();
+      String text = ((IMailText) context).getTxtString();
+      if (betreff == null || betreff.isEmpty())
+      {
+        throw new ApplicationException("Bitte Betreff eingeben!");
+      }
       DBIterator<MailVorlage> vorlagen = Einstellungen.getDBService()
           .createList(MailVorlage.class);
       vorlagen.addFilter("betreff = ?", betreff);

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -3,7 +3,6 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.input.FormularInput;
-import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Ausgabesortierung;
@@ -13,7 +12,7 @@ import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 
-public class DruckMailControl extends FilterControl implements IMailText
+public class DruckMailControl extends FilterControl implements IMailControl
 {
   public DruckMailControl(AbstractView view)
   {

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -3,6 +3,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.input.FormularInput;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.keys.Adressblatt;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Ausgabesortierung;
@@ -12,7 +13,7 @@ import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 
-public class DruckMailControl extends FilterControl
+public class DruckMailControl extends FilterControl implements IMailText
 {
   public DruckMailControl(AbstractView view)
   {
@@ -157,6 +158,7 @@ public class DruckMailControl extends FilterControl
     return mailbetreff;
   }
 
+  @Override
   public String getBetreffString()
   {
     return (String) getBetreff().getValue();
@@ -174,6 +176,7 @@ public class DruckMailControl extends FilterControl
     return mailtext;
   }
   
+  @Override
   public String getTxtString()
   {
     return (String) getTxt().getValue();

--- a/src/de/jost_net/JVerein/gui/control/IMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/IMailControl.java
@@ -15,14 +15,14 @@
  * www.jverein.de
  **********************************************************************/
 
-package de.jost_net.JVerein.gui.view;
+package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 
 /**
  * Interface für den zugriff auf Mail Betreff und Text
  */
-public interface IMailText
+public interface IMailControl
 {
 
   /**

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -32,7 +32,6 @@ import de.jost_net.JVerein.gui.menu.MailAuswahlMenu;
 import de.jost_net.JVerein.gui.menu.MailMenu;
 import de.jost_net.JVerein.gui.parts.AutoUpdateTablePart;
 import de.jost_net.JVerein.gui.util.EvalMail;
-import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.io.MailSender;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
@@ -59,7 +58,7 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class MailControl extends FilterControl implements IMailText
+public class MailControl extends FilterControl implements IMailControl
 {
 
   private AutoUpdateTablePart empfaenger;

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -32,6 +32,7 @@ import de.jost_net.JVerein.gui.menu.MailAuswahlMenu;
 import de.jost_net.JVerein.gui.menu.MailMenu;
 import de.jost_net.JVerein.gui.parts.AutoUpdateTablePart;
 import de.jost_net.JVerein.gui.util.EvalMail;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.io.MailSender;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
@@ -58,7 +59,7 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class MailControl extends FilterControl
+public class MailControl extends FilterControl implements IMailText
 {
 
   private AutoUpdateTablePart empfaenger;
@@ -389,11 +390,13 @@ public class MailControl extends FilterControl
     return b;
   }
 
+  @Override
   public String getBetreffString() throws RemoteException
   {
     return (String) getBetreff().getValue();
   }
 
+  @Override
   public String getTxtString() throws RemoteException
   {
     return (String) getTxt().getValue();

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -20,7 +20,6 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.menu.MailVorlageMenu;
-import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -34,7 +33,7 @@ import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class MailVorlageControl extends AbstractControl implements IMailText
+public class MailVorlageControl extends AbstractControl implements IMailControl
 {
 
   private TablePart mailvorlageList;

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.menu.MailVorlageMenu;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -33,7 +34,7 @@ import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class MailVorlageControl extends AbstractControl
+public class MailVorlageControl extends AbstractControl implements IMailText
 {
 
   private TablePart mailvorlageList;
@@ -75,6 +76,7 @@ public class MailVorlageControl extends AbstractControl
     return betreff;
   }
 
+  @Override
   public String getBetreffString()
   {
     return (String) betreff.getValue();
@@ -92,6 +94,7 @@ public class MailVorlageControl extends AbstractControl
     return txt;
   }
 
+  @Override
   public String getTxtString()
   {
     return (String) txt.getValue();

--- a/src/de/jost_net/JVerein/gui/dialogs/MailTextVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailTextVorschauDialog.java
@@ -26,9 +26,9 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.MitgliedMap;
+import de.jost_net.JVerein.gui.control.IMailControl;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.util.EvalMail;
-import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.server.MitgliedImpl;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
@@ -46,7 +46,7 @@ import de.willuhn.logging.Logger;
 public class MailTextVorschauDialog extends AbstractDialog<Object>
 {
 
-  private final IMailText control;
+  private final IMailControl control;
 
   private Map<String, Object> map;
 
@@ -66,7 +66,7 @@ public class MailTextVorschauDialog extends AbstractDialog<Object>
 
   private final de.willuhn.jameica.system.Settings settings;
 
-  public MailTextVorschauDialog(IMailText control,
+  public MailTextVorschauDialog(IMailControl control,
       Map<String, Object> map, int position, boolean mitMitglied)
   {
     super(position);

--- a/src/de/jost_net/JVerein/gui/dialogs/MailTextVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailTextVorschauDialog.java
@@ -20,17 +20,15 @@ package de.jost_net.JVerein.gui.dialogs;
 import java.rmi.RemoteException;
 import java.util.Map;
 
-import de.willuhn.jameica.gui.AbstractControl;
-import de.willuhn.util.ApplicationException;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.MitgliedMap;
-import de.jost_net.JVerein.gui.control.DruckMailControl;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.util.EvalMail;
+import de.jost_net.JVerein.gui.view.IMailText;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.server.MitgliedImpl;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
@@ -48,7 +46,7 @@ import de.willuhn.logging.Logger;
 public class MailTextVorschauDialog extends AbstractDialog<Object>
 {
 
-  private final AbstractControl control;
+  private final IMailText control;
 
   private Map<String, Object> map;
 
@@ -68,7 +66,7 @@ public class MailTextVorschauDialog extends AbstractDialog<Object>
 
   private final de.willuhn.jameica.system.Settings settings;
 
-  public MailTextVorschauDialog(AbstractControl control,
+  public MailTextVorschauDialog(IMailText control,
       Map<String, Object> map, int position, boolean mitMitglied)
   {
     super(position);
@@ -101,15 +99,8 @@ public class MailTextVorschauDialog extends AbstractDialog<Object>
     SimpleContainer container = new SimpleContainer(parent, true, 2);
     em = new EvalMail(map);
 
-    if (control instanceof DruckMailControl)
-    {
-      betreffString = ((DruckMailControl) control).getBetreffString();
-      textString = ((DruckMailControl) control).getTxtString();
-    }
-    else
-    {
-      throw new ApplicationException("Fehler beim Anzeigen der Vorschau");
-    }
+    betreffString = control.getBetreffString();
+    textString = control.getTxtString();
 
     if (mitMitglied)
     {

--- a/src/de/jost_net/JVerein/gui/view/FreiesFormularMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FreiesFormularMailView.java
@@ -8,6 +8,7 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.FreieFormulareControl;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -89,6 +90,9 @@ public class FreiesFormularMailView extends AbstractView
     buttons
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
         control, false, "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     buttons.addButton(
         control.getStartFreieFormulareButton(this.getCurrentObject(), control));
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/IMailText.java
+++ b/src/de/jost_net/JVerein/gui/view/IMailText.java
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.view;
+
+import java.rmi.RemoteException;
+
+/**
+ * Interface für den zugriff auf Mail Betreff und Text
+ */
+public interface IMailText
+{
+
+  /**
+   * @return Betreff der Mail
+   */
+  public String getBetreffString() throws RemoteException;
+
+  /**
+   * @return Text der Mail
+   */
+  public String getTxtString() throws RemoteException;
+}

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.server.MitgliedImpl;
@@ -106,6 +107,9 @@ public class KontoauszugMailView extends AbstractView
     buttons
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
         control, false, "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     buttons.addButton(control.getStartKontoauszugButton(
         this.getCurrentObject(), control));
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -99,6 +100,9 @@ public class MahnungMailView extends AbstractView
     buttons
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
         control, false, "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     /*buttons.addButton(new Button("Export", new MitgliedskontoExportAction(
         EXPORT_TYP.MAHNUNGEN, getCurrentObject()), control, false, "document-save.png"));*/
     buttons.addButton(control.getStartMahnungButton(this.getCurrentObject()));

--- a/src/de/jost_net/JVerein/gui/view/MailDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailDetailView.java
@@ -29,6 +29,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.action.MailVorschauAction;
 import de.jost_net.JVerein.gui.action.OpenInsertVariableDialogAction;
@@ -192,6 +193,9 @@ public class MailDetailView extends AbstractView
     buttons.addButton(
         new Button("Vorschau", new MailVorschauAction(control), m, false,
             "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     buttons.addButton(control.getMailSpeichernButton());
     buttons.addButton(control.getMailReSendButton());
     buttons.addButton(control.getMailSendButton());

--- a/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
-import de.jost_net.JVerein.gui.action.MailVorschauAction;
+import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
 import de.jost_net.JVerein.gui.action.OpenInsertVariableDialogAction;
 import de.jost_net.JVerein.gui.control.MailVorlageControl;
 import de.jost_net.JVerein.server.MitgliedImpl;
@@ -54,8 +54,9 @@ public class MailVorlageDetailView extends AbstractView
         DokumentationUtil.MAILVORLAGE, false, "question-circle.png");
     buttons.addButton("Variablen anzeigen",
         new OpenInsertVariableDialogAction(), map, false, "bookmark.png");
-    buttons.addButton(new Button("Vorschau", new MailVorschauAction(control),
-        MitgliedImpl.getDummy(), false, "edit-copy.png"));
+    buttons
+        .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
+            control, false, "edit-copy.png"));
     buttons.addButton("Speichern", context -> control.handleStore(), null, true,
         "document-save.png");
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/PreNotificationMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/PreNotificationMailView.java
@@ -31,6 +31,7 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.PreNotificationControl;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -94,6 +95,9 @@ public class PreNotificationMailView extends AbstractView
     buttons1
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
         control, false, "edit-copy.png"));
+    buttons1.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     buttons1.addButton(control.getStartButton(this.getCurrentObject()));
     addButtonArea(buttons1, grtabMailPDF.getComposite());
 

--- a/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
 import de.jost_net.JVerein.server.MitgliedImpl;
@@ -97,6 +98,9 @@ public class RechnungMailView extends AbstractView
     buttons.addButton(new Button("Vorschau",
         new MailTextVorschauAction(map, true), control, false,
         "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+        control, false, "document-new.png"));
     buttons.addButton(control.getStartRechnungButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.Variable.SpendenbescheinigungMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
+import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
 import de.jost_net.JVerein.server.MitgliedImpl;
@@ -100,6 +101,9 @@ public class SpendenbescheinigungMailView extends AbstractView
     buttons
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
         control, false, "edit-copy.png"));
+    buttons.addButton(
+        new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
+            control, false, "document-new.png"));
     buttons.addButton(control.getStartButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }


### PR DESCRIPTION
Ich habe die Druck und Mail Views noch um einen Button erweitert um die Texte als Vorlage zu speichern.
![Bildschirmfoto_20250315_165507](https://github.com/user-attachments/assets/aa615f39-25b2-488e-b777-39ac284c34bf)

Existiert bereits eine Vorlage mit dem gleichen Betreff wird der User gefragt ob er sie überschreiben will.
![Bildschirmfoto_20250315_164939](https://github.com/user-attachments/assets/d48f299d-6e13-46a9-a0b8-67f0d0f19ec0)
