### PR TITLE
Weitere DummyMap Fixes

### DIFF
--- a/src/de/jost_net/JVerein/Variable/AbstractMap.java
+++ b/src/de/jost_net/JVerein/Variable/AbstractMap.java
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.Variable;
+
+import java.util.Date;
+
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+
+public abstract class AbstractMap
+{
+
+  public AbstractMap()
+  {
+    //
+  }
+
+  protected static Date toDate(String datum)
+  {
+    Date d = null;
+
+    try
+    {
+      d = new JVDateFormatTTMMJJJJ().parse(datum);
+    }
+    catch (Exception ignored)
+    {
+    }
+    return d;
+  }
+}

--- a/src/de/jost_net/JVerein/Variable/LastschriftMap.java
+++ b/src/de/jost_net/JVerein/Variable/LastschriftMap.java
@@ -27,8 +27,13 @@ import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Lastschrift;
 
-public class LastschriftMap
+public class LastschriftMap extends AbstractMap
 {
+
+  public LastschriftMap()
+  {
+    super();
+  }
 
   public Map<String, Object> getMap(Lastschrift ls, Map<String, Object> inma)
       throws RemoteException
@@ -143,8 +148,10 @@ public class LastschriftMap
     }
 
     map.put(LastschriftVar.ABRECHNUNGSLAUF_NR.getName(), "99");
-    map.put(LastschriftVar.ABRECHNUNGSLAUF_DATUM.getName(), "01.01.2025");
-    map.put(LastschriftVar.ABRECHNUNGSLAUF_FAELLIGKEIT.getName(), "10.01.2025");
+    map.put(LastschriftVar.ABRECHNUNGSLAUF_DATUM.getName(),
+        toDate("01.01.2025"));
+    map.put(LastschriftVar.ABRECHNUNGSLAUF_FAELLIGKEIT.getName(),
+        toDate("10.01.2025"));
     map.put(LastschriftVar.ANREDE_DU.getName(), "Hallo Willi,");
     map.put(LastschriftVar.ANREDE_FOERMLICH.getName(),
         "Sehr geehrter Herr Dr. Dr. Wichtig,");
@@ -162,12 +169,12 @@ public class LastschriftMap
     map.put(LastschriftVar.STAAT.getName(), "Deutschland");
     map.put(LastschriftVar.EMAIL.getName(), "willi.wichtig@email.de");
     map.put(LastschriftVar.MANDATID.getName(), "12345");
