### PR TITLE
Fix Kontoauszug für PDF Report

### DIFF
--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -274,7 +274,14 @@ public class Kontoauszug
     rpt.addColumn(Zahlungsweg.get((Integer) node.getAttribute("zahlungsweg")),
         Element.ALIGN_LEFT);
     rpt.addColumn((Double) node.getAttribute("soll"));
-    rpt.addColumn((Double) node.getAttribute("ist"));
+    if (node.getType() != MitgliedskontoNode.SOLL)
+    {
+      rpt.addColumn((Double) node.getAttribute("ist"));
+    }
+    else
+    {
+      rpt.addColumn((Double) null);
+    }
     rpt.addColumn((Double) node.getAttribute("differenz"));
   }
 


### PR DESCRIPTION
Ich habe kürzlich Kontoauszüge an meine Vereinsmitglieder verschickt. Ich habe dann zahlreiche Rückmeldungen bekommen die von dem Report irritiert waren.
Konkret ging es um die Ist Spalte. Hier stehen sowohl die Beträge in den Ist Zeilen, also die echten Buchungsbeträge als auch in der Soll Zeile. Hier steht dann der Betrag nochmals und manche denken es handelt sich auch um eine Buchung. Auch stimmt die Summe der Einträge nicht mit der Summe ganz oben überein.
Im entsprechenden View macht das ja Sinn, weil wenn der Baum nicht ganz aufgeklappt ist sieht man in der Soll Zeile neben dem Soll Betrag auch gleich die bisher aufgelaufenen Zahlungen.
Im PDF Report fürt das aber doch sehr zu Verwirrung.
Mein Vorschlag hier ist, im PDF Report bei der Soll Zeile keine Ist Beträge auszugeben. Damit gibt es in der Ist Spalte auch nur echte Ist Buchungen.
Ich denke das sollte einige Verwirrung vermeiden.