### PR TITLE
Rechungsmap auch in ZipMailer

### DIFF
--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -93,11 +93,11 @@ public class FreiesFormularAusgabe
           {
             continue;
           }
-          File f = File.createTempFile(getDateiname(m), ".pdf");
+          File f = File.createTempFile(getDateiname(m, formular), ".pdf");
           formularaufbereitung = new FormularAufbereitung(f, false, false);
           aufbereitenFormular(m, formularaufbereitung, formular);
           formularaufbereitung.closeFormular();
-          zos.putNextEntry(new ZipEntry(getDateiname(m) + ".pdf"));
+          zos.putNextEntry(new ZipEntry(getDateiname(m, formular) + ".pdf"));
           FileInputStream in = new FileInputStream(f);
           // buffer size
           byte[] b = new byte[1024];
@@ -118,8 +118,7 @@ public class FreiesFormularAusgabe
       case MAIL:
         zos.close();
         new ZipMailer(file, (String) control.getBetreff().getValue(),
-            (String) control.getTxt().getValue(),
-            formular.getBezeichnung() + ".pdf");
+            (String) control.getTxt().getValue());
         break;
     }
 
@@ -162,9 +161,10 @@ public class FreiesFormularAusgabe
     fo.store();
   }
 
-  String getDateiname(Mitglied m) throws RemoteException
+  String getDateiname(Mitglied m, Formular formular) throws RemoteException
   {
-    String filename = m.getID() + "#";
+    // MITGLIED-ID#ART#ART-ID#MAILADRESSE#DATEINAME.pdf
+    String filename = m.getID() + "# # #";
     String email = StringTool.toNotNullString(m.getEmail());
     if (email.length() > 0)
     {
@@ -174,7 +174,7 @@ public class FreiesFormularAusgabe
     {
       filename += m.getName() + m.getVorname();
     }
-    return filename;
+    return filename + "#" + formular.getBezeichnung();
   }
 
 }

--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -6,7 +6,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -26,7 +25,6 @@ import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.Dateiname;
-import de.jost_net.JVerein.util.JVDateFormatJJJJMMTT;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
@@ -166,8 +164,7 @@ public class FreiesFormularAusgabe
 
   String getDateiname(Mitglied m) throws RemoteException
   {
-    String filename = m.getID() + "#"
-        + new JVDateFormatJJJJMMTT().format(new Date()) + "#";
+    String filename = m.getID() + "#";
     String email = StringTool.toNotNullString(m.getEmail());
     if (email.length() > 0)
     {

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -164,7 +164,7 @@ public class Kontoauszug
           return;
         }
         new ZipMailer(file, (String) control.getBetreff().getValue(),
-            (String) control.getTxt().getValue(), "Kontoauszug.pdf");
+            (String) control.getTxt().getValue());
         break;
     } 
   }
@@ -302,9 +302,10 @@ public class Kontoauszug
   
   String getDateiname(Mitglied m) throws RemoteException
   {
-    String filename = m.getID() + "#";
+    // MITGLIED-ID#ART#ART-ID#MAILADRESSE#DATEINAME.pdf
+    String filename = m.getID() + "# # #";
     String email = StringTool.toNotNullString(m.getEmail());
-    filename += email;
+    filename += email + "#Kontoauszug";
     return filename;
   }
 }

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -162,7 +162,7 @@ public class Rechnungsausgabe
       case MAIL:
         zos.close();
         new ZipMailer(file, (String) control.getBetreff().getValue(),
-            (String) control.getTxt().getValue(), typ.name() + ".pdf");
+            (String) control.getTxt().getValue());
         break;
     }
   }
@@ -216,6 +216,7 @@ public class Rechnungsausgabe
 
   String getDateiname(Rechnung re) throws RemoteException
   {
+    // MITGLIED-ID#ART#ART-ID#MAILADRESSE#DATEINAME.pdf
     Mitglied m = re.getMitglied();
     String filename = m.getID() + "#rechnung#" + re.getID() + "#";
     String email = StringTool.toNotNullString(m.getEmail());
@@ -227,7 +228,7 @@ public class Rechnungsausgabe
     {
       filename += m.getName() + m.getVorname();
     }
-    return filename;
+    return filename + "#" + typ.name();
   }
 
 }

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -40,7 +40,6 @@ import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.util.Dateiname;
-import de.jost_net.JVerein.util.JVDateFormatJJJJMMTT;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.GenericIterator;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -218,8 +217,7 @@ public class Rechnungsausgabe
   String getDateiname(Rechnung re) throws RemoteException
   {
     Mitglied m = re.getMitglied();
-    String filename = m.getID() + "#"
-        + new JVDateFormatJJJJMMTT().format(re.getDatum()) + "#";
+    String filename = m.getID() + "#rechnung#" + re.getID() + "#";
     String email = StringTool.toNotNullString(m.getEmail());
     if (email.length() > 0)
     {

--- a/src/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/de/jost_net/JVerein/io/ZipMailer.java
@@ -64,10 +64,10 @@ import de.willuhn.util.ProgressMonitor;
 public class ZipMailer
 {
   /**
-   * Sendet die Mail mit den Dateien aus dem Zi an alle empfnger
+   * Sendet die Mail mit den Dateien aus dem Zip an alle Empfnger
    * 
    * @param zipfile
-   *          das Archiev mit allen PDFs (o.ä.) die an die Mitglieer verschickt
+   *          das Archiv mit allen PDFs (o.ä.) die an die Mitglieder verschickt
    *          werden sollen. Die Dateien darin müssen den Dateinamen in der Form
    *          MITGLIED-ID#ART#ART-ID#MAILADRESSE.pdf haben.
    * @param betreff
@@ -75,7 +75,8 @@ public class ZipMailer
    * @param text
    *          Text der Mail
    * @param dateiname
-   *          Der Dateiname des Anhangs wie er verwendet werden soll
+   *          Der Dateiname des Anhangs wie er verwendet werden soll (kann auch
+   *          Variablen enthalten)
    * @throws RemoteException
    */
   public ZipMailer(final File zipfile, final String betreff, String text,


### PR DESCRIPTION
Bisher können die Rechnungsvariablen nicht im Mail verwendet werden. Dafür habe ich nun den Zipmailer umgestellt, so dass auch die RechnungsId im Dateinamen ist und dadurch die Rechnungsmap geladen werden kann.
Außerdem hab ich es auch für Spendenbescheinigungen und Lastschriften vorbereitet, dass diese auch mit dem Zip-Mailer versendet werden können.