-    map.put(LastschriftVar.MANDATDATUM.getName(), "01.01.2024");
+    map.put(LastschriftVar.MANDATDATUM.getName(), toDate("01.01.2024"));
     map.put(LastschriftVar.BIC.getName(), "XXXXXXXXXXX");
     map.put(LastschriftVar.IBAN.getName(), "DE89370400440532013000");
     map.put(LastschriftVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");
     map.put(LastschriftVar.VERWENDUNGSZWECK.getName(), "Zweck");
-    map.put(LastschriftVar.BETRAG.getName(), "23,80");
+    map.put(LastschriftVar.BETRAG.getName(), Double.valueOf("23.80"));
     map.put(LastschriftVar.EMPFAENGER.getName(),
         "Herr\nWilli Wichtig\nHinterhof bei Müller\nBahnhofstr. 22\n12345 Testenhausen\nDeutschland");
     return map;

--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -39,7 +39,6 @@ import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Zusatzfelder;
 import de.jost_net.JVerein.util.Datum;
-import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.LesefeldAuswerter;
 import de.jost_net.JVerein.util.StringTool;
 import de.jost_net.OBanToo.SEPA.BankenDaten.Bank;
@@ -48,12 +47,12 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class MitgliedMap
+public class MitgliedMap extends AbstractMap
 {
 
   public MitgliedMap()
   {
-    //
+    super();
   }
 
   public Map<String, Object> getMap(Mitglied m, Map<String, Object> inma)
@@ -381,9 +380,10 @@ public class MitgliedMap
     map.put(MitgliedVar.BEITRAGSGRUPPE_ARBEITSEINSATZ_BETRAG.getName(), "50");
     map.put(MitgliedVar.BEITRAGSGRUPPE_ARBEITSEINSATZ_STUNDEN.getName(), "10");
     map.put(MitgliedVar.BEITRAGSGRUPPE_BEZEICHNUNG.getName(), "Beitrag");
-    map.put(MitgliedVar.BEITRAGSGRUPPE_BETRAG.getName(), "300,00");
+    map.put(MitgliedVar.BEITRAGSGRUPPE_BETRAG.getName(),
+        Double.valueOf("300.00"));
     map.put(MitgliedVar.BEITRAGSGRUPPE_ID.getName(), "1");
-    map.put(MitgliedVar.MANDATDATUM.getName(), "01.01.2024");
+    map.put(MitgliedVar.MANDATDATUM.getName(), toDate("01.01.2024"));
     map.put(MitgliedVar.MANDATID.getName(), "12345");
     map.put(MitgliedVar.BIC.getName(), "BICXXXXXXXX");
     map.put(MitgliedVar.BLZ.getName(), "");
@@ -399,7 +399,8 @@ public class MitgliedMap
     map.put(MitgliedVar.IBAN.getName(), "DE89370400440532013000");
     map.put(MitgliedVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");
     map.put(MitgliedVar.ID.getName(), "15");
-    map.put(MitgliedVar.INDIVIDUELLERBEITRAG.getName(), "123.45");
+    map.put(MitgliedVar.INDIVIDUELLERBEITRAG.getName(),
+        Double.valueOf("123.45"));
     map.put(MitgliedVar.KONTO.getName(), "");
     map.put(MitgliedVar.BANKNAME.getName(), "XY Bank");
     map.put(MitgliedVar.KONTOINHABER.getName(), "Maier, Werner");
@@ -500,20 +501,6 @@ public class MitgliedMap
     map.putAll(l.getLesefelderMap());
 
     return map;
-  }
-
-  private static Date toDate(String datum)
-  {
-    Date d = null;
-
-    try
-    {
-      d = new JVDateFormatTTMMJJJJ().parse(datum);
-    }
-    catch (Exception ignored)
-    {
-    }
-    return d;
   }
 
 }

--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -34,12 +34,12 @@ import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 
-public class RechnungMap
+public class RechnungMap extends AbstractMap
 {
 
   public RechnungMap()
   {
-    //
+    super();
   }
 
   @SuppressWarnings("deprecation")
@@ -203,12 +203,12 @@ public class RechnungMap
       map = inMap;
     }
 
-    map.put(RechnungVar.SUMME.getName(), "23,80");
-    map.put(RechnungVar.IST.getName(), "10,00");
-    map.put(RechnungVar.STAND.getName(), "-13,80");
-    map.put(RechnungVar.SUMME_OFFEN.getName(), "13,80");
+    map.put(RechnungVar.SUMME.getName(), Double.valueOf("23.80"));
+    map.put(RechnungVar.IST.getName(), Double.valueOf("10.00"));
+    map.put(RechnungVar.STAND.getName(), Double.valueOf("-13.80"));
+    map.put(RechnungVar.SUMME_OFFEN.getName(), Double.valueOf("13.80"));
     map.put(RechnungVar.QRCODE_INTRO.getName(), "QRCode Intro");
-    map.put(RechnungVar.DATUM.getName(), "10.01.2025");
+    map.put(RechnungVar.DATUM.getName(), toDate("10.01.2025"));
     map.put(RechnungVar.NUMMER.getName(), "Nummer");
     map.put(RechnungVar.ANREDE.getName(), "Herrn");
     map.put(RechnungVar.TITEL.getName(), "Dr. Dr.");
@@ -225,7 +225,7 @@ public class RechnungMap
         "Sehr geehrter Herr Dr. Dr. Wichtig,");
     map.put(RechnungVar.PERSONENART.getName(), "n");
     map.put(RechnungVar.MANDATID.getName(), "12345");
