### PR TITLE
Fix Exception bei Buchung Speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1167,6 +1167,10 @@ public class BuchungsControl extends AbstractControl
   {
     try
     {
+      if (!Einstellungen.getEinstellung().getProjekteAnzeigen())
+      {
+        return null;
+      }
       Projekt projekt = (Projekt) getProjekt().getValue();
       if (null == projekt)
         return null;


### PR DESCRIPTION
Beim Speichern der Buchung kam manchmal eine Exception wenn die Projekte nicht angezeigt sind.