### PR TITLE
Filter Parameter in Reports ausgeben

### DIFF
--- a/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/BuchungAuswertungPDF.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeMap;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.DocumentException;
@@ -57,7 +58,8 @@ public class BuchungAuswertungPDF
   private boolean kontonummer_in_buchungsliste = false;
 
   public BuchungAuswertungPDF(ArrayList<Buchungsart> buchungsarten,
-      final File file, BuchungQuery query, boolean einzel)
+      final File file, BuchungQuery query, boolean einzel,
+      final TreeMap<String, String> params)
       throws ApplicationException
   {
     try
@@ -153,9 +155,11 @@ public class BuchungAuswertungPDF
           reporter.addColumn("Saldo", Element.ALIGN_LEFT);
           reporter.addColumn("", Element.ALIGN_LEFT);
           reporter.addColumn(summeeinnahmen + summeausgaben + summeumbuchungen);
+          reporter.closeTable();
         }
 
       }
+      reporter.addParams(params);
       GUI.getStatusBar().setSuccessText("Auswertung fertig.");
 
       reporter.close();

--- a/src/de/jost_net/JVerein/io/BuchungsjournalPDF.java
+++ b/src/de/jost_net/JVerein/io/BuchungsjournalPDF.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.io;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.TreeMap;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.DocumentException;
@@ -36,7 +37,8 @@ import de.willuhn.util.ApplicationException;
 public class BuchungsjournalPDF
 {
 
-  public BuchungsjournalPDF(BuchungQuery query, final File file)
+  public BuchungsjournalPDF(BuchungQuery query, final File file,
+      final TreeMap<String, String> params)
       throws ApplicationException
   {
     try
@@ -158,6 +160,7 @@ public class BuchungsjournalPDF
       }
 
       reporter.closeTable();
+      reporter.addParams(params);
       GUI.getStatusBar().setSuccessText("Auswertung fertig.");
 
       reporter.close();

--- a/src/de/jost_net/JVerein/io/MitgliedAbstractPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAbstractPDF.java
@@ -1,0 +1,226 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.TreeMap;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
+import de.jost_net.JVerein.gui.input.MailAuswertungInput;
+import de.jost_net.JVerein.gui.view.IAuswertung;
+import de.jost_net.JVerein.rmi.Beitragsgruppe;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.util.ApplicationException;
+
+public abstract class MitgliedAbstractPDF implements IAuswertung
+{
+
+  protected MitgliedControl control;
+
+  protected Mitgliedstyp mitgliedstyp;
+
+  protected String subtitle = "";
+
+  protected TreeMap<String, String> params;
+
+  protected String zusatzfeld = null;
+
+  protected String zusatzfelder = null;
+
+  public MitgliedAbstractPDF(MitgliedControl control)
+  {
+    this.control = control;
+    this.zusatzfeld = control.getAdditionalparamprefix1();
+    this.zusatzfelder = control.getAdditionalparamprefix2();
+  }
+
+  @Override
+  public String getDateiname()
+  {
+    return null;
+  }
+
+  @Override
+  public String getDateiendung()
+  {
+    return null;
+  }
+
+  @Override
+  public void beforeGo() throws RemoteException
+  {
+    if (control.isSuchMitgliedstypActive())
+    {
+      mitgliedstyp = (Mitgliedstyp) control
+          .getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
+    }
+    else
+    {
+      DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
+          .createList(Mitgliedstyp.class);
+      mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
+      mitgliedstyp = (Mitgliedstyp) mtIt.next();
+    }
+    initParams();
+    String ueberschrift = (String) control.getAuswertungUeberschrift()
+        .getValue();
+    if (ueberschrift.length() > 0)
+    {
+      subtitle = ueberschrift;
+    }
+  }
+
+  @Override
+  public void go(ArrayList<Mitglied> list, File file)
+      throws ApplicationException
+  {
+    // Wird in abgeleiteter Klasse implementiert
+
+  }
+
+  @Override
+  public boolean openFile()
+  {
+    return false;
+  }
+
+  public void initParams() throws RemoteException
+  {
+
+    params = new TreeMap<>();
+
+    if (control.isMitgliedStatusAktiv())
+    {
+      params.put("Status", (String) control.getMitgliedStatus().getValue());
+    }
+    if (control.isEigenschaftenAuswahlAktiv())
+    {
+      String eig = control.getEigenschaftenAuswahl().getText();
+      if (eig.length() > 0)
+      {
+        params.put("Eigenschaften", eig);
+      }
+    }
+    if (control.isSuchExterneMitgliedsnummerActive()
+        && control.getSuchExterneMitgliedsnummer() != null)
+    {
+      String val = control.getSuchExterneMitgliedsnummer().getValue()
+          .toString();
+      if (val.length() > 0)
+      {
+        params.put("Externe Mitgliedsnummer ", val);
+      }
+    }
+    if (control.isGeburtsdatumvonAktiv()
+        && control.getGeburtsdatumvon().getValue() != null)
+    {
+      Date d = (Date) control.getGeburtsdatumvon().getValue();
+      params.put("Geburtsdatum von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isGeburtsdatumbisAktiv()
+        && control.getGeburtsdatumbis().getValue() != null)
+    {
+      Date d = (Date) control.getGeburtsdatumbis().getValue();
+      params.put("Geburtsdatum bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isEintrittvonAktiv()
+        && control.getEintrittvon().getValue() != null)
+    {
+      Date d = (Date) control.getEintrittvon().getValue();
+      params.put("Eintritt von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isEintrittbisAktiv()
+        && control.getEintrittbis().getValue() != null)
+    {
+      Date d = (Date) control.getEintrittbis().getValue();
+      params.put("Eintritt bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isAustrittvonAktiv()
+        && control.getAustrittvon().getValue() != null)
+    {
+      Date d = (Date) control.getAustrittvon().getValue();
+      params.put("Austritt von ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isAustrittbisAktiv()
+        && control.getAustrittbis().getValue() != null)
+    {
+      Date d = (Date) control.getAustrittbis().getValue();
+      params.put("Austritt bis ", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isSterbedatumvonAktiv()
+        && control.getSterbedatumvon().getValue() != null)
+    {
+      Date d = (Date) control.getSterbedatumvon().getValue();
+      params.put("Sterbetag von", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isSterbedatumbisAktiv()
+        && control.getSterbedatumbis().getValue() != null)
+    {
+      Date d = (Date) control.getSterbedatumbis().getValue();
+      params.put("Sterbedatum bis", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isBeitragsgruppeAuswAktiv()
+        && control.getBeitragsgruppeAusw().getValue() != null)
+    {
+      Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
+          .getValue();
+      params.put("Beitragsgruppe", bg.getBezeichnung());
+    }
+    if (control.isMailauswahlAktiv())
+    {
+      int ma = (Integer) control.getMailauswahl().getValue();
+      if (ma != MailAuswertungInput.ALLE)
+      {
+        params.put("Mail", control.getMailauswahl().getText());
+      }
+    }
+    if (control.isSuchGeschlechtAktiv()
+        && control.getSuchGeschlecht().getValue() != null)
+    {
+      params.put("Geschlecht", control.getSuchGeschlecht().getText());
+    }
+    if (control.isStichtagAktiv()
+        && control.getStichtag(false).getValue() != null)
+    {
+      Date d = (Date) control.getStichtag(false).getValue();
+      params.put("Stichtag", new JVDateFormatTTMMJJJJ().format(d));
+    }
+    if (control.isZusatzfelderAuswahlAktiv())
+    {
+      int counter = control.getSettings().getInt(zusatzfelder + "counter", 0);
+      for (int i = 1; i <= counter; i++)
+      {
+        String value = control.getSettings()
+            .getString(zusatzfeld + i + ".value", "");
+        if (!value.equals("") && !value.equals("false"))
+        {
+          params.put(
+              control.getSettings().getString(zusatzfeld + i + ".name", ""),
+              value);
+        }
+      }
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/io/MitgliedAdresslistePDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAdresslistePDF.java
@@ -18,7 +18,6 @@ package de.jost_net.JVerein.io;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.rmi.RemoteException;
 import java.util.ArrayList;
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Element;
@@ -26,58 +25,19 @@ import com.itextpdf.text.Paragraph;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
-import de.jost_net.JVerein.gui.view.IAuswertung;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
-import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Mitglied;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 
-public class MitgliedAdresslistePDF implements IAuswertung
+public class MitgliedAdresslistePDF extends MitgliedAbstractPDF
 {
-
-  private MitgliedControl control;
-
-  private Mitgliedstyp mitgliedstyp;
-
-  private String subtitle = "";
-  
-  String zusatzfeld = null;
-  
-  String zusatzfelder = null;
 
   public MitgliedAdresslistePDF(MitgliedControl control)
   {
-    this.control = control;
-  }
-
-  @Override
-  public void beforeGo() throws RemoteException
-  { 
-    zusatzfeld = control.getAdditionalparamprefix1();
-    zusatzfelder = control.getAdditionalparamprefix2();
-    
-    if (control.isSuchMitgliedstypActive())
-    {
-      mitgliedstyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
-    }
-    else
-    {
-      DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
-          .createList(Mitgliedstyp.class);
-      mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
-      mitgliedstyp = (Mitgliedstyp) mtIt.next();
-    }
-    String ueberschrift = (String) control.getAuswertungUeberschrift()
-        .getValue();
-    if (ueberschrift.length() > 0)
-    {
-      subtitle = ueberschrift;
-    }
+    super(control);
   }
 
   @Override
@@ -142,6 +102,7 @@ public class MitgliedAdresslistePDF implements IAuswertung
       report.add(new Paragraph(String.format("Anzahl %s: %d",
           mitgliedstyp.getBezeichnungPlural(), list.size()), Reporter.getFreeSans(8)));
 
+      report.addParams(params);
       report.close();
       GUI.getStatusBar().setSuccessText(
           String.format("Auswertung fertig. %d Sätze.", list.size()));

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -18,10 +18,8 @@ package de.jost_net.JVerein.io;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.TreeMap;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Element;
@@ -29,161 +27,21 @@ import com.itextpdf.text.Paragraph;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
-import de.jost_net.JVerein.gui.input.MailAuswertungInput;
-import de.jost_net.JVerein.gui.view.IAuswertung;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
-import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.server.Tools.EigenschaftenTool;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class MitgliedAuswertungPDF implements IAuswertung
+public class MitgliedAuswertungPDF extends MitgliedAbstractPDF
 {
-
-  private MitgliedControl control;
-
-  private Mitgliedstyp mitgliedstyp;
-
-  private String subtitle = "";
-
-  private TreeMap<String, String> params;
-  
-  String zusatzfeld = null;
-  
-  String zusatzfelder = null;
 
   public MitgliedAuswertungPDF(MitgliedControl control)
   {
-    this.control = control;
-  }
-
-  @Override
-  public void beforeGo() throws RemoteException
-  {
-    params = new TreeMap<>();
-    
-    zusatzfeld = control.getAdditionalparamprefix1();
-    zusatzfelder = control.getAdditionalparamprefix2();
-    
-    if (control.isSuchMitgliedstypActive())
-    {
-      mitgliedstyp = (Mitgliedstyp) control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED).getValue();
-    }
-    else
-    {
-      DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
-          .createList(Mitgliedstyp.class);
-      mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
-      mitgliedstyp = (Mitgliedstyp) mtIt.next();
-    }
-
-    if (control.isMitgliedStatusAktiv())
-    {
-      params.put("Status", (String) control.getMitgliedStatus().getValue());
-    }
-    if (control.isEigenschaftenAuswahlAktiv())
-    {
-      String eig = control.getEigenschaftenAuswahl().getText();
-      if (eig.length() > 0)
-      {
-        params.put("Eigenschaften", eig);
-      }
-    }
-    if (control.isSuchExterneMitgliedsnummerActive() && control.getSuchExterneMitgliedsnummer() != null)
-    {
-      String val = control.getSuchExterneMitgliedsnummer().getValue().toString();
-      if (val.length() > 0) {
-        params.put("Externe Mitgliedsnummer ", val);
-      }
-    }
-    if (control.isGeburtsdatumvonAktiv() && control.getGeburtsdatumvon().getValue() != null)
-    {
-      Date d = (Date) control.getGeburtsdatumvon().getValue();
-      params.put("Geburtsdatum von ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isGeburtsdatumbisAktiv() && control.getGeburtsdatumbis().getValue() != null)
-    {
-      Date d = (Date) control.getGeburtsdatumbis().getValue();
-      params.put("Geburtsdatum bis ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isEintrittvonAktiv() && control.getEintrittvon().getValue() != null)
-    {
-      Date d = (Date) control.getEintrittvon().getValue();
-      params.put("Eintritt von ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isEintrittbisAktiv() && control.getEintrittbis().getValue() != null)
-    {
-      Date d = (Date) control.getEintrittbis().getValue();
-      params.put("Eintritt bis ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isAustrittvonAktiv() && control.getAustrittvon().getValue() != null)
-    {
-      Date d = (Date) control.getAustrittvon().getValue();
-      params.put("Austritt von ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isAustrittbisAktiv() && control.getAustrittbis().getValue() != null)
-    {
-      Date d = (Date) control.getAustrittbis().getValue();
-      params.put("Austritt bis ", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isSterbedatumvonAktiv() && control.getSterbedatumvon().getValue() != null)
-    {
-      Date d = (Date) control.getSterbedatumvon().getValue();
-      params.put("Sterbetag von", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isSterbedatumbisAktiv() && control.getSterbedatumbis().getValue() != null)
-    {
-      Date d = (Date) control.getSterbedatumbis().getValue();
-      params.put("Sterbedatum bis", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isBeitragsgruppeAuswAktiv() && control.getBeitragsgruppeAusw().getValue() != null)
-    {
-      Beitragsgruppe bg = (Beitragsgruppe) control.getBeitragsgruppeAusw()
-          .getValue();
-      params.put("Beitragsgruppe", bg.getBezeichnung());
-    }
-    if (control.isMailauswahlAktiv())
-    {
-      int ma = (Integer) control.getMailauswahl().getValue();
-      if (ma != MailAuswertungInput.ALLE)
-      {
-        params.put("Mail", control.getMailauswahl().getText());
-      }
-    }
-    if (control.isSuchGeschlechtAktiv() && control.getSuchGeschlecht().getValue() != null)
-    {
-      params.put("Geschlecht", control.getSuchGeschlecht().getText());
-    }
-    if (control.isStichtagAktiv() && control.getStichtag(false).getValue() != null)
-    {
-      Date d = (Date) control.getStichtag(false).getValue();
-      params.put("Stichtag", new JVDateFormatTTMMJJJJ().format(d));
-    }
-    if (control.isZusatzfelderAuswahlAktiv())
-    {
-      int counter = control.getSettings().getInt(zusatzfelder + "counter", 0);
-      for (int i = 1; i <= counter; i++)
-      {
-        String value = control.getSettings().getString(zusatzfeld + i + ".value", "");
-        if (!value.equals("") && !value.equals("false"))
-        {
-          params.put(
-            control.getSettings().getString(zusatzfeld + i + ".name", ""), value);
-        }
-      }
-    }
-    String ueberschrift = (String) control.getAuswertungUeberschrift()
-        .getValue();
-    if (ueberschrift.length() > 0)
-    {
-      subtitle = ueberschrift;
-    }
+    super(control);
   }
 
   @Override
@@ -311,18 +169,7 @@ public class MitgliedAuswertungPDF implements IAuswertung
       report.add(new Paragraph(String.format("Anzahl %d: %s", list.size(),
           mitgliedstyp.getBezeichnungPlural()), Reporter.getFreeSans(8)));
 
-      report.add(new Paragraph("Parameter", Reporter.getFreeSans(12)));
-
-      report.addHeaderColumn("Parameter", Element.ALIGN_RIGHT, 100,
-          BaseColor.LIGHT_GRAY);
-      report.addHeaderColumn("Wert", Element.ALIGN_LEFT, 200,
-          BaseColor.LIGHT_GRAY);
-      report.createHeader(75f, Element.ALIGN_LEFT);
-      for (String key : params.keySet())
-      {
-        report.addColumn(key, Element.ALIGN_RIGHT);
-        report.addColumn(params.get(key), Element.ALIGN_LEFT);
-      }
+      report.addParams(params);
       report.closeTable();
       report.close();
       GUI.getStatusBar().setSuccessText(

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.TreeMap;
 
 import com.itextpdf.text.BadElementException;
 import com.itextpdf.text.BaseColor;
@@ -559,5 +560,22 @@ public class Reporter
   public String notNull(String text)
   {
     return text == null ? "" : text;
+  }
+
+  public void addParams(final TreeMap<String, String> params)
+      throws DocumentException
+  {
+    add(new Paragraph("Parameter", Reporter.getFreeSans(12)));
+
+    addHeaderColumn("Parameter", Element.ALIGN_RIGHT, 100,
+        BaseColor.LIGHT_GRAY);
+    addHeaderColumn("Wert", Element.ALIGN_LEFT, 200, BaseColor.LIGHT_GRAY);
+    createHeader(75f, Element.ALIGN_LEFT);
+    for (String key : params.keySet())
+    {
+      addColumn(key, Element.ALIGN_RIGHT);
+      addColumn(params.get(key), Element.ALIGN_LEFT);
+    }
+    closeTable();
   }
 }


### PR DESCRIPTION
Implementiert #837 

In den drei Reports aus dem BuchungListeView werden die Filter Parameter in den PDF Reports ausgegeben.

Bei der Mitglieder und Nichtmitglieder Auswertung habe ich die Parameter auch zum MitgliedAdresslistePDF Report hinzugefügt. Dafür habe ich das Füllen der Parameter und auch die beforeGo() Methode in eine abstrakte Klasse verschoben. Damit kann man sie bei weiteren Mitglied PDFs wiederverwenden.

Die Ausgabe der Parameter Tabelle habe ich in den Reporter verschoben. Damit wird der Code nur einmal implementiert.