### PR TITLE
GUI Update für angezeigter Zeitraum

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/VonBisPart.java
@@ -29,7 +29,6 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
-import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.util.ApplicationException;
@@ -56,30 +55,24 @@ public class VonBisPart implements Part
   @Override
   public void paint(Composite parent) throws RemoteException
   {
-    SimpleContainer group = new SimpleContainer(parent, false, 2);
-    
-    LabelGroup zgroup = new LabelGroup(group.getComposite(), "Aktuell angezeigter Zeitraum");
-    ColumnLayout cl1 = new ColumnLayout(zgroup.getComposite(), 2);
-    SimpleContainer left1 = new SimpleContainer(cl1.getComposite());
-    left1.addLabelPair("Von", control.getDatumvon());
     if (!suchen)
     {
-      SimpleContainer right1 = new SimpleContainer(cl1.getComposite());
-      right1.addLabelPair("Bis", control.getDatumbis());
+      LabelGroup group = new LabelGroup(parent, "Aktuell angezeigter Zeitraum");
+      SimpleContainer left = new SimpleContainer(group.getComposite(), true, 4);
+      left.addLabelPair("Von", control.getDatumvon());
+      left.addLabelPair("Bis", control.getDatumbis());
     }
     else
     {
-      left1.addLabelPair("Bis", control.getDatumbis());
-    }
-
-    if (suchen)
-    {
-      LabelGroup sgroup = new LabelGroup(group.getComposite(), "Suchen");
-      ColumnLayout cl2 = new ColumnLayout(sgroup.getComposite(), 2);
-      SimpleContainer left2 = new SimpleContainer(cl2.getComposite());
-      left2.addLabelPair("Von", control.getSuchDatumvon());
-      SimpleContainer right2 = new SimpleContainer(cl2.getComposite());
-      right2.addLabelPair("Bis", control.getSuchDatumbis());
+      LabelGroup group = new LabelGroup(parent,
+          "Aktuell angezeigter Zeitraum und Suchen");
+      SimpleContainer left = new SimpleContainer(group.getComposite());
+      left.addLabelPair("Von", control.getDatumvon());
+      left.addLabelPair("Bis", control.getDatumbis());
+      left.addLabelPair("Geschäftsjahr", control.getGeschaeftsjahr());
+      SimpleContainer right = new SimpleContainer(group.getComposite());
+      right.addLabelPair("Von", control.getSuchDatumvon());
+      right.addLabelPair("Bis", control.getSuchDatumbis());
       ButtonArea buttons = new ButtonArea();
 
       Button zurueck = new Button("", new Action()
@@ -174,7 +167,7 @@ public class VonBisPart implements Part
         }
       }, null, true, "search.png");
       buttons.addButton(suchen);
-      sgroup.addButtonArea(buttons);
+      right.addButtonArea(buttons);
     }
   }
   


### PR DESCRIPTION
Das ist ein kleiner GUI Update. Bei den angezeigter Zeitraum waren die Rahmen nicht ganz aussen wie bei denen weiter unten. Bei dem mit Suchen waren die beiden Rahmen nicht gleich hoch.
Ich fand das optisch nicht sehr ansprechend, auch wenn ich das damals verbrochen hatte.
Die Änderungen sind so:
Ohne Suchen alt:
![Bildschirmfoto_20250318_092135](https://github.com/user-attachments/assets/0b3626b8-529d-4e48-9e98-0e69ecb4f1d8)
Ohne Suchen neu ( der Rahmen ist jetzt so breit wie der darunter):
![Bildschirmfoto_20250318_091829](https://github.com/user-attachments/assets/a1819ea8-3541-4b0d-b638-9ecaa356cd51)
Mit Suchen alt:
![Bildschirmfoto_20250318_092154](https://github.com/user-attachments/assets/86e73cff-6145-42f7-b6d8-b24ba07f4962)
Mit Suchen neu (ein einziger Rahmen sobreit wie der unten, Geschäftsjahr wegen einheitlicher Höhe der Einträge):
![Bildschirmfoto_20250318_091847](https://github.com/user-attachments/assets/4baae21b-e4c9-46d2-94b3-f593db269844)

