### PR TITLE
Limit für Fehlbetrag und Überzahlung unterstützen

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -363,11 +363,20 @@ public class SollbuchungQuery
     sql.append(
         " GROUP BY " + Sollbuchung.TABLE_NAME_ID + ", " + Sollbuchung.T_BETRAG);
 
+    Double limit = Double.valueOf(0d);
+    if (control.isDoubleAuswAktiv()
+        && control.getDoubleAusw().getValue() != null)
+    {
+      // Es ist egal ob der Betrag positiv oder negativ eingetragen wurde
+      limit = Math.abs((Double) control.getDoubleAusw().getValue());
+    }
     if (DIFFERENZ.FEHLBETRAG == diff)
     {
-      sql.append(" HAVING SUM(buchung.betrag) < " + Sollbuchung.T_BETRAG
+      sql.append(
+          " HAVING SUM(buchung.betrag) < " + Sollbuchung.T_BETRAG + " - "
+              + limit.toString()
           + " OR (SUM(buchung.betrag) IS NULL AND " + Sollbuchung.T_BETRAG
-          + " > 0)");
+              + " - " + limit.toString() + " > 0)");
     }
     if (DIFFERENZ.UEBERZAHLUNG == diff)
     {

--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -376,13 +376,14 @@ public class SollbuchungQuery
           " HAVING SUM(buchung.betrag) < " + Sollbuchung.T_BETRAG + " - "
               + limit.toString()
           + " OR (SUM(buchung.betrag) IS NULL AND " + Sollbuchung.T_BETRAG
-              + " - " + limit.toString() + " > 0)");
+              + " > " + limit.toString() + ")");
     }
     if (DIFFERENZ.UEBERZAHLUNG == diff)
     {
-      sql.append(" HAVING SUM(buchung.betrag) > " + Sollbuchung.T_BETRAG
+      sql.append(" HAVING SUM(buchung.betrag) > " + Sollbuchung.T_BETRAG + " + "
+          + limit.toString()
           + " OR (SUM(buchung.betrag) IS NULL AND " + Sollbuchung.T_BETRAG
-          + " < 0)");
+          + " + " + limit.toString() + " < 0)");
     }
 
     List<Long> ids = (List<Long>) service.execute(sql.toString(), param.toArray(),

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -897,7 +897,7 @@ public class FilterControl extends AbstractControl
   {
     differenz = new SelectInput(DIFFERENZ.values(), defaultvalue);
     differenz.setName("Differenz");
-    differenz.addListener(new FilterListener());
+    differenz.addListener(new DifferenzListener());
     return differenz;
   }
   
@@ -1109,6 +1109,21 @@ public class FilterControl extends AbstractControl
       doubleauswahl = new DecimalInput(Einstellungen.DECIMALFORMAT);
     }
     doubleauswahl.setName("Auswahl");
+
+    // Falls der Input in Zusammenhang mit Differenz benutzt wird
+    if (differenz != null && differenz.getValue() != null)
+    {
+      DIFFERENZ diff = (DIFFERENZ) differenz.getValue();
+      if (diff == DIFFERENZ.FEHLBETRAG || diff == DIFFERENZ.UEBERZAHLUNG)
+      {
+        doubleauswahl.enable();
+      }
+      else
+      {
+        doubleauswahl.setValue(null);
+        doubleauswahl.disable();
+      }
+    }
     return doubleauswahl;
   }
 
@@ -1439,6 +1454,37 @@ public class FilterControl extends AbstractControl
     }
   }
   
