### PR TITLE
Umsatzsteuer Voranmeldung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -1,0 +1,290 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.parts.KontensaldoListTablePart;
+import de.jost_net.JVerein.io.ISaldoExport;
+import de.jost_net.JVerein.io.UmsatzsteuerSaldoCSV;
+import de.jost_net.JVerein.io.UmsatzsteuerSaldoPDF;
+import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.Kontoart;
+import de.jost_net.JVerein.server.ExtendedDBIterator;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.FeatureSummary;
+import de.willuhn.util.ApplicationException;
+
+public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
+{
+  /**
+   * Die Art der Buchung: Einnahme (0), Ausgabe (1), Umbuchung (2)
+   */
+  protected static final String ARTBUCHUNGSART = "art";
+
+  /**
+   * Die Summe
+   */
+  public static final String SUMME = "summe";
+
+  /**
+   * Anzahl Buchungen
+   */
+  public static final String ANZAHL = "anzahl";
+
+  public static final String STEUER = "steuer";
+
+  public static final String STEUERBETRAG = "steuerbetrag";
+
+  private static final String ARTSTEUERBUCHUNGSART = "artsteuerbuchungsart";
+
+  private KontensaldoListTablePart saldoList;
+
+  public UmsatzsteuerSaldoControl(AbstractView view) throws RemoteException
+  {
+    super(view);
+  }
+
+  @Override
+  public TablePart getSaldoList() throws ApplicationException
+  {
+    try
+    {
+      if (saldoList != null)
+      {
+        return saldoList;
+      }
+      saldoList = new KontensaldoListTablePart(getList(), null)
+      {
+        @Override
+        protected void orderBy(int index)
+        {
+          return;
+        }
+      };
+      saldoList.addColumn("Steuerart", GRUPPE, null, false, Column.ALIGN_RIGHT);
+      saldoList.addColumn("Steuer Name", STEUER);
+      saldoList.addColumn("Bemessungsgrundlage", SUMME,
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+          Column.ALIGN_RIGHT);
+      saldoList.addColumn("Steuerbetrag", STEUERBETRAG,
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+          Column.ALIGN_RIGHT);
+      saldoList.addColumn("Anzahl", ANZAHL);
+      saldoList.setRememberColWidths(true);
+      saldoList.setMulti(true);
+      saldoList.addFeature(new FeatureSummary());
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler aufgetreten " + e.getMessage());
+    }
+    return saldoList;
+  }
+
+  @Override
+  public ArrayList<PseudoDBObject> getList() throws RemoteException
+  {
+    ExtendedDBIterator<PseudoDBObject> it = getIterator();
+
+    ArrayList<PseudoDBObject> zeilen = new ArrayList<>();
+
+    String artAlt = null;
+
+    // Summen der Steuerart
+    Double steuerSumme = 0d;
+
+    // Summen aller Steuern
+    Double steuerGesamt = 0d;
+
+    while (it.hasNext())
+    {
+      PseudoDBObject o = it.next();
+
+      String art = null;
+      Integer steuerArt = o.getInteger(ARTSTEUERBUCHUNGSART);
+      if (steuerArt == (Integer) ArtBuchungsart.EINNAHME || (steuerArt == null
+          && o.getInteger(ARTBUCHUNGSART) == (Integer) ArtBuchungsart.EINNAHME))
+      {
+        art = "Umsatzsteuer";
+      }
+      else if (steuerArt == (Integer) ArtBuchungsart.AUSGABE)
+      {
+        art = "Vorsteuer";
+      }
+      else
+      {
+        // Steuerfreie Ausgaben geben wir nicht mit aus.
+        // Umbuchungen darf es gar nicht geben
+        continue;
+      }
+
+      // Vor neuer Art Summe der letzten anzeigen.
+      if (!art.equals(artAlt) && artAlt != null)
+      {
+        PseudoDBObject summe = new PseudoDBObject();
+        summe.setAttribute(ART, ART_SALDOFOOTER);
+        summe.setAttribute(GRUPPE, "Summe " + artAlt);
+        summe.setAttribute(STEUERBETRAG, steuerSumme);
+        zeilen.add(summe);
+
+        steuerSumme = 0d;
+      }
+
+      // Bei neuer Art Kopfzeile anzeigen.
+      if (!art.equals(artAlt))
+      {
+        PseudoDBObject head = new PseudoDBObject();
+        head.setAttribute(ART, ART_HEADER);
+        head.setAttribute(GRUPPE, art);
+        zeilen.add(head);
+        artAlt = art;
+      }
+      // Die Detailzeile wie sie aus dem iterator kommt anzeigen.
+      o.setAttribute(ART, ART_DETAIL);
+      if (o.getAttribute(STEUER) == null)
+      {
+        o.setAttribute(STEUER, "Steuerfreie Umsätze");
+      }
+
+      zeilen.add(o);
+      steuerSumme += o.getDouble(STEUERBETRAG);
+      steuerGesamt += o.getDouble(STEUERBETRAG);
+    }
+
+    // Am Ende noch Saldo der letzten Art.
+    if (artAlt != null)
+    {
+      PseudoDBObject summe = new PseudoDBObject();
+      summe.setAttribute(ART, ART_SALDOFOOTER);
+      summe.setAttribute(GRUPPE, "Summe " + artAlt);
+      summe.setAttribute(STEUERBETRAG, steuerSumme);
+      zeilen.add(summe);
+    }
+
+    PseudoDBObject o = new PseudoDBObject();
+    o.setAttribute(ART, ART_LEERZEILE);
+    zeilen.add(o);
+
+    PseudoDBObject saldo = new PseudoDBObject();
+    saldo.setAttribute(ART, ART_GESAMTSALDOFOOTER);
+    saldo.setAttribute(GRUPPE,
+        "Verbleibende Umsatzsteuer/Verbleibender Überschuss ");
+    saldo.setAttribute(STEUERBETRAG, steuerGesamt);
+    zeilen.add(saldo);
+
+    return zeilen;
+  }
+
+  /**
+   * Holt den Iterator, auf dessen Basis die Salodliste erstellt wird.
+   * 
+   * @return der Iterator
+   * @throws RemoteException
+   */
+  protected ExtendedDBIterator<PseudoDBObject> getIterator()
+      throws RemoteException
+  {
+    final boolean steuerInBuchung = Einstellungen.getEinstellung()
+        .getSteuerInBuchung();
+
+    ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+        "buchungsart");
+    it.addColumn("steuer.name as " + STEUER);
+    it.addColumn("buchungsart.art as " + ARTBUCHUNGSART);
+    it.addColumn("steuerbuchungsart.art as " + ARTSTEUERBUCHUNGSART);
+    it.addColumn("COUNT(buchung.id) as " + ANZAHL);
+
+    // Bemessungsgrundlage (Netto) berechnen
+    it.addColumn(
+        // Alte Steuerbuchungen mit dependencyid direkt nehmen.
+        "COALESCE(SUM(CASE WHEN buchung.dependencyid > -1 then buchung.betrag ELSE "
+            + "CAST(buchung.betrag*100/(100+COALESCE(steuer.satz,0)) AS DECIMAL(10,2)) END),0) AS "
+            + SUMME);
+
+    // Steuer berechnen.
+    it.addColumn("COALESCE(SUM("
+        // Alte Steuerbuchungen mit dependencyid keine Steuer berechnen
+        + "CASE WHEN buchung.dependencyid > -1 THEN 0 ELSE "
+        + "CAST(steuer.satz/100 * buchung.betrag*100/(100+COALESCE(steuer.satz,0)) AS DECIMAL(10,2)) END "
+        // Alte Steuer hinzurechnen
+        + "+ COALESCE(buchung_steuer_alt.betrag,0)" + "),0) AS "
+        + STEUERBETRAG);
+
+    it.join("buchung",
+        "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?",
+        getDatumvon().getDate(), getDatumbis().getDate());
+
+    // Die Steuer-Splitbuchung mit der gleichen dependecy-ID anhängen um die
+    // alte Steuer zu ermitteln.
+    it.leftJoin("buchung as buchung_steuer_alt",
+        "buchung_steuer_alt.splitid = buchung.splitid AND buchung_steuer_alt.dependencyid = buchung.dependencyid"
+            + " AND buchung_steuer_alt.dependencyid > -1 AND ABS(buchung_steuer_alt.betrag) < ABS(buchung.betrag)");
+    it.addFilter(
+        "buchung.dependencyid is null or buchung.dependencyid = -1 OR buchung_steuer_alt.betrag IS NOT NULL");
+
+    it.leftJoin("konto", "buchung.konto = konto.id");
+    it.addFilter("konto.kontoart is null OR konto.kontoart < ?",
+        Kontoart.LIMIT.getKey());
+    // Keine Steuer auf Anlagekonten
+    it.addFilter("konto.kontoart != ?", Kontoart.ANLAGE.getKey());
+
+    if (steuerInBuchung)
+    {
+      it.leftJoin("steuer", "steuer.id = buchung.steuer");
+    }
+    else
+    {
+      it.leftJoin("steuer", "steuer.id = buchungsart.steuer");
+    }
+    it.leftJoin("buchungsart as steuerbuchungsart",
+        "steuer.buchungsart = steuerbuchungsart.id");
+
+    it.addGroupBy("steuer.id, buchungsart.art");
+
+    it.setOrder("ORDER BY buchungsart.art, steuerbuchungsart.art, steuer.id");
+
+    return it;
+  }
+
+  @Override
+  protected String getAuswertungTitle()
+  {
+    return "Umsatzsteuer Voranmeldung";
+  }
+
+  @Override
+  protected ISaldoExport getAuswertung(String type) throws ApplicationException
+  {
+    switch (type)
+    {
+      case AuswertungCSV:
+        return new UmsatzsteuerSaldoCSV();
+      case AuswertungPDF:
+        return new UmsatzsteuerSaldoPDF(getAuswertungTitle());
+      default:
+        throw new ApplicationException("Ausgabetyp nicht implementiert");
+    }
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -20,7 +20,6 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.gui.parts.KontensaldoListTablePart;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.io.UmsatzsteuerSaldoCSV;
 import de.jost_net.JVerein.io.UmsatzsteuerSaldoPDF;
@@ -58,7 +57,7 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
 
   private static final String ARTSTEUERBUCHUNGSART = "artsteuerbuchungsart";
 
-  private KontensaldoListTablePart saldoList;
+  private TablePart saldoList;
 
   public UmsatzsteuerSaldoControl(AbstractView view) throws RemoteException
   {
@@ -74,7 +73,7 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
       {
         return saldoList;
       }
-      saldoList = new KontensaldoListTablePart(getList(), null)
+      saldoList = new TablePart(getList(), null)
       {
         @Override
         protected void orderBy(int index)
@@ -92,7 +91,6 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
           Column.ALIGN_RIGHT);
       saldoList.addColumn("Anzahl", ANZAHL);
       saldoList.setRememberColWidths(true);
-      saldoList.setMulti(true);
       saldoList.addFeature(new FeatureSummary());
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -93,6 +93,7 @@ import de.jost_net.JVerein.gui.view.SpendenbescheinigungMailView;
 import de.jost_net.JVerein.gui.view.StatistikJahrgaengeView;
 import de.jost_net.JVerein.gui.view.StatistikMitgliedView;
 import de.jost_net.JVerein.gui.view.SteuerListeView;
+import de.jost_net.JVerein.gui.view.UmsatzsteuerSaldoView;
 import de.jost_net.JVerein.gui.view.WiedervorlageListeView;
 import de.jost_net.JVerein.gui.view.ZusatzbetragListeView;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
@@ -233,6 +234,14 @@ public class MyExtension implements Extension
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungsklassensaldo",
           new StartViewAction(BuchungsklasseSaldoView.class),
           "emblem-documents.png"));
