### PR TITLE
Fix für Zahler auf Main Branch

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoControl.java
@@ -852,6 +852,14 @@ public class MitgliedskontoControl extends DruckMailControl
     zahler = new MitgliedInput().getMitgliedInput(zahler,
         getMitgliedskonto().getZahler(),
         Einstellungen.getEinstellung().getMitgliedAuswahl());
+    if (zahler instanceof SelectInput)
+    {
+      ((SelectInput) zahler).setPleaseChoose("Bitte auswählen");
+      if (getMitgliedskonto().getZahler() == null)
+      {
+        ((SelectInput) zahler).setPreselected(null);
+      }
+    }
     zahler.setMandatory(true);
     return zahler;
   }


### PR DESCRIPTION
Das ist der Zahler Fix für den Main. Hier war nur das Öffnen einer Sollbuchung ohne Zahler der Fehler.
Das ander war korrekt.