### PR TITLE
Fix Fehlermeldung bei neuer Mailvorlage

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -101,8 +101,21 @@ public class MailVorlageControl extends AbstractControl
   {
     try
     {
+      String betreff = (String) getBetreff(false).getValue();
+      if (betreff == null || betreff.isEmpty())
+      {
+        throw new ApplicationException("Bitte Betreff eingeben!");
+      }
       MailVorlage mv = getMailVorlage();
-      mv.setBetreff((String) getBetreff(false).getValue());
+      DBIterator<MailVorlage> vorlagen = Einstellungen.getDBService()
+          .createList(MailVorlage.class);
+      vorlagen.addFilter("betreff = ?", betreff);
+      if (vorlagen.hasNext() && mv.isNewObject())
+      {
+        throw new ApplicationException(
+            "Es existiert bereits eine Vorlage mit diesem Betreff!");
+      }
+      mv.setBetreff(betreff);
       mv.setTxt((String) getTxt().getValue());
       mv.store();
       GUI.getStatusBar().setSuccessText("MailVorlage gespeichert");


### PR DESCRIPTION
Beim Erzeugen einer neuen Mailvorlage mit einem bereits existierenden Betreff kommt es zu einer unleserlichen Fehlermeldung.
![Bildschirmfoto_20250315_165732](https://github.com/user-attachments/assets/f1923af6-e166-464d-85eb-e1e9ef9507f2)

Jetzt wird diese Fehlermeldung ausgegeben.
![Bildschirmfoto_20250315_171927](https://github.com/user-attachments/assets/cb2e3c85-2925-40cf-98a8-e6da065bcbbf)
