### PR TITLE
Korrektur Sollbuchung Fehlbetrag

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -380,7 +380,7 @@ public class SollbuchungQuery
     {
       sql.append(
           " HAVING CAST(COALESCE(SUM(buchung.betrag),0) AS DECIMAL(10,2)) > "
-              + Sollbuchung.T_BETRAG + " - " + limit.toString());
+              + Sollbuchung.T_BETRAG + " + " + limit.toString());
     }
 
     List<Long> ids = (List<Long>) service.execute(sql.toString(), param.toArray(),

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -313,7 +313,7 @@ public class RechnungControl extends DruckMailControl
       else
       {
         sql += " HAVING CAST(COALESCE(SUM(buchung.betrag),0) AS DECIMAL(10,2)) > "
-            + Sollbuchung.T_BETRAG + " - " + limit.toString();
+            + Sollbuchung.T_BETRAG + " + " + limit.toString();
       }
 
       @SuppressWarnings("unchecked")


### PR DESCRIPTION
Bei mir kam es immer wieder vor, dass bei Sollbuchungen ein Fehlbetrag oder Überzahlung angezeigt wurde, obwohl sie ausgeglichen ist. Das lag daran, dass die SQL Summe bei mehreren Buchungen manchmal einen Betrag von zB. 9.999999999998 berechnete. Hier habe ich ein Cast auf 2 Nachkommastellen eingebaut.