### PR TITLE
Fix Sollbuchung Detail View Refresh

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -164,13 +164,14 @@ public class SollbuchungControl extends DruckMailControl
     sollbuchung = sollb;
   }
 
-  public Sollbuchung getSollbuchung()
+  public Sollbuchung getSollbuchung() throws RemoteException
   {
     if (sollbuchung != null)
     {
       return sollbuchung;
     }
-    sollbuchung = (Sollbuchung) getCurrentObject();
+    sollbuchung = Einstellungen.getDBService().createObject(Sollbuchung.class,
+        ((Sollbuchung) getCurrentObject()).getID());
     return sollbuchung;
   }
 

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungPositionDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungPositionDetailView.java
@@ -65,8 +65,6 @@ public class SollbuchungPositionDetailView extends AbstractView
         {
           control.handleStore();
           GUI.startPreviousView();
-          GUI.startView(SollbuchungDetailView.class.getName(),
-              control.getPosition().getSollbuchung());
           GUI.getStatusBar().setSuccessText("Sollbuchungsposition gespeichert");
         }
         catch (ApplicationException | RemoteException e)


### PR DESCRIPTION
Durch das Feature "Speichern und neu" Button wurde beim Editieren einer Sollbuchungposition und auch beim Erzeugen einer neuen Sollbuchungposition nach deren Speicherung im SollbuchungDetailView das Feld Betrag nicht angepasst.
Der Grund war wohl, dass startPreviousView() einfach den alten View wieder anzeigt.
Mit startView wird er neu aufgebaut und auch der neue Wert für den Betrag angezeigt.

Allerdings kommt man jetzt wenn man wieder Return drückt zur Sollbuchungposition zurück. Gibt es auch eine andere Lösung mit startPreviousView() ?