### PR TITLE
Typos korrigiert

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -62,9 +62,9 @@ public class BuchungMenu extends ContextMenu
     boolean geldkonto = control.getGeldkonto();
     addItem(new CheckedSingleContextMenuItem("Bearbeiten",
         new BuchungAction(false), "text-x-generic.png"));
-    addItem(new GeprueftBuchungItem("als \"geprüft\" markieren",
+    addItem(new GeprueftBuchungItem("Als \"geprüft\" markieren",
         new BuchungGeprueftAction(true), "emblem-default.png", false));
-    addItem(new GeprueftBuchungItem("als \"ungeprüft\" markieren",
+    addItem(new GeprueftBuchungItem("Als \"ungeprüft\" markieren",
         new BuchungGeprueftAction(false), "edit-undo.png", true));
     addItem(new SingleBuchungItem("Duplizieren", new BuchungDuplizierenAction(),
         "edit-copy.png"));

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -254,7 +254,7 @@ public class MyExtension implements Extension
         buchfuehrung.addChild(new MyItem(buchfuehrung, "Mittelverwendung",
             new StartViewAction(MittelverwendungReportView.class),
             "gnome-session-switch.png"));
-        buchfuehrung.addChild(new MyItem(buchfuehrung, "Mittelverwendungsaldo",
+        buchfuehrung.addChild(new MyItem(buchfuehrung, "Mittelverwendungssaldo",
             new StartViewAction(MittelverwendungSaldoView.class),
             "gnome-session-switch.png"));
       }

--- a/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
@@ -30,7 +30,7 @@ public class MittelverwendungSaldoView extends AbstractView
   @Override
   public void bind() throws Exception
   {
-    GUI.getView().setTitle("Mittelverwendungsaldo");
+    GUI.getView().setTitle("Mittelverwendungssaldo");
 
     final BuchungsklasseSaldoControl control = new BuchungsklasseSaldoControl(
         this);


### PR DESCRIPTION
Grossschrift im Menü und Mittelverwendungssaldo mit zwei s.