### PR TITLE
Fix fehlendes Mitglied in Spendenbescheinigung bei alternativem 

### DIFF
--- a/src/de/jost_net/JVerein/util/SpbAdressaufbereitung.java
+++ b/src/de/jost_net/JVerein/util/SpbAdressaufbereitung.java
@@ -29,10 +29,10 @@ public class SpbAdressaufbereitung
   public static void adressaufbereitung(Mitglied m, Spendenbescheinigung spb)
       throws RemoteException
   {
+    spb.setMitglied(m);
     ArrayList<String> adresse = new ArrayList<>();
     if (m.getKtoiName() == null || m.getKtoiName().length() == 0)
     {
-      spb.setMitglied(m);
       adresse.add(m.getAnrede());
       adresse.add(Adressaufbereitung.getVornameName(m));
       if (m.getAdressierungszusatz() != null


### PR DESCRIPTION
Fix fehlendes Mitglied in Spendenbescheinigung bei alternativem  Kontinhaber. Siehe #777

Wie dort erklärt geht die Mail aber trotzdem an das Mitglied.

Weitere Änderungen zu diesem Issue sollten mit eigenem PR gemacht werden, wenn eine Lösung diskutiert wurde.