### PR TITLE
Projekte über Einstellungen freischalten

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1375,7 +1375,10 @@ public class BuchungsControl extends AbstractControl
         buchungsList.addColumn(new Column(Buchung.SOLLBUCHUNG, "Mitglied",
           new SollbuchungFormatter(), false, Column.ALIGN_AUTO,
           Column.SORT_BY_DISPLAY));
-      buchungsList.addColumn("Projekt", "projekt", new ProjektFormatter());
+      if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        buchungsList.addColumn("Projekt", "projekt", new ProjektFormatter());
+      }
       buchungsList.addColumn("Abrechnungslauf", "abrechnungslauf");
       buchungsList.setMulti(true);
       buchungsList.setContextMenu(new BuchungMenu(this));
@@ -1455,7 +1458,11 @@ public class BuchungsControl extends AbstractControl
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
       splitbuchungsList.addColumn("Mitglied", Buchung.SOLLBUCHUNG,
           new SollbuchungFormatter());
-      splitbuchungsList.addColumn("Projekt", "projekt", new ProjektFormatter());
+      if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        splitbuchungsList.addColumn("Projekt", "projekt",
+            new ProjektFormatter());
+      }
       splitbuchungsList.setContextMenu(new SplitBuchungMenu(this));
       splitbuchungsList.setRememberColWidths(true);
       splitbuchungsList.addFeature(new FeatureSummary());

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -347,6 +347,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput mittelverwendung;
 
+  private CheckboxInput projekte;
+
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
    */
@@ -2176,6 +2178,17 @@ public class EinstellungControl extends AbstractControl
     return mittelverwendung;
   }
 
+  public CheckboxInput getProjekte() throws RemoteException
+  {
+    if (projekte != null)
+    {
+      return projekte;
+    }
+    projekte = new CheckboxInput(
+        Einstellungen.getEinstellung().getProjekteAnzeigen());
+    return projekte;
+  }
+
   public void handleStoreAllgemein()
   {
     try
@@ -2267,6 +2280,7 @@ public class EinstellungControl extends AbstractControl
         e.setAfaInJahresabschluss(true);
       e.setMitgliedsnummerAnzeigen((Boolean) nummeranzeigen.getValue());
       e.setMittelverwendung((Boolean) mittelverwendung.getValue());
+      e.setProjekteAnzeigen((Boolean) projekte.getValue());
 
       e.store();
       Einstellungen.setEinstellung(e);

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.menu;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.AnlagenkontoNeuAction;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.BuchungBuchungsartZuordnungAction;
@@ -96,8 +97,18 @@ public class BuchungMenu extends ContextMenu
       addItem(new CheckedContextMenuItem("Sollbuchung zuordnen",
           new BuchungSollbuchungZuordnungAction(), "view-refresh.png"));
     }
-    addItem(new CheckedContextMenuItem("Projekt zuordnen",
-        new BuchungProjektZuordnungAction(), "view-refresh.png"));
+    try
+    {
+      if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        addItem(new CheckedContextMenuItem("Projekt zuordnen",
+            new BuchungProjektZuordnungAction(), "view-refresh.png"));
+      }
+    }
+    catch (RemoteException e)
+    {
+      // Dann nicht anzeigen
+    }
     if (geldkonto)
       addItem(new CheckedContextMenuItem("Kontoauszug zuordnen",
           new BuchungKontoauszugZuordnungAction(), "view-refresh.png"));

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -271,9 +271,12 @@ public class MyExtension implements Extension
       auswertung = new MyItem(auswertung, "Auswertungen", null);
       auswertung.addChild(new MyItem(auswertung, "Mitglieder",
           new StartViewAction(AuswertungMitgliedView.class), "receipt.png"));
-      auswertung.addChild(new MyItem(auswertung, "Nicht-Mitglieder",
-          new StartViewAction(AuswertungNichtMitgliedView.class),
-          "receipt.png"));
+      if (Einstellungen.getEinstellung().getZusatzadressen())
+      {
+        auswertung.addChild(new MyItem(auswertung, "Nicht-Mitglieder",
+            new StartViewAction(AuswertungNichtMitgliedView.class),
+            "receipt.png"));
+      }
       auswertung.addChild(new MyItem(auswertung, "Jubiläen",
           new StartViewAction(JubilaeenView.class), "receipt.png"));
       if (Einstellungen.getEinstellung().getKursteilnehmer())

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -227,8 +227,11 @@ public class MyExtension implements Extension
           new StartViewAction(BuchungsklasseSaldoView.class),
           "emblem-documents.png"));
       // Projekte