+      // UstVA
+      if (Einstellungen.getEinstellung().getOptiert())
+      {
+        buchfuehrung
+            .addChild(new MyItem(buchfuehrung, "Umsatzsteuer Voranmeldung",
+                new StartViewAction(UmsatzsteuerSaldoView.class),
+                "coins.png"));
+      }
       // Projekte
       if (Einstellungen.getEinstellung().getProjekteAnzeigen())
       {

--- a/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.UmsatzsteuerSaldoControl;
+import de.jost_net.JVerein.gui.parts.QuickAccessPart;
+import de.jost_net.JVerein.gui.parts.VonBisPart;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+public class UmsatzsteuerSaldoView extends AbstractView
+{
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Umsatzsteuer Voranmeldung");
+
+    final UmsatzsteuerSaldoControl control = new UmsatzsteuerSaldoControl(this);
+
+    VonBisPart vpart = new VonBisPart(control, true);
+    vpart.paint(this.getParent());
+
+    QuickAccessPart part = new QuickAccessPart(control, true);
+    part.paint(this.getParent());
+
+    LabelGroup group2 = new LabelGroup(getParent(), "Saldo", true);
+    group2.addPart(control.getSaldoList());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.JAHRESSALDO, false, "question-circle.png");
+    buttons.addButton(control.getStartAuswertungCSVButton());
+    buttons.addButton(control.getStartAuswertungPDFButton());
+    buttons.paint(this.getParent());
+  }
+}

