### PR TITLE
Zahler bei Sollbuchung Neu Dialog immer überschreiben

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -912,8 +912,7 @@ public class SollbuchungControl extends DruckMailControl
       try
       {
         Mitglied m = (Mitglied) getMitglied().getValue();
-        Mitglied z = (Mitglied) getZahler().getValue();
-        if (m != null && z == null)
+        if (m != null)
         {
           getZahler().setValue(m.getZahler());
         }


### PR DESCRIPTION
Zahler bei Sollbuchung Neu Dialog immer überschreiben