### PR TITLE
Rechnungen/Mahnungen über Einstellungen aktivieren

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -351,6 +351,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput spendenbescheinigungen;
 
+  private CheckboxInput rechnungen;
+
   /**
    * Verschlüsselte Datei für besonders sensible Daten (Passwörter)
    */
@@ -2202,6 +2204,17 @@ public class EinstellungControl extends AbstractControl
     return spendenbescheinigungen;
   }
 
+  public CheckboxInput getRechnungen() throws RemoteException
+  {
+    if (rechnungen != null)
+    {
+      return rechnungen;
+    }
+    rechnungen = new CheckboxInput(
+        Einstellungen.getEinstellung().getRechnungenAnzeigen());
+    return rechnungen;
+  }
+
   public void handleStoreAllgemein()
   {
     try
@@ -2296,6 +2309,7 @@ public class EinstellungControl extends AbstractControl
       e.setProjekteAnzeigen((Boolean) projekte.getValue());
       e.setSpendenbescheinigungenAnzeigen(
           (Boolean) spendenbescheinigungen.getValue());
+      e.setRechnungenAnzeigen((Boolean) rechnungen.getValue());
 
       e.store();
       Einstellungen.setEinstellung(e);

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -119,6 +119,17 @@ public class FormularControl extends FormularPartControl
         list.remove(FormularArt.SAMMELSPENDENBESCHEINIGUNG);
       }
     }
+    if (!Einstellungen.getEinstellung().getRechnungenAnzeigen())
+    {
+      if (aktuelleFormularArt != FormularArt.RECHNUNG)
+      {
+        list.remove(FormularArt.RECHNUNG);
+      }
+      if (aktuelleFormularArt != FormularArt.MAHNUNG)
+      {
+        list.remove(FormularArt.MAHNUNG);
+      }
+    }
     art = new SelectInput(list, aktuelleFormularArt);
     return art;
   }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -470,7 +470,10 @@ public class SollbuchungControl extends DruckMailControl
       });
       sollbuchungenList.addColumn("Zahlungseingang", Sollbuchung.ISTSUMME,
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-      sollbuchungenList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        sollbuchungenList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
+      }
       sollbuchungenList.setContextMenu(menu);
       sollbuchungenList.setRememberColWidths(true);
       sollbuchungenList.setRememberOrder(true);

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedskontoMenu.java
@@ -54,12 +54,22 @@ public class MitgliedskontoMenu extends ContextMenu
         "text-x-generic.png"));
     addItem(new SollOhneIstItem("Sollbuchung löschen",
         new SollbuchungLoeschenAction(), "user-trash-full.png"));
-    addItem(new MitRechnungItem("Rechnung anzeigen",
-        new SollbuchungRechnungAction(), "file-invoice.png"));
-    addItem(new OhneRechnungItem("Rechnung(en) erstellen",
-        new RechnungNeuAction(), "file-invoice.png"));
-    addItem(new MultiItem("Gesamtrechnung erstellen",
-        new GesamtrechnungNeuAction(), "file-invoice.png"));
+    try
+    {
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        addItem(new MitRechnungItem("Rechnung anzeigen",
+            new SollbuchungRechnungAction(), "file-invoice.png"));
+        addItem(new OhneRechnungItem("Rechnung(en) erstellen",
+            new RechnungNeuAction(), "file-invoice.png"));
+        addItem(new MultiItem("Gesamtrechnung erstellen",
+            new GesamtrechnungNeuAction(), "file-invoice.png"));
+      }
+    }
+    catch (RemoteException e)
+    {
+      // Dann nicht anzeigen
+    }
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SollMitIstItem("Istbuchung bearbeiten",
         new IstbuchungEditAction(), "text-x-generic.png"));

--- a/src/de/jost_net/JVerein/gui/menu/SollbuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/SollbuchungMenu.java
@@ -54,12 +54,22 @@ public class SollbuchungMenu extends ContextMenu
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedSingleContextMenuItem("Mitglied anzeigen",
         new MitgliedDetailAction(), "user-friends.png"));