--- a/src/de/jost_net/JVerein/io/UmsatzsteuerSaldoCSV.java
+++ b/src/de/jost_net/JVerein/io/UmsatzsteuerSaldoCSV.java
@@ -1,0 +1,142 @@
+/**********************************************************************
+ * Copyright (c) by Thomas Laubrock
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.supercsv.cellprocessor.ConvertNullTo;
+import org.supercsv.cellprocessor.FmtNumber;
+import org.supercsv.cellprocessor.ift.CellProcessor;
+import org.supercsv.io.CsvMapWriter;
+import org.supercsv.io.ICsvMapWriter;
+import org.supercsv.prefs.CsvPreference;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.control.AbstractSaldoControl;
+import de.jost_net.JVerein.gui.control.UmsatzsteuerSaldoControl;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class UmsatzsteuerSaldoCSV implements ISaldoExport
+{
+
+  private static CellProcessor[] getProcessors()
+  {
+
+    final CellProcessor[] processors = new CellProcessor[] {
+        new ConvertNullTo(""), // Steuerart,
+        new ConvertNullTo(""), // Steuer-Name
+        new ConvertNullTo("", new FmtNumber(Einstellungen.DECIMALFORMAT)), // Bemessungsgrundlage
+        new ConvertNullTo("", new FmtNumber(Einstellungen.DECIMALFORMAT)), // Steuer
+    };
+    return processors;
+  }
+
+  @Override
+  public void export(ArrayList<PseudoDBObject> zeile, final File file,
+      Date datumvon, Date datumbis) throws ApplicationException
+  {
+    ICsvMapWriter writer = null;
+    try
+    {
+      writer = new CsvMapWriter(new FileWriter(file),
+          CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE);
+      final CellProcessor[] processors = getProcessors();
+      Map<String, Object> csvzeile = new HashMap<>();
+      String[] header;
+      header = new String[] { "Steuerart", "Steuer Name", "Bemessungsgrundlage",
+          "Steuer" };
+      writer.writeHeader(header);
+
+      String subtitle = new JVDateFormatTTMMJJJJ().format(datumvon) + " - "
+          + new JVDateFormatTTMMJJJJ().format(datumbis);
+      csvzeile.put(header[0], subtitle);
+      writer.write(csvzeile, header, processors);
+
+      for (PseudoDBObject bkz : zeile)
+      {
+        csvzeile = new HashMap<>();
+        switch (bkz.getInteger(AbstractSaldoControl.ART))
+        {
+          case AbstractSaldoControl.ART_HEADER:
+          {
+            csvzeile.put(header[0],
+                (String) bkz.getAttribute(AbstractSaldoControl.GRUPPE));
+            break;
+          }
+          case AbstractSaldoControl.ART_DETAIL:
+          {
+            csvzeile.put(header[1],
+                (String) bkz.getAttribute(UmsatzsteuerSaldoControl.STEUER));
+            csvzeile.put(header[2],
+                bkz.getDouble(UmsatzsteuerSaldoControl.SUMME));
+            csvzeile.put(header[3],
+                bkz.getDouble(UmsatzsteuerSaldoControl.STEUERBETRAG));
+            break;
+          }
+          case AbstractSaldoControl.ART_SALDOFOOTER:
+          case AbstractSaldoControl.ART_GESAMTSALDOFOOTER:
+          {
+            csvzeile.put(header[0],
+                (String) bkz.getAttribute(AbstractSaldoControl.GRUPPE));
+            csvzeile.put(header[3],
+                bkz.getDouble(UmsatzsteuerSaldoControl.STEUERBETRAG));
+            break;
+          }
+          default:
+          {
+            csvzeile.put(header[0], "");
+          }
+        }
+        writer.write(csvzeile, header, processors);
+      }
+      GUI.getStatusBar().setSuccessText("Auswertung fertig");
+      writer.close();
+
+      FileViewer.show(file);
+    }
+    catch (Exception e)
+    {
+      Logger.error("Error while creating report", e);
+      throw new ApplicationException("Fehler", e);
+    }
+    finally
+    {
+      if (writer != null)
+      {
+        try
+        {
+          writer.close();
+        }
+        catch (Exception e)
+        {
+          Logger.error("Error while creating report", e);
+          throw new ApplicationException("Fehler", e);
+        }
+      }
+    }
+
+  }
+}

--- a/src/de/jost_net/JVerein/io/UmsatzsteuerSaldoPDF.java
+++ b/src/de/jost_net/JVerein/io/UmsatzsteuerSaldoPDF.java
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de | www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.io;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Date;
+
+import com.itextpdf.text.BaseColor;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Element;
+
+import de.jost_net.JVerein.gui.control.AbstractSaldoControl;
+import de.jost_net.JVerein.gui.control.UmsatzsteuerSaldoControl;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class UmsatzsteuerSaldoPDF implements ISaldoExport
+{
+  private String title;
+
+  public UmsatzsteuerSaldoPDF(String title)
+  {
+    this.title = title;
+  }
+
+  @Override
+  public void export(ArrayList<PseudoDBObject> zeile, final File file,
+      Date datumvon, Date datumbis) throws ApplicationException
+  {
+    try
+    {
+      FileOutputStream fos = new FileOutputStream(file);
+      String subtitle = new JVDateFormatTTMMJJJJ().format(datumvon) + " - "
+          + new JVDateFormatTTMMJJJJ().format(datumbis);
+      Reporter reporter = new Reporter(fos, title, subtitle, zeile.size());
+      makeHeader(reporter);
+
+      for (PseudoDBObject bkz : zeile)
+      {
+        switch (bkz.getInteger(AbstractSaldoControl.ART))
+        {
+          case AbstractSaldoControl.ART_HEADER:
+          {
+            reporter.addColumn(
+                (String) bkz.getAttribute(AbstractSaldoControl.GRUPPE),
+                Element.ALIGN_LEFT, new BaseColor(220, 220, 220), 3);
+            break;
+          }
+          case AbstractSaldoControl.ART_DETAIL:
+          {
+            reporter.addColumn(
+                (String) bkz.getAttribute(UmsatzsteuerSaldoControl.STEUER),
+                Element.ALIGN_LEFT);
+            reporter.addColumn(bkz.getDouble(UmsatzsteuerSaldoControl.SUMME));
+            reporter.addColumn(
+                bkz.getDouble(UmsatzsteuerSaldoControl.STEUERBETRAG));
+            break;
+          }
+          case AbstractSaldoControl.ART_SALDOFOOTER:
+          case AbstractSaldoControl.ART_GESAMTSALDOFOOTER:
+          {
+            reporter.addColumn(
+                (String) bkz.getAttribute(AbstractSaldoControl.GRUPPE),
+                Element.ALIGN_RIGHT, 2);
+            reporter.addColumn(
+                bkz.getDouble(UmsatzsteuerSaldoControl.STEUERBETRAG));
+            break;
+          }
+        }
+      }
+      GUI.getStatusBar().setSuccessText("Auswertung fertig.");
+      reporter.closeTable();
+      reporter.close();
+      fos.close();
+      FileViewer.show(file);
+    }
+    catch (Exception e)
+    {
+      Logger.error("error while creating report", e);
+      throw new ApplicationException("Fehler", e);
+    }
+  }
+
+  private void makeHeader(Reporter reporter) throws DocumentException
+  {
+    reporter.addHeaderColumn("Steuer Name", Element.ALIGN_CENTER, 45,
+        BaseColor.LIGHT_GRAY);
+    reporter.addHeaderColumn("Bemessungsgrundlage", Element.ALIGN_CENTER, 45,
+        BaseColor.LIGHT_GRAY);
+    reporter.addHeaderColumn("Steuer", Element.ALIGN_CENTER, 45,
+        BaseColor.LIGHT_GRAY);
+    reporter.createHeader();
+  }
+}


### PR DESCRIPTION
Hier habe ich eine neue View "Umsatzsteuer Voranmeldung" erstellt. Die alle Umsätze und ihr Steuer aufsummiert, so wie sie für die Steuererklärung gebraucht werden.
![Bildschirmfoto zu 2025-06-10 13-33-17](https://github.com/user-attachments/assets/64b16ee3-d53f-48bd-a09e-b7201642ea3a)

Hinweis: Die Steuer und die Nettobeträge werden einzeln aufsummiert, daher passen evtl. bei den Summen Steuer und Netto nicht mehr zusammen, da es durch Rundungsfehler bis zu 0.5ct pro Buchung abweichen kann. Das wird auch von vielen anderem Programmen so gehandhabt, u.a. DATEV.