### PR TITLE
Fix zurueck Sollbuchung und Spendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -149,7 +149,7 @@ public class SollbuchungControl extends DruckMailControl
 
   private BuchungListPart istbuchungList;
 
-  private static Sollbuchung lastSollbuchung = null;
+  private static Sollbuchung letzteSollbuchung = null;
 
   public SollbuchungControl(AbstractView view)
   {
@@ -175,11 +175,11 @@ public class SollbuchungControl extends DruckMailControl
     try
     {
       sollbuchung = (Sollbuchung) getCurrentObject();
-      lastSollbuchung = sollbuchung;
+      letzteSollbuchung = sollbuchung;
     }
     catch (ClassCastException ex)
     {
-      sollbuchung = lastSollbuchung;
+      sollbuchung = letzteSollbuchung;
     }
     return sollbuchung;
   }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -149,6 +149,8 @@ public class SollbuchungControl extends DruckMailControl
 
   private BuchungListPart istbuchungList;
 
+  private static Sollbuchung lastSollbuchung = null;
+
   public SollbuchungControl(AbstractView view)
   {
     super(view);
@@ -170,7 +172,15 @@ public class SollbuchungControl extends DruckMailControl
     {
       return sollbuchung;
     }
-    sollbuchung = (Sollbuchung) getCurrentObject();
+    try
+    {
+      sollbuchung = (Sollbuchung) getCurrentObject();
+      lastSollbuchung = sollbuchung;
+    }
+    catch (ClassCastException ex)
+    {
+      sollbuchung = lastSollbuchung;
+    }
     return sollbuchung;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -151,6 +151,8 @@ public class SpendenbescheinigungControl extends DruckMailControl
 
   final static String ExportCSV = "CSV";
 
+  private static Spendenbescheinigung letzteSpendenbescheinigung = null;
+
   public SpendenbescheinigungControl(AbstractView view)
   {
     super(view);
@@ -169,7 +171,15 @@ public class SpendenbescheinigungControl extends DruckMailControl
     {
       return spendenbescheinigung;
     }
-    spendenbescheinigung = (Spendenbescheinigung) getCurrentObject();
+    try
+    {
+      spendenbescheinigung = (Spendenbescheinigung) getCurrentObject();
+      letzteSpendenbescheinigung = spendenbescheinigung;
+    }
+    catch (ClassCastException ex)
+    {
+      spendenbescheinigung = letzteSpendenbescheinigung;
+    }
     return spendenbescheinigung;
   }
 


### PR DESCRIPTION
Wenn man aus Sollbuchung und Spendenbescheinigung über die Context Menüs das Mitglied aufruft gibt es beim grünen Zurück Pfeil eine ClassCastException weil current Object ein Mutglied ist.

Ich habe es in 3.1.0 gemacht weil in 3.0.x die Klassen Namen anders sind.