### PR TITLE
Zahler aus Sollbuchung Neu Dialog entfernt

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -844,7 +844,6 @@ public class SollbuchungControl extends DruckMailControl
     {
       mitglied = new MitgliedInput().getMitgliedInput(mitglied, null,
           Einstellungen.getEinstellung().getMitgliedAuswahl());
-      mitglied.addListener(new MitgliedListener());
       if (mitglied instanceof SelectInput)
       {
         ((SelectInput) mitglied).setPleaseChoose("Bitte auswählen");
@@ -896,31 +895,6 @@ public class SollbuchungControl extends DruckMailControl
       final String meldung = "Gewählter Zahler kann nicht ermittelt werden";
       Logger.error(meldung, ex);
       throw new ApplicationException(meldung, ex);
-    }
-  }
-
-  public class MitgliedListener implements Listener
-  {
-
-    MitgliedListener()
-    {
-    }
-
-    @Override
-    public void handleEvent(Event event)
-    {
-      try
-      {
-        Mitglied m = (Mitglied) getMitglied().getValue();
-        if (m != null)
-        {
-          getZahler().setValue(m.getZahler());
-        }
-      }
-      catch (RemoteException e)
-      {
-        e.printStackTrace();
-      }
     }
   }
 

--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
@@ -78,7 +78,6 @@ public class SollbuchungNeuDialog extends AbstractDialog<Boolean>
     SimpleContainer left = new SimpleContainer(cols.getComposite());
     left.addHeadline("Sollbuchung");
     left.addLabelPair("Mitglied", sollbControl.getMitglied());
-    left.addLabelPair("Zahler", sollbControl.getZahler());
     DateInput datumInput = sollbControl.getDatum();
     datumInput.addListener(event -> {
       if (event.type != SWT.Selection && event.type != SWT.FocusOut)
@@ -208,15 +207,6 @@ public class SollbuchungNeuDialog extends AbstractDialog<Boolean>
               ((MitgliedSearchInput) mitgliedInput)
                   .setValue("Zum Suchen tippen");
             }
-            Input zahlerInput = sollbControl.getZahler();
-            if (zahlerInput instanceof SelectInput)
-            {
-              ((SelectInput) zahlerInput).setPreselected(null);
-            }
-            else if (zahlerInput instanceof MitgliedSearchInput)
-            {
-              ((MitgliedSearchInput) zahlerInput).setValue("Zum Suchen tippen");
-            }
           }
           catch (Exception e)
           {
@@ -269,6 +259,7 @@ public class SollbuchungNeuDialog extends AbstractDialog<Boolean>
         sollbPosControl.getZweck()
             .setValue(sollbControl.getZweck1().getValue());
       }
+      sollbControl.getZahler().setValue(sollbControl.getMitglied().getValue());
       if (!sollbControl.handleStore())
       {
         DBTransaction.rollback();


### PR DESCRIPTION
Nach den Diskussionen in #777 und #783 habe ich jetzt den Zahler aus dem Sollbuchung Neu Dialog entfernt.
Beim Speichern wird das Mitglied selbst als Zahler gesetzt.