+  public class DifferenzListener implements Listener
+  {
+
+    DifferenzListener()
+    {
+    }
+
+    @Override
+    public void handleEvent(Event event)
+    {
+      if (event.type != SWT.Selection && event.type != SWT.FocusOut)
+      {
+        return;
+      }
+      DIFFERENZ diff = (DIFFERENZ) getDifferenz().getValue();
+      if (doubleauswahl != null && diff != null)
+      {
+        if (diff == DIFFERENZ.FEHLBETRAG || diff == DIFFERENZ.UEBERZAHLUNG)
+        {
+          doubleauswahl.enable();
+        }
+        else
+        {
+          doubleauswahl.setValue(null);
+          doubleauswahl.disable();
+        }
+      }
+      refresh();
+    }
+  }
+
   static class EigenschaftListener implements Listener
   {
 

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -63,6 +63,7 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.formatter.TreeFormatter;
 import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.DateInput;
+import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
@@ -166,6 +167,8 @@ public class FilterControl extends AbstractControl
   protected SelectInput suchbuchungsartart = null;
 
   protected SelectInput suchkontoart = null;
+
+  protected DecimalInput doubleauswahl = null;
 
   private Calendar calendar = Calendar.getInstance();
 
@@ -1089,6 +1092,31 @@ public class FilterControl extends AbstractControl
     return integerausw != null;
   }
   
+  public DecimalInput getDoubleAusw()
+  {
+    if (doubleauswahl != null)
+    {
+      return doubleauswahl;
+    }
+    String tmp = settings.getString(settingsprefix + "doubleauswahl", "");
+    if (tmp != null && !tmp.isEmpty())
+    {
+      doubleauswahl = new DecimalInput(Double.parseDouble(tmp),
+          Einstellungen.DECIMALFORMAT);
+    }
+    else
+    {
+      doubleauswahl = new DecimalInput(Einstellungen.DECIMALFORMAT);
+    }
+    doubleauswahl.setName("Auswahl");
+    return doubleauswahl;
+  }
+
+  public boolean isDoubleAuswAktiv()
+  {
+    return doubleauswahl != null;
+  }
+
   public SelectInput getSuchSpendenart()
   {
     if (suchspendenart != null)
@@ -1354,6 +1382,8 @@ public class FilterControl extends AbstractControl
           suchbuchungsartart.setValue(null);
         if (suchkontoart != null)
           suchkontoart.setValue(null);
+        if (doubleauswahl != null)
+          doubleauswahl.setValue(null);
         refresh();
       }
     }, null, false, "eraser.png");
@@ -1742,6 +1772,19 @@ public class FilterControl extends AbstractControl
       }
     }
     
+    if (doubleauswahl != null)
+    {
+      Double tmp = (Double) doubleauswahl.getValue();
+      if (tmp != null)
+      {
+        settings.setAttribute(settingsprefix + "doubleauswahl", tmp);
+      }
+      else
+      {
+        settings.setAttribute(settingsprefix + "doubleauswahl", "");
+      }
+    }
+
     if (suchspendenart != null )
     {
       SuchSpendenart ss = (SuchSpendenart) suchspendenart.getValue();

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -292,6 +292,12 @@ public class RechnungControl extends DruckMailControl
 
     if (isDifferenzAktiv() && getDifferenz().getValue() != DIFFERENZ.EGAL)
     {
+      Double limit = Double.valueOf(0d);
+      if (isDoubleAuswAktiv() && getDoubleAusw().getValue() != null)
+      {
+        // Es ist egal ob der Betrag positiv oder negativ eingetragen wurde
+        limit = Math.abs((Double) getDoubleAusw().getValue());
+      }
       String sql = "SELECT DISTINCT " + Sollbuchung.T_RECHNUNG + ", "
           + Sollbuchung.T_BETRAG + ", " + "sum(buchung.betrag) FROM "
           + Sollbuchung.TABLE_NAME
@@ -301,15 +307,15 @@ public class RechnungControl extends DruckMailControl
           + Sollbuchung.TABLE_NAME_ID;
       if (getDifferenz().getValue() == DIFFERENZ.FEHLBETRAG)
       {
-        sql += " having sum(buchung.betrag) < " + Sollbuchung.T_BETRAG + " or "
-            + "(sum(buchung.betrag) is null and " + Sollbuchung.T_BETRAG
-            + " > 0) ";
+        sql += " having sum(buchung.betrag) < " + Sollbuchung.T_BETRAG + " - "
+            + limit.toString() + " or (sum(buchung.betrag) is null and "
+            + Sollbuchung.T_BETRAG + " > " + limit.toString() + ")";
       }
       else
       {
-        sql += " having sum(buchung.betrag) > " + Sollbuchung.T_BETRAG + " or "
-            + "(sum(buchung.betrag) is null and " + Sollbuchung.T_BETRAG
-            + " < 0) ";
+        sql += " having sum(buchung.betrag) > " + Sollbuchung.T_BETRAG + " + "
+            + limit.toString() + " or (sum(buchung.betrag) is null and "
+            + Sollbuchung.T_BETRAG + " + " + limit.toString() + " < 0) ";
       }
 
       @SuppressWarnings("unchecked")

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
@@ -60,7 +60,7 @@ public class KontoauszugMailView extends AbstractView
       SimpleContainer middle = new SimpleContainer(cl.getComposite());
       middle.addInput(control.getMailauswahl());
       middle.addInput(control.getDifferenz());
-      middle.addLabelPair("Min. Fehlbetrag", control.getDoubleAusw());
+      middle.addLabelPair("Differenz Limit", control.getDoubleAusw());
 
       SimpleContainer right = new SimpleContainer(cl.getComposite());
       right.addInput(control.getDatumvon());

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
@@ -51,17 +51,20 @@ public class KontoauszugMailView extends AbstractView
     
     if (this.getCurrentObject() == null)
     {
-      ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+      ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
       SimpleContainer left = new SimpleContainer(cl.getComposite());
       left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.ALLE));
       left.addInput(control.getMitgliedStatus());
       left.addInput(control.getBeitragsgruppeAusw());
-      left.addInput(control.getMailauswahl());
+
+      SimpleContainer middle = new SimpleContainer(cl.getComposite());
+      middle.addInput(control.getMailauswahl());
+      middle.addInput(control.getDifferenz());
+      middle.addLabelPair("Min. Fehlbetrag", control.getDoubleAusw());
 
       SimpleContainer right = new SimpleContainer(cl.getComposite());
       right.addInput(control.getDatumvon());
       right.addInput(control.getDatumbis());
-      right.addInput(control.getDifferenz());
       right.addInput(control.getStichtag(false));
     }
     else

--- a/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
@@ -51,17 +51,20 @@ public class MahnungMailView extends AbstractView
     if (this.getCurrentObject() == null)
     {
       LabelGroup group = new LabelGroup(getParent(), "Filter");
-      ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+      ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
       
       SimpleContainer left = new SimpleContainer(cl.getComposite());
       left.addInput(control.getSuchname());
-      left.addInput(control.getDifferenz());
+      left.addInput(control.getMailauswahl());
       left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
-      
+
+      SimpleContainer middle = new SimpleContainer(cl.getComposite());
+      middle.addInput(control.getDifferenz());
+      middle.addLabelPair("Differenz Limit", control.getDoubleAusw());
+
       SimpleContainer right = new SimpleContainer(cl.getComposite());
       right.addInput(control.getDatumvon());
       right.addInput(control.getDatumbis());
-      right.addInput(control.getMailauswahl());
       
       ButtonArea filterbuttons = new ButtonArea();
       filterbuttons.addButton(control.getResetButton());

--- a/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
@@ -42,13 +42,16 @@ public class RechnungListeView extends AbstractView
 
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addInput(control.getSuchname());
-    left.addInput(control.getDifferenz());
+    left.addInput(control.getMailauswahl());
     left.addLabelPair("Ohne Abbucher",control.getOhneAbbucher());
+
+    SimpleContainer middle = new SimpleContainer(cl.getComposite());
+    middle.addInput(control.getDifferenz());
+    middle.addLabelPair("Differenz Limit", control.getDoubleAusw());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addInput(control.getDatumvon());
     right.addInput(control.getDatumbis());
-    right.addInput(control.getMailauswahl());
     
     ButtonArea fbuttons = new ButtonArea();
     ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),