-    addItem(new MitRechnungItem("Rechnung anzeigen",
-        new SollbuchungRechnungAction(), "file-invoice.png"));
-    addItem(new OhneRechnungItem("Rechnung(en) erstellen",
-        new RechnungNeuAction(), "file-invoice.png"));
-    addItem(new MultiItem("Gesamtrechnung erstellen",
-        new GesamtrechnungNeuAction(), "file-invoice.png"));
+    try
+    {
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        addItem(new MitRechnungItem("Rechnung anzeigen",
+            new SollbuchungRechnungAction(), "file-invoice.png"));
+        addItem(new OhneRechnungItem("Rechnung(en) erstellen",
+            new RechnungNeuAction(), "file-invoice.png"));
+        addItem(new MultiItem("Gesamtrechnung erstellen",
+            new GesamtrechnungNeuAction(), "file-invoice.png"));
+      }
+    }
+    catch (RemoteException e)
+    {
+      // Dann nicht anzeigen
+    }
   }
 
   private static class SollOhneIstItem extends CheckedContextMenuItem

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -173,8 +173,11 @@ public class MyExtension implements Extension
       
       mitglieder.addChild(new MyItem(mitglieder, "Sollbuchungen",
           new StartViewAction(SollbuchungListeView.class), "calculator.png"));
-      mitglieder.addChild(new MyItem(mitglieder, "Rechnungen",
-          new StartViewAction(RechnungListeView.class), "file-invoice.png"));
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        mitglieder.addChild(new MyItem(mitglieder, "Rechnungen",
+            new StartViewAction(RechnungListeView.class), "file-invoice.png"));
+      }
       if (Einstellungen.getEinstellung().getSpendenbescheinigungenAnzeigen())
       {
         mitglieder.addChild(new MyItem(mitglieder, "Spendenbescheinigungen",
@@ -303,10 +306,13 @@ public class MyExtension implements Extension
 
       NavigationItem mail = null;
       mail = new MyItem(mail, "Druck & Mail", null);
-      mail.addChild(new MyItem(mail, "Rechnungen",
-          new StartViewAction(RechnungMailView.class), "document-print.png"));
-      mail.addChild(new MyItem(mail, "Mahnungen",
-          new StartViewAction(MahnungMailView.class), "document-print.png"));
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        mail.addChild(new MyItem(mail, "Rechnungen",
+            new StartViewAction(RechnungMailView.class), "document-print.png"));
+        mail.addChild(new MyItem(mail, "Mahnungen",
+            new StartViewAction(MahnungMailView.class), "document-print.png"));
+      }
       mail.addChild(new MyItem(mail, "Kontoauszüge",
           new StartViewAction(KontoauszugMailView.class),
           "document-print.png"));
@@ -373,10 +379,13 @@ public class MyExtension implements Extension
           administrationEinstellungen, "Buchführung",
           new StartViewAction(EinstellungenBuchfuehrungView.class),
           "wrench.png"));
-      administrationEinstellungen
-          .addChild(new MyItem(administrationEinstellungen, "Rechnungen",
-              new StartViewAction(EinstellungenRechnungenView.class),
-              "wrench.png"));
+      if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+      {
+        administrationEinstellungen
+            .addChild(new MyItem(administrationEinstellungen, "Rechnungen",
+                new StartViewAction(EinstellungenRechnungenView.class),
+                "wrench.png"));
+      }
       administrationEinstellungen
           .addChild(new MyItem(administrationEinstellungen, "Mail",
               new StartViewAction(EinstellungenMailView.class), "wrench.png"));

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -74,11 +74,14 @@ public class AbrechnungSEPAView extends AbstractView
     rigth.addLabelPair("Lastschrift-PDF erstellen", control.getSEPAPrint());
     rigth.addLabelPair("Abbuchungsausgabe", control.getAbbuchungsausgabe());
     