-    map.put(RechnungVar.MANDATDATUM.getName(), "01.01.2024");
+    map.put(RechnungVar.MANDATDATUM.getName(), toDate("01.01.2024"));
     map.put(RechnungVar.BIC.getName(), "XXXXXXXXXXX");
     map.put(RechnungVar.IBAN.getName(), "DE89370400440532013000");
     map.put(RechnungVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");

--- a/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
+++ b/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
@@ -37,12 +37,12 @@ import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.logging.Logger;
 import jonelo.NumericalChameleon.SpokenNumbers.GermanNumber;
 
-public class SpendenbescheinigungMap
+public class SpendenbescheinigungMap extends AbstractMap
 {
 
   public SpendenbescheinigungMap()
   {
-    //
+    super();
   }
 
   public Map<String, Object> getMap(Spendenbescheinigung spb, Map<String, Object> inMap)
@@ -433,11 +433,13 @@ public class SpendenbescheinigungMap
     map.put(SpendenbescheinigungVar.ANREDE.getName(), "Herrn");
     map.put(SpendenbescheinigungVar.EMPFAENGER.getName(),
         "Herr\nWilli Wichtig\nHinterhof bei Müller\nBahnhofstr. 22\n12345 Testenhausen\nDeutschland");
-    map.put(SpendenbescheinigungVar.BETRAG.getName(), "300,00");
+    map.put(SpendenbescheinigungVar.BETRAG.getName(), Double.valueOf("300.00"));
     map.put(SpendenbescheinigungVar.BETRAGINWORTEN.getName(), "dreihundert");
-    map.put(SpendenbescheinigungVar.BESCHEINIGUNGDATUM.getName(), "10.01.2025");
+    map.put(SpendenbescheinigungVar.BESCHEINIGUNGDATUM.getName(),
+        toDate("10.01.2025"));
     map.put(SpendenbescheinigungVar.SPENDEART.getName(), "Geldspende");
-    map.put(SpendenbescheinigungVar.SPENDEDATUM.getName(), "01.01.2025");
+    map.put(SpendenbescheinigungVar.SPENDEDATUM.getName(),
+        toDate("01.01.2025"));
     map.put(SpendenbescheinigungVar.SPENDENZEITRAUM.getName(),
         "01.01.2025 bis 01.03.2025");
     map.put(SpendenbescheinigungVar.ERSATZAUFWENDUNGEN.getName(), "X");
@@ -448,7 +450,8 @@ public class SpendenbescheinigungMap
     map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_DATEN.getName(), "Willi");
     map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_ART.getName(), "Spende");
     map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_VERZICHT.getName(), "nein");
-    map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_BETRAG.getName(), "300,00");
+    map.put(SpendenbescheinigungVar.BUCHUNGSLISTE_BETRAG.getName(),
+        Double.valueOf("300.00"));
     map.put(SpendenbescheinigungVar.BEZEICHNUNGSACHZUWENDUNG.getName(),
         "Waschmaschine");
     map.put(SpendenbescheinigungVar.HERKUNFTSACHZUWENDUNG.getName(),
@@ -456,7 +459,8 @@ public class SpendenbescheinigungMap
     map.put(SpendenbescheinigungVar.UNTERLAGENWERTERMITTUNG.getName(), "X");
     map.put(SpendenbescheinigungVar.FINANZAMT.getName(), "Testhausen");
     map.put(SpendenbescheinigungVar.STEUER_NR.getName(), "14/814/70099");
-    map.put(SpendenbescheinigungVar.DATUM_BESCHEID.getName(), "01.06.2025");
+    map.put(SpendenbescheinigungVar.DATUM_BESCHEID.getName(),
+        toDate("01.06.2025"));
     map.put(SpendenbescheinigungVar.VERANLAGUNGSZEITRAUM.getName(),
         "2022 bis 2024");
     map.put(SpendenbescheinigungVar.ZWECK.getName(), "Spende");


### PR DESCRIPTION
Man lernt ja nie aus. Ich habe festgestellt, dass die Geldbeträge in der Vorschau und in den Mails als Double mit Punkt ausgegeben werden.
Die Lösung habe ich über den übergebenen Formatter gefunden. Man muss im Mailtext das hier angeben:
$decimalformat.format($rechnung_summe). 
Auch beim Datum kann man einen Formatter nutzen so wie hier:
$dateformat.format($rechnung_datum).

Wenn man das verwendet gibt es aber Exceptions im MailTextVorschau Dialog weil die Formatter ein Double bzw. Date wollen.

Ich habe jetzt in den Dummy Maps Geldbeträge von String in Double umgewandelt und einige fehlende Datumswerte in Date. Damit gibt es keine Exceptions mehr im Dialog und die Ersetzung funktioniert. Die toDate() Methode in der MitgliedMap habe ich in eine abstrakte Klasse verschoben damit sie von abben Maps verwendet werden kann.

Es ist mir aber noch etwas aufgefallen. Wird kein Date Formatter verwendet, dann ist die Ausgabe in der Mail z.B. (25-05-25). Im Vorschau Dialog aber (Fri Jan 10 00:00:00 CET 2025). Es wird aber doch eigentlich in beiden Fällen ein Date in die Map geschrieben. Die Ersetzung ist auch gleich. Warum die Ausgabe dann unterschiedlich ist erschliest sich mir nicht.