-      buchfuehrung.addChild(new MyItem(buchfuehrung, "Projektsaldo",
-          new StartViewAction(ProjektSaldoView.class), "screwdriver.png"));
+      if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        buchfuehrung.addChild(new MyItem(buchfuehrung, "Projektsaldo",
+            new StartViewAction(ProjektSaldoView.class), "screwdriver.png"));
+      }
       // Anlagen
       if (anlagenkonto)
       {
@@ -423,9 +426,12 @@ public class MyExtension implements Extension
       einstellungenbuchfuehrung
           .addChild(new MyItem(einstellungenbuchfuehrung, "Kontenrahmen-Import",
               new KontenrahmenImportAction(), "file-import.png"));
-      einstellungenbuchfuehrung.addChild(new MyItem(einstellungenbuchfuehrung,
-          "Projekte", new StartViewAction(ProjektListeView.class),
-          "screwdriver.png"));
+      if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        einstellungenbuchfuehrung.addChild(new MyItem(einstellungenbuchfuehrung,
+            "Projekte", new StartViewAction(ProjektListeView.class),
+            "screwdriver.png"));
+      }
       administration.addChild(einstellungenbuchfuehrung);
       
       NavigationItem einstellungenerweitert = null;

--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -87,7 +87,10 @@ public class BuchungPart implements Part
     {
       grBuchungsinfos.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
     }
-    grBuchungsinfos.addLabelPair("Projekt", control.getProjekt());
+    if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+    {
+      grBuchungsinfos.addLabelPair("Projekt", control.getProjekt());
+    }
     grBuchungsinfos.addLabelPair("Auszugsnummer", control.getAuszugsnummer());
     grBuchungsinfos.addLabelPair("Blattnummer", control.getBlattnummer());
     grBuchungsinfos.addLabelPair("Sollbuchung", control.getSollbuchung());

--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
@@ -65,7 +65,10 @@ public class AnlagenbuchungListeView extends AbstractView
 
     left.addLabelPair("Konto", control.getSuchKonto());
     left.addLabelPair("Buchungsart", control.getSuchBuchungsart());
-    left.addLabelPair("Projekt", control.getSuchProjekt());
+    if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+    {
+      left.addLabelPair("Projekt", control.getSuchProjekt());
+    }
     left.addLabelPair("Splitbuchung", control.getSuchSplibuchung());
 
     right.addLabelPair("Datum von", control.getVondatum());

--- a/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.TabFolder;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.BuchungImportAction;
 import de.jost_net.JVerein.gui.action.BuchungNeuAction;
 import de.jost_net.JVerein.gui.action.BuchungsuebernahmeAction;
@@ -67,7 +68,10 @@ public class BuchungListeView extends AbstractView
 
     left.addLabelPair("Konto", control.getSuchKonto());
     left.addLabelPair("Buchungsart", control.getSuchBuchungsart());
-    left.addLabelPair("Projekt", control.getSuchProjekt());
+    if (Einstellungen.getEinstellung().getProjekteAnzeigen())
+    {
+      left.addLabelPair("Projekt", control.getSuchProjekt());
+    }
     left.addLabelPair("Splitbuchung", control.getSuchSplibuchung());
 
     center.addLabelPair("Betrag", control.getSuchBetrag());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -69,6 +69,7 @@ public class EinstellungenAnzeigeView extends AbstractView
     left.addLabelPair("Mitgliedsfoto *", control.getMitgliedfoto());
     left.addLabelPair("Mittelverwendung anzeigen" + "*",
         control.getMittelverwendung());
+    left.addLabelPair("Projekte anzeigen" + "*", control.getProjekte());
 
     SimpleContainer right = new SimpleContainer(cols1.getComposite());
     right.addLabelPair("Lesefelder anzeigen *", control.getUseLesefelder());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -50,26 +50,26 @@ public class EinstellungenAnzeigeView extends AbstractView
     left.addLabelPair("Sterbedatum", control.getSterbedatum());
     left.addLabelPair("Kommunikationsdaten anzeigen",
         control.getKommunikationsdaten());