-    rigth.addHeadline("Rechnungen");
-    rigth.addLabelPair("Rechnung(en) erstellen²", control.getRechnung());
-    rigth.addLabelPair("Rechnung Formular", control.getRechnungFormular());
-    rigth.addLabelPair("Rechnung Text", control.getRechnungstext());
-    rigth.addLabelPair("Rechnung Datum", control.getRechnungsdatum());
+    if (Einstellungen.getEinstellung().getRechnungenAnzeigen())
+    {
+      rigth.addHeadline("Rechnungen");
+      rigth.addLabelPair("Rechnung(en) erstellen²", control.getRechnung());
+      rigth.addLabelPair("Rechnung Formular", control.getRechnungFormular());
+      rigth.addLabelPair("Rechnung Text", control.getRechnungstext());
+      rigth.addLabelPair("Rechnung Datum", control.getRechnungsdatum());
+    }
 
     group.addSeparator();
     group.addText(

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -71,6 +71,8 @@ public class EinstellungenAnzeigeView extends AbstractView
     left.addLabelPair("Projekte anzeigen *", control.getProjekte());
     left.addLabelPair("Spendenbescheinigungen anzeigen *",
         control.getSpendenbescheinigungen());
+    left.addLabelPair("Rechnungen/Mahnungen anzeigen *",
+        control.getRechnungen());
 
     SimpleContainer right = new SimpleContainer(cols1.getComposite());
     right.addLabelPair("Lesefelder anzeigen *", control.getUseLesefelder());

--- a/src/de/jost_net/JVerein/rmi/Einstellung.java
+++ b/src/de/jost_net/JVerein/rmi/Einstellung.java
@@ -656,4 +656,9 @@ public interface Einstellung extends DBObject, IBankverbindung
 
   public void setSpendenbescheinigungenAnzeigen(
       boolean spendenbescheinigungenanzeigen) throws RemoteException;
+
+  public boolean getRechnungenAnzeigen() throws RemoteException;
+
+  public void setRechnungenAnzeigen(boolean rechnungenanzeigen)
+      throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0473.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0473.java
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0473 extends AbstractDDLUpdate
+{
+  protected DBService service;
+
+  public Update0473(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("einstellung",
+        new Column("rechnungenanzeigen", COLTYPE.BOOLEAN, 0, "0",
+            false, false)));
+    
+    execute("UPDATE einstellung SET rechnungenanzeigen = CASE "
+        + "WHEN EXISTS (SELECT 1 FROM rechnung) THEN 1 ELSE 0 "
+        + "END;");
+  }
+}

--- a/src/de/jost_net/JVerein/server/EinstellungImpl.java
+++ b/src/de/jost_net/JVerein/server/EinstellungImpl.java
@@ -2280,4 +2280,17 @@ public class EinstellungImpl extends AbstractDBObject implements Einstellung
     setAttribute("spendenbescheinigungenanzeigen",
         spendenbescheinigungenanzeigen);
   }
+
+  @Override
+  public boolean getRechnungenAnzeigen() throws RemoteException
+  {
+    return Util.getBoolean(getAttribute("rechnungenanzeigen"));
+  }
+
+  @Override
+  public void setRechnungenAnzeigen(boolean rechnungenanzeigen)
+      throws RemoteException
+  {
+    setAttribute("rechnungenanzeigen", rechnungenanzeigen);
+  }
 }


### PR DESCRIPTION
Rechnungen/Mahnungen über Einstellungen aktivieren.

Die Konfiguration kontrolliert Rechnungen und Mahnungen gleichzeitig. Eine Mahnung ohne Rechnung geht ja auch nicht. Rechnung ohne Mahnung würde gehen, ich weiß aber nicht ob das sinnvoll wäre seperat zu konfigurieren. Wenn ja könnte man das mit einem eigen PR nachholen.
Ich habe darum das Attribut auch nur "rechnungenanzeigen" genannt für die Option später evtl. ein "mahnungenanzeigen" zu erstellen.