### PR TITLE
Automatische Auflösung der Bibliotheken für Eclipse Nutzer verbessern

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,36 +2,40 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="junit/src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="src" path="/jameica"/>
 	<classpathentry kind="lib" path="lib/nc.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/javax.mail-1.6.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/javax.mail.jar"/>
+	<classpathentry kind="lib" path="lib/bsh-core.jar"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/hibiscus"/>
 	<classpathentry exported="true" kind="lib" path="lib/activation.jar"/>
 	<classpathentry exported="true" kind="lib" path="/hibiscus/lib/obantoo-bin-2.1.12.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/bsh-core-2.0b4.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/csvjdbc-1.0.40.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/csvjdbc.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/itext-hyph-xml.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jollyday-0.5.10.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/joda-time-2.12.7.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/snakeyaml-2.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jollyday.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/joda-time.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/snakeyaml.jar"/>
 	<classpathentry exported="true" kind="lib" path="/jameica/lib/swt/win64/swt.jar" sourcepath="/jameica/lib.src/swt/linux/swt.src.zip"/>
-	<classpathentry exported="true" kind="lib" path="lib/junit-4.13.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/javase-3.5.3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/core-3.1.0.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib.testk/junit.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/javase.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/core.jar"/>
 	<classpathentry exported="true" kind="lib" path="/jameica/lib/de_willuhn_ds/de_willuhn_ds.jar"/>
 	<classpathentry exported="true" kind="lib" path="/hibiscus/lib/super-csv-2.4.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="/hibiscus/lib/itext-pdfa-5.5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="/hibiscus/lib/itextpdf-5.5.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/freemarker-2.3.33.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-core-2.17.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.18.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/vinnie-2.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/ez-vcard-0.12.1.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/freemarker.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jackson-core.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/jsoup.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/vinnie.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/ez-vcard.jar"/>
 	<classpathentry exported="true" kind="lib" path="/hibiscus/lib/pdfbox/pdfbox-3.0.2.jar"/>
-	<classpathentry kind="lib" path="lib/xmpbox-3.0.3.jar"/>
-	<classpathentry kind="lib" path="lib/jakarta.activation-api-2.1.3.jar"/>
-	<classpathentry kind="lib" path="lib/dom4j-2.1.4.jar"/>
-	<classpathentry kind="lib" path="lib/mustang-2.16.0.jar"/>
+	<classpathentry kind="lib" path="lib/xmpbox.jar"/>
+	<classpathentry kind="lib" path="lib/jakarta.activation-api.jar"/>
+	<classpathentry kind="lib" path="lib/dom4j.jar"/>
+	<classpathentry kind="lib" path="lib/library.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -20,7 +20,7 @@
 	<classpathentry exported="true" kind="lib" path="lib/joda-time.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/snakeyaml.jar"/>
 	<classpathentry exported="true" kind="lib" path="/jameica/lib/swt/win64/swt.jar" sourcepath="/jameica/lib.src/swt/linux/swt.src.zip"/>
-	<classpathentry exported="true" kind="lib" path="lib.testk/junit.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib.test/junit.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/javase.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/core.jar"/>
 	<classpathentry exported="true" kind="lib" path="/jameica/lib/de_willuhn_ds/de_willuhn_ds.jar"/>

--- a/build/build.xml
+++ b/build/build.xml
@@ -17,14 +17,14 @@
     <resolver:resolve failonmissingattachments="true">
       <resolver:files dir="lib"
                       scopes="compile,runtime"
-                      layout="{artifactId}-{version}.{extension}" />
+                      layout="{artifactId}.{extension}" />
     </resolver:resolve>
     <!-- Download test dependencies for Eclipse -->
     <mkdir dir="lib.test" />
     <resolver:resolve failonmissingattachments="true">
       <resolver:files dir="lib.test"
                       scopes="test"
-                      layout="{artifactId}-{version}.{extension}" />
+                      layout="{artifactId}.{extension}" />
     </resolver:resolve>
   </target>
 


### PR DESCRIPTION
Direkte Bibliotheksabhängigkeiten werden im lib* Verzeichnis ohne Version gespeichert und ohne Version im classpath referenziert
Damit muss bei einem Update der Versionen keine Anpassung des classpath mehr erfolgen.