-    left.addLabelPair("Sekundäre Beitragsgruppen anzeigen" + "*",
+    left.addLabelPair("Sekundäre Beitragsgruppen anzeigen *",
         control.getSekundaereBeitragsgruppen());
-    left.addLabelPair("Zusatzbeträge anzeigen" + "*",
+    left.addLabelPair("Zusatzbeträge anzeigen *",
         control.getZusatzbetrag());
     left.addLabelPair("Zusatzbeträge auch für Ausgetretene *",
         control.getZusatzbetragAusgetretene());
     left.addLabelPair("Vermerke anzeigen", control.getVermerke());
-    left.addLabelPair("Wiedervorlage anzeigen" + "*",
+    left.addLabelPair("Wiedervorlage anzeigen *",
         control.getWiedervorlage());
-    left.addLabelPair("Kursteilnehmer anzeigen" + "*",
+    left.addLabelPair("Kursteilnehmer anzeigen *",
         control.getKursteilnehmer());
     left.addLabelPair("Kursteilnehmer Geburtsdatum und Geschlecht Pflichtfeld",
         control.getKursteilnehmerGebGesPflicht());
-    left.addLabelPair("Lehrgänge anzeigen" + "*", control.getLehrgaenge());
+    left.addLabelPair("Lehrgänge anzeigen *", control.getLehrgaenge());
     left.addLabelPair("Juristische Personen erlaubt",
         control.getJuristischePersonen());
     left.addLabelPair("Mitgliedsfoto *", control.getMitgliedfoto());
-    left.addLabelPair("Mittelverwendung anzeigen" + "*",
+    left.addLabelPair("Mittelverwendung anzeigen *",
         control.getMittelverwendung());
-    left.addLabelPair("Projekte anzeigen" + "*", control.getProjekte());
+    left.addLabelPair("Projekte anzeigen *", control.getProjekte());
 
     SimpleContainer right = new SimpleContainer(cols1.getComposite());
     right.addLabelPair("Lesefelder anzeigen *", control.getUseLesefelder());

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -646,4 +646,9 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public void setMitgliedsnummerAnzeigen(boolean nummeranzeigen)
       throws RemoteException;
+
+  public boolean getProjekteAnzeigen() throws RemoteException;
+
+  public void setProjekteAnzeigen(boolean projekteanzeigen)
+      throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0471.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0471.java
@@ -15,6 +15,7 @@ package de.jost_net.JVerein.server.DDLTool.Updates;
 
 import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
 import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
@@ -22,6 +23,8 @@ import java.sql.Connection;
 
 public class Update0471 extends AbstractDDLUpdate
 {
+  protected DBService service;
+
   public Update0471(String driver, ProgressMonitor monitor, Connection conn)
   {
     super(driver, monitor, conn);
@@ -31,6 +34,10 @@ public class Update0471 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     execute(addColumn("einstellung",
-        new Column("projekteanzeigen", COLTYPE.BOOLEAN, 0, "1", false, false)));
+        new Column("projekteanzeigen", COLTYPE.BOOLEAN, 0, "0", false, false)));
+    
+    execute("UPDATE einstellung SET projekteanzeigen = CASE "
+        + "WHEN EXISTS (SELECT 1 FROM projekt) THEN 1 ELSE 0 "
+        + "END;");
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0471.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0471.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0471 extends AbstractDDLUpdate
+{
+  public Update0471(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung",
+        new Column("projekteanzeigen", COLTYPE.BOOLEAN, 0, "1", false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2253,4 +2253,17 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
   {
     setAttribute("nummeranzeigen", nummeranzeigen);
   }
+
+  @Override
+  public boolean getProjekteAnzeigen() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("projekteanzeigen"));
+  }
+
+  @Override
+  public void setProjekteAnzeigen(boolean projekteanzeigen)
+      throws RemoteException
+  {
+    setAttribute("projekteanzeigen", projekteanzeigen);
+  }
 }


### PR DESCRIPTION
Nachdem wir immer über zu viele Einträge im Navigation Menü klagen, habe ich jetzt in den Einstellungen die Möglichkeit geschaffen die Anzeige von Projekten zu konfigurieren.

Da Projekte schon genutzt werden sind sie default mäßig eingeschaltet. Wer sie aber nicht verwendet kann sie jetzt entfernen.