### PR TITLE
Buchungen ohne Buchungsart im Saldo anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/AbstractSaldoList.java
+++ b/src/de/jost_net/JVerein/gui/parts/AbstractSaldoList.java
@@ -95,6 +95,7 @@ public class AbstractSaldoList extends TablePart
       return Double.valueOf(rs.getDouble(1));
     }
   };
+
   ResultSetExtractor rsi = new ResultSetExtractor()
   {
     @Override
@@ -209,19 +210,35 @@ public class AbstractSaldoList extends TablePart
         new BuchungsklasseSaldoZeile(BuchungsklasseSaldoZeile.GESAMTSALDOFOOTER,
             "Saldo aller Buchungsklassen ", suEinnahmen, suAusgaben,
             suUmbuchungen));
+
+    // Buchungen ohne Buchungsart
+    String sqlOhneBuchungsart = "SELECT sum(buchung.betrag) FROM buchung, konto "
+        + "WHERE datum >= ? AND datum <= ? AND buchung.konto = konto.id "
+        + "AND konto.kontoart < ? AND buchung.buchungsart is null";
+    Double ohneBuchungsart = (Double) service.execute(sqlOhneBuchungsart,
+        new Object[] { datumvon, datumbis, Kontoart.LIMIT.getKey() }, rsd);
+
+    if (ohneBuchungsart >= 0.01d || ohneBuchungsart <= -0.01d)
+    {
+      zeile.add(new BuchungsklasseSaldoZeile(
+          BuchungsklasseSaldoZeile.GESAMTGEWINNVERLUST,
+          "Saldo Buchungen ohne Buchungsart ", ohneBuchungsart));
+    }
+
     zeile.add(new BuchungsklasseSaldoZeile(
         BuchungsklasseSaldoZeile.GESAMTGEWINNVERLUST, "Gesamtsaldo ",
-        suEinnahmen + suAusgaben + suUmbuchungen));
+        suEinnahmen + suAusgaben + suUmbuchungen + ohneBuchungsart));
 
     // Gesamtübersicht Steuern ausgeben
     getSteuerUebersicht(zeile);
 
-    // Buchungen ohne Buchungsart
-    String sql = "select count(*) from buchung " + "where datum >= ? and datum <= ?  "
-        + "and buchung.buchungsart is null";
+    // Anzahl Buchungen ohne Buchungsart
+    String sql = "SELECT count(*) FROM buchung, konto "
+        + "WHERE datum >= ? AND datum <= ? AND buchung.konto = konto.id "
+        + "AND konto.kontoart < ? AND buchung.buchungsart is null";
 
     Integer anzahl = (Integer) service.execute(sql,
-        new Object[] { datumvon, datumbis }, rsi);
+        new Object[] { datumvon, datumbis, Kontoart.LIMIT.getKey() }, rsi);
     if (anzahl > 0)
     {
       zeile.add(new BuchungsklasseSaldoZeile(

--- a/src/de/jost_net/JVerein/gui/parts/MittelverwendungList.java
+++ b/src/de/jost_net/JVerein/gui/parts/MittelverwendungList.java
@@ -52,6 +52,19 @@ public class MittelverwendungList
     }
   };
 
+  ResultSetExtractor rsi = new ResultSetExtractor()
+  {
+    @Override
+    public Object extract(ResultSet rs) throws SQLException
+    {
+      if (!rs.next())
+      {
+        return Integer.valueOf(0);
+      }
+      return Integer.valueOf(rs.getInt(1));
+    }
+  };
+
   ResultSetExtractor rsmap = new ResultSetExtractor()
   {
     @Override


### PR DESCRIPTION
Nachdem bei einem der letzten PRs die Buchungen ohne Buchungsart in das Kontensaldo aufgenommen wurden, stimmten die Gesamtsalden des Kontosaldo View nicht mehr mit dem im Buchungsklassensaldo View überein.

Ich habe darum folgendes geändert:
* Im Buchungsklassensaldo und Mittelverwendungsaldo View wird das Saldo der Buchungen ohne Buchungsart ausgegeben und im Gesamtsaldo berücksichtigt
* Es wurde ein Fehler bei der Berechnung der Anzahl der Buchungen ohne Buchungsart behoben. In ein Saldo gehen nur die Buchungen unter dem Limit bei Konten ein, also keinen Rücklagen und Vermögen
* Im Mittelverwendungsreport (Zufluss-basiert) habe ich auch Zeilen eingefügt für Anzahl und Beträge von Buchungen ohne Buchungsart. Hier getrennt nach Buchungen im Saldo und Buchungen bei Rücklagen und Vermögen Konten