### PR TITLE
Fix Zurück Button bei Mitglied

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
@@ -133,7 +133,6 @@ public class MitgliedDetailAction implements Action
       {
         GUI.getCurrentView().setCurrentObject(mitglied);
       }
-      GUI.getCurrentView().setCurrentObject(mitglied);
       if (mitglied.getMitgliedstyp() == null || mitglied.getMitgliedstyp()
           .getID().equals(String.valueOf(Mitgliedstyp.MITGLIED)))
       {


### PR DESCRIPTION
Wird aus der Sollbuchung oder Spendenbescheinigung über das Kontextmenü ein Mitglied aufgerufen funktionierte der Zurück Button nicht.