### PR TITLE
Vollzahler vor eintritt Speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/input/VollzahlerInput.java
+++ b/src/de/jost_net/JVerein/gui/input/VollzahlerInput.java
@@ -71,7 +71,6 @@ public class VollzahlerInput
         zhl.addFilter("(" + cond.toString() + ")");
         if(mitglied.getID() != null)
           zhl.addFilter("id != ?",mitglied.getID());
-        MitgliedUtils.setNurAktive(zhl);
         MitgliedUtils.setMitglied(zhl);
         zhl.setOrder("ORDER BY name, vorname");
         mitgliedInput = new SelectNoScrollInput(zhl != null ? 

--- a/src/de/jost_net/JVerein/gui/input/VollzahlerSearchInput.java
+++ b/src/de/jost_net/JVerein/gui/input/VollzahlerSearchInput.java
@@ -65,7 +65,6 @@ public class VollzahlerSearchInput extends SearchInput
       zhl.addFilter("(" + cond.toString() + ")");
       if(mitglied.getID() != null)
         zhl.addFilter("id != ?",mitglied.getID());
-      MitgliedUtils.setNurAktive(zhl);
       MitgliedUtils.setMitglied(zhl);
       if (text != null)
       {


### PR DESCRIPTION
Wie in #852  gewünscht ist es hiermit auch möglich, den Vollzahler bereits vor dem Eintritt zu setzen. Beim Speichern wird nach wie vor geprüft, dass der Vollzahler nicht später als das Mitglied eingetreten sein darf.