### PR TITLE
Bei Bulk Splittbuchung Handling von Zweck und Kommentar ändern

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SplitbuchungNeuAction.java
@@ -50,6 +50,7 @@ public class SplitbuchungNeuAction implements Action
       buch.setZweck(master.getZweck());
       buch.setBuchungsartId(master.getBuchungsartId());
       buch.setBuchungsklasseId(master.getBuchungsklasseId());
+      buch.setIban(master.getIban());
       buch.setSpeicherung(false);
       buch.setSplitTyp(SplitbuchungTyp.SPLIT);
       buch.setBetrag(SplitbuchungsContainer.getSumme(SplitbuchungTyp.HAUPT).doubleValue() - SplitbuchungsContainer.getSumme(SplitbuchungTyp.SPLIT).doubleValue());

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -62,7 +62,9 @@ public class SplitbuchungsContainer
     else
     {
       buchungen = bl;
-      text = String.format("Es werden %s Splitbuchungen erzeugt.", anzahl);
+      text = String.format(
+          "Es werden %s Splitbuchungen erzeugt.\nGeänderte Zwecke oder Kommentare in Splitpositionen werden bei allen Buchungen übernommen.",
+          anzahl);
     }
     initiate(bl[0]);
   }

--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -258,6 +258,30 @@ public class SplitbuchungsContainer
       Buchung master = null;
       Buchung gegen = null;
       Buchung split = null;
+      HashMap<Buchung, Boolean> zweckeVonHauptbuchung = new HashMap<>();
+      HashMap<Buchung, Boolean> kommentareVonHauptbuchung = new HashMap<>();
+      Boolean zweckVonHauptbuchung = false;
+      Boolean kommentarVonHauptbuchung = false;
+      for (Buchung b : get())
+      {
+        zweckVonHauptbuchung = false;
+        kommentarVonHauptbuchung = false;
+        if (!b.isToDelete() && (b.getSplitTyp() == SplitbuchungTyp.SPLIT))
+        {
+          if (buchungen[0].getZweck() != null
+              && buchungen[0].getZweck().equals(b.getZweck()))
+          {
+            zweckVonHauptbuchung = true;
+          }
+          zweckeVonHauptbuchung.put(b, zweckVonHauptbuchung);
+          if (buchungen[0].getKommentar() != null
+              && buchungen[0].getKommentar().equals(b.getKommentar()))
+          {
+            kommentarVonHauptbuchung = true;
+          }
+          kommentareVonHauptbuchung.put(b, kommentarVonHauptbuchung);
+        }
+      }
       for (int i = 1; i < anzahl; i++)
       {
         master = buchungen[i];
@@ -270,7 +294,8 @@ public class SplitbuchungsContainer
         {
           if (!b.isToDelete() && (b.getSplitTyp() == SplitbuchungTyp.SPLIT))
           {
-            split = getSplitbuchung(master, b);
+            split = getSplitbuchung(master, b, zweckeVonHauptbuchung,
+                kommentareVonHauptbuchung);
             split.store();
           }
         }
@@ -309,11 +334,14 @@ public class SplitbuchungsContainer
     buch.setSplitId(Long.valueOf(b.getID()));
     buch.setUmsatzid(b.getUmsatzid());
     buch.setZweck(b.getZweck());
+    buch.setIban(b.getIban());
     buch.setSplitTyp(SplitbuchungTyp.GEGEN);
     return buch;
   }
 
-  private static Buchung getSplitbuchung(Buchung master, Buchung origin)
+  private static Buchung getSplitbuchung(Buchung master, Buchung origin,
+      HashMap<Buchung, Boolean> zweckeVonHauptbuchung,
+      HashMap<Buchung, Boolean> kommentareVonHauptbuchung)
       throws RemoteException
   {
     Buchung buch = (Buchung) Einstellungen.getDBService()
@@ -324,14 +352,29 @@ public class SplitbuchungsContainer
     buch.setBuchungsartId(origin.getBuchungsartId());
     buch.setBuchungsklasseId(origin.getBuchungsklasseId());
     buch.setDatum(master.getDatum());
-    buch.setKommentar(origin.getKommentar());
+    if (kommentareVonHauptbuchung.get(origin) == true)
+    {
+      buch.setKommentar(master.getKommentar());
+    }
+    else
+    {
+      buch.setKommentar(origin.getKommentar());
+    }
     buch.setKonto(master.getKonto());
     buch.setSollbuchungID(master.getSollbuchungID());
     buch.setName(master.getName());
     buch.setProjekt(master.getProjekt());
     buch.setSplitId(Long.valueOf(master.getID()));
     buch.setUmsatzid(master.getUmsatzid());
-    buch.setZweck(origin.getZweck());
+    if (zweckeVonHauptbuchung.get(origin) == true)
+    {
+      buch.setZweck(master.getZweck());
+    }
+    else
+    {
+      buch.setZweck(origin.getZweck());
+    }
+    buch.setIban(master.getIban());
     buch.setDependencyId(origin.getDependencyId());
     buch.setSplitTyp(SplitbuchungTyp.SPLIT);
     return buch;


### PR DESCRIPTION
Entsprechend der Diskussion in #817 habe ich meinen Vorschlag implementiert.
Werden in den Spliteinträgen der Zweck oder Kommentar nicht geändert werden sie jeweils von der Hauptbuchung übernommen. Wird ein Eintrag geändert, dann wird der geänderte Text bei allen Buchungen für diesen Spliteintrag auf diesen Text geändert.

Ich habe jetzt keine Schalter eingeführt aber den Info Text erweitert mit der Info, dass geänderte Zwecke oder Kommentare bei allen Buchungen übernommen werden.

PS: Ich habe auch noch die Iban in die Gegenbuchung und Splitpositionen kopiert.