--- a/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
@@ -50,17 +50,20 @@ public class RechnungMailView extends AbstractView
     if (this.getCurrentObject() == null)
     {
       LabelGroup group = new LabelGroup(getParent(), "Filter");
-      ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+      ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
       
       SimpleContainer left = new SimpleContainer(cl.getComposite());
       left.addInput(control.getSuchname());
-      left.addInput(control.getDifferenz());
+      left.addInput(control.getMailauswahl());
       left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
-      
+
+      SimpleContainer middle = new SimpleContainer(cl.getComposite());
+      middle.addInput(control.getDifferenz());
+      middle.addLabelPair("Differenz Limit", control.getDoubleAusw());
+
       SimpleContainer right = new SimpleContainer(cl.getComposite());
       right.addInput(control.getDatumvon());
       right.addInput(control.getDatumbis());
-      right.addInput(control.getMailauswahl());
       
       ButtonArea filterbuttons = new ButtonArea();
       filterbuttons.addButton(control.getResetButton());

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -53,7 +53,7 @@ public class SollbuchungListeView extends AbstractView
 
     SimpleContainer middle = new SimpleContainer(cl.getComposite());
     middle.addInput(control.getDifferenz());
-    middle.addLabelPair("Min. Fehlbetrag", control.getDoubleAusw());
+    middle.addLabelPair("Differenz Limit", control.getDoubleAusw());
     middle.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -44,18 +44,21 @@ public class SollbuchungListeView extends AbstractView
     control.init("sollbuchung.", null, null);
 
     LabelGroup group = new LabelGroup(getParent(), "Filter");
-    ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
+    ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
 
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     left.addLabelPair("Zahler", control.getSuchname());
     left.addLabelPair("Mitglied", control.getSuchtext());
-    left.addInput(control.getDifferenz());
-    left.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
+    left.addLabelPair("Zahler Mail", control.getMailauswahl());
+
+    SimpleContainer middle = new SimpleContainer(cl.getComposite());
+    middle.addInput(control.getDifferenz());
+    middle.addLabelPair("Min. Fehlbetrag", control.getDoubleAusw());
+    middle.addLabelPair("Ohne Abbucher", control.getOhneAbbucher());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
     right.addInput(control.getDatumvon());
     right.addInput(control.getDatumbis());
-    right.addLabelPair("Zahler Mail", control.getMailauswahl());
 
     ButtonArea fbuttons = new ButtonArea();
     ToolTipButton zurueck = control.getZurueckButton(control.getDatumvon(),

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -220,7 +220,8 @@ public class Kontoauszug
     {
       return false;
     }
-    if (diff == DIFFERENZ.UEBERZAHLUNG && node.getSoll() >= node.getIst())
+    if (diff == DIFFERENZ.UEBERZAHLUNG
+        && node.getSoll() >= node.getIst() - limit)
     {
       return false;
     }

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -208,7 +208,15 @@ public class Kontoauszug
     MitgliedskontoNode node = new MitgliedskontoNode(m, (Date) control.getDatumvon().getValue(), 
         (Date) control.getDatumbis().getValue());
     
-    if (diff == DIFFERENZ.FEHLBETRAG && node.getIst() >= node.getSoll())
+    Double limit = Double.valueOf(0d);
+    if (control.isDoubleAuswAktiv()
+        && control.getDoubleAusw().getValue() != null)
+    {
+      // Es ist egal ob der Betrag positiv oder negativ eingetragen wurde
+      limit = Math.abs((Double) control.getDoubleAusw().getValue());
+    }
+
+    if (diff == DIFFERENZ.FEHLBETRAG && node.getIst() >= node.getSoll() - limit)
     {
       return false;
     }


### PR DESCRIPTION
Mit diesem Feature kann man im Sollbuchungen Liste View und beim Kontoauszüge View neben der Differenz auch ein Limit für den Fehlbetrag bzw. Überzahlung eingeben. Es werden dann nur Einträge gelistet bei denen der Fehlbetrag  bzw. Überzahlung das Limit überschreitet.

Dazu habe ich bei den beiden Views den Filterbereich drei spaltig gemacht.