### PR TITLE
Mitglieder Status Spalte

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -1390,7 +1390,21 @@ public class MitgliedImpl extends AbstractDBObject implements Mitglied
       return getAlter();
     }
     else if ("beitragsgruppe".equals(fieldName))
+    {
       return getBeitragsgruppe();
+    }
+    else if ("status".equals(fieldName))
+    {
+      try
+      {
+        plausi();
+        return true;
+      }
+      catch (Exception e)
+      {
+        return false;
+      }
+    }
     return super.getAttribute(fieldName);
   }
 

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -42,6 +42,14 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
   public MitgliedSpaltenauswahl()
   {
     super("mitglied");
+    add("Status", "status", false, new Formatter()
+    {
+      @Override
+      public String format(Object o)
+      {
+        return (Boolean) o ? "\u2705" : "\u2757";
+      }
+    }, Column.ALIGN_LEFT, true);
     add("Mitgliedsnummer", "idint", false, true);
     try
     {


### PR DESCRIPTION
Durch Ändern von Einstellungen kann man Mitglieder Konfigurationen ungültig machen. Ändert man z.B. die Einstellung auf "Geburtsdatum Pflichtfeld" ist es zwar für neue Mitglieder Pflicht aber wenn man schon welche eingegeben hat kann es sein, dass keines gesetzt ist.
Änliches gilt für die Kontodaten, da hatten wir früher keine vollständigen Checks. Es kann z.B. das Mandatsdatum fehlen oder die IBAN ist nicht korrekt.

Ich habe jetzt eine neue Spalte "Status" beim Mitglied eingeführt. Dieser liefert das Ergebnis des plausi Checks. Die Spalte kann über die Einstellungen ausgewählt werden. Schlägt der plausi Check fehl, wird ein Ausrufezeichen angezeigt.
![Bildschirmfoto_20250318_173357](https://github.com/user-attachments/assets/c280913a-c875-49a8-b820-78949f9a8df7)
