### PR TITLE
Fehlerbehandlung und Ausgabe bei Abrechnung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -546,6 +546,10 @@ public class AbrechnungSEPAControl extends AbstractControl
       fd.setFileName(new Dateiname("abbuchungRCUR", "",
           Einstellungen.getEinstellung().getDateinamenmuster(), "PDF").get());
       pdffileRCUR = fd.open();
+      if (pdffileRCUR == null)
+      {
+        return;
+      }
       File file = new File(pdffileRCUR);
       // Wir merken uns noch das Verzeichnis fürs nächste mal
       settings.setAttribute("lastdir.pdf", file.getParent());
@@ -605,7 +609,8 @@ public class AbrechnungSEPAControl extends AbstractControl
               Logger.error("error during operation", e);
               ae = new ApplicationException("Fehler beim Abrechnungslauf", e);
             }
-            GUI.getStatusBar().setErrorText(ae.getMessage());
+            GUI.getStatusBar()
+                .setErrorText(ae.getMessage() + ": " + e.getMessage());
             throw ae;
           }
         }

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2242,8 +2242,11 @@ public class EinstellungControl extends AbstractControl
       e.setSEPADatumOffset((Integer) sepadatumoffset.getValue());
       e.setAbrlAbschliessen((Boolean) abrlabschliessen.getValue());
       e.setBeitragAltersstufen((String)beitragaltersstufen.getValue());
-      e.setVerrechnungskontoId((Long
+      if (verrechnungskonto.getValue() != null)
+      {
+        e.setVerrechnungskontoId((Long
           .parseLong((String) ((Konto) verrechnungskonto.getValue()).getID())));
+      }
       e.store();
       Einstellungen.setEinstellung(e);
 


### PR DESCRIPTION
Beim Abrechnungslauf wurde im Fehlerfall nicht die ganze Fehlermeldung ausgegeben.
Außerdem haben zwei null checks gefehlt.