### PR TITLE
Fix SKR 42 Support bei Buchungsreports

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1491,11 +1491,6 @@ public class BuchungsControl extends AbstractControl
           buchungsarten.add(list.next());
         }
       }
-      Buchungsart ohnezuordnung = (Buchungsart) Einstellungen.getDBService()
-          .createObject(Buchungsart.class, null);
-      ohnezuordnung.setBezeichnung("Ohne Zuordnung");
-      ohnezuordnung.setArt(-1);
-      buchungsarten.add(ohnezuordnung);
 
       FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
       fd.setText("Ausgabedatei wählen.");


### PR DESCRIPTION
Der PR addressiert einen Teil der Doskussion im Forum: https://jverein-forum.de/viewtopic.php?t=7443

Im Zuge der Einführung des Support für SKR 42 wurde übersehen, die PDF Reports im Buchung Liste View entsprechend anzupassen. Ich habe hier erst einmal den "PDF Einzelbuchungen" und "PDF Summen" angepasst.
Die Änderungen sind:
* Die Ausgabe von Buchungsart und Buchungsklasse benutzt den Formatter, so dass das eingestellte Format benutzt wird z.B. mit der Nummer am Anfang
* Im "PDF Summen" Report habe ich die Spalte Buchungsklasse eingefügt. Nur damit sind die Einträge eindeutig
* Es werden auch die Buchungen mit Buchungsart aber ohne Buchungsklasse separat aufgelistet
* Zuletzt wird auch die Summe der Buchungen ohne Buchungsart aufgelistet
* Im "PDF Einzelbuchungen" wird bei den Überschriften neben der Buchungsart auch die Buchungsklasse gelistet

Ich habe das jetzt für den Main Branch gemacht weil es ein Fix für den Support des SKR 42 ist. Ohne dem Fix sind die Reports so nicht brauchbar.

Das Buchungsjournal werde ich auch noch mit einem eigenen PR anpassen. Ich weiß nur noch nicht genau wie ich die Buchungsklasse wegen des begrenzten Raumes reinbekomme.