### PR TITLE
Steuer Zuordnung Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungSteuerZuordnenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSteuerZuordnenAction.java
@@ -1,0 +1,127 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.dialogs.SteuerZuordnungDialog;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Steuer;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Steuer zuordnen.
+ */
+public class BuchungSteuerZuordnenAction implements Action
+{
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (context == null
+        || (!(context instanceof Buchung) && !(context instanceof Buchung[])))
+    {
+      throw new ApplicationException("Keine Buchung(en) ausgewählt");
+    }
+    try
+    {
+      Buchung[] b = null;
+      if (context instanceof Buchung)
+      {
+        b = new Buchung[1];
+        b[0] = (Buchung) context;
+      }
+      if (context instanceof Buchung[])
+      {
+        b = (Buchung[]) context;
+      }
+      if (b == null || b.length == 0 || b[0].isNewObject())
+      {
+        return;
+      }
+
+      SteuerZuordnungDialog dialog = new SteuerZuordnungDialog(
+          SteuerZuordnungDialog.POSITION_MOUSE);
+      Steuer steuer = dialog.open();
+      if (!dialog.getAbort())
+      {
+        DBTransaction.starten();
+        int counter = 0;
+        if (steuer == null)
+        {
+          for (Buchung buchung : b)
+          {
+            buchung.setSteuer(null);
+            buchung.store();
+          }
+        }
+        else
+        {
+          for (Buchung buchung : b)
+          {
+            if (buchung.getSteuer() != null && !dialog.getOverride())
+            {
+              counter++;
+            }
+            else
+            {
+              buchung.setSteuer(steuer);
+              buchung.store();
+            }
+          }
+        }
+        if (steuer == null)
+        {
+          GUI.getStatusBar().setSuccessText("Steuer gelöscht");
+        }
+        else
+        {
+          String protecttext = "";
+          if (counter > 0)
+          {
+            protecttext = String
+                .format(", %d Buchungen wurden nicht überschrieben. ", counter);
+          }
+          GUI.getStatusBar()
+              .setSuccessText("Steuer zugeordnet" + protecttext);
+        }
+        DBTransaction.commit();
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (ApplicationException e)
+    {
+      DBTransaction.rollback();
+      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
+    }
+    catch (Exception e)
+    {
+      DBTransaction.rollback();
+      Logger.error("Fehler", e);
+      GUI.getStatusBar()
+          .setErrorText("Fehler bei der Zuordnung der Steuer: "
+              + e.getLocalizedMessage());
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/SteuerZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SteuerZuordnungDialog.java
@@ -1,0 +1,153 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.rmi.RemoteException;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.rmi.Steuer;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.LabelInput;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+/**
+ * Dialog zur Zuordnung der Steuer.
+ */
+public class SteuerZuordnungDialog extends AbstractDialog<Steuer>
+{
+
+  private SelectInput steuerInput = null;
+
+  private CheckboxInput ueberschreiben = null;
+
+  private LabelInput status = null;
+
+  private Steuer steuer = null;
+
+  private boolean ueberschr;
+
+  private boolean abort = true;
+
+  /**
+   * @param position
+   */
+  public SteuerZuordnungDialog(int position)
+  {
+    super(position);
+    setTitle("Zuordnung Steuer");
+    setSize(400, SWT.DEFAULT);
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    LabelGroup group = new LabelGroup(parent, "");
+    group.addLabelPair("Steuer", getSteuerAuswahl());
+    group.addLabelPair("Steuer überschreiben", getUeberschreiben());
+    group.addLabelPair("", getStatus());
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Übernehmen", context -> {
+      if (steuerInput.getValue() == null)
+      {
+        status.setValue("Bitte Steuer auswählen");
+        status.setColor(Color.ERROR);
+        return;
+      }
+      steuer = (Steuer) steuerInput.getValue();
+      ueberschr = (Boolean) getUeberschreiben().getValue();
+      abort = false;
+      close();
+    }, null, true, "ok.png");
+
+    buttons.addButton("Entfernen", context -> {
+      steuer = null;
+      abort = false;
+      close();
+    }, null, false, "user-trash-full.png");
+
+    buttons.addButton("Abbrechen", context -> close(), null, false,
+        "process-stop.png");
+
+    buttons.paint(parent);
+    getShell().setMinimumSize(getShell().computeSize(SWT.DEFAULT, SWT.DEFAULT));
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
+   */
+  @Override
+  public Steuer getData() throws Exception
+  {
+    return steuer;
+  }
+
+  public boolean getOverride()
+  {
+    return ueberschr;
+  }
+
+  public boolean getAbort()
+  {
+    return abort;
+  }
+
+  private SelectInput getSteuerAuswahl() throws RemoteException
+  {
+    if (steuerInput != null)
+    {
+      return steuerInput;
+    }
+    DBIterator<Steuer> it = Einstellungen.getDBService()
+        .createList(Steuer.class);
+    it.addFilter("aktiv = true");
+
+    steuerInput = new SelectInput(PseudoIterator.asList(it), null);
+    steuerInput.setAttribute("name");
+    steuerInput.setPleaseChoose("Keine Steuer");
+
+    return steuerInput;
+  }
+
+  private LabelInput getStatus()
+  {
+    if (status != null)
+    {
+      return status;
+    }
+    status = new LabelInput("");
+    return status;
+  }
+
+  private CheckboxInput getUeberschreiben()
+  {
+    if (ueberschreiben != null)
+    {
+      return ueberschreiben;
+    }
+    ueberschreiben = new CheckboxInput(false);
+    return ueberschreiben;
+  }
+}

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -29,6 +29,7 @@ import de.jost_net.JVerein.gui.action.BuchungGeprueftAction;
 import de.jost_net.JVerein.gui.action.BuchungKontoauszugZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungSollbuchungZuordnungAction;
+import de.jost_net.JVerein.gui.action.BuchungSteuerZuordnenAction;
 import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
@@ -103,6 +104,18 @@ public class BuchungMenu extends ContextMenu
     }
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(), "view-refresh.png"));
+    try
+    {
+      if (Einstellungen.getEinstellung().getSteuerInBuchung())
+      {
+        addItem(new CheckedContextMenuItem("Steuer zuordnen",
+            new BuchungSteuerZuordnenAction(), "view-refresh.png"));
+      }
+    }
+    catch (RemoteException e)
+    {
+      // Dann nicht anzeigen
+    }
     if (geldkonto) {
       addItem(new CheckedContextMenuItem("Sollbuchung zuordnen",
           new BuchungSollbuchungZuordnungAction(), "view-refresh.png"));


### PR DESCRIPTION
Dieser PR beinhaltet einen Steuer-Zuordnen-Dialog ähnlich wie die Buchungsart, Projekt etc. Dialoge. So kann die Steuer von mehreren Buchungen gleichzeitig geändert werden.

Es ist die Frag, wie man damit umgeht, wenn das zuordnen Fehlschlägt (zB. Einnahmen eine Vorsteuer zuordnen), hier gibt es folgende Möglichkeiten:

- Bei Fehlern keine Steuer zuweisen (hier umgesetzt)
- Alle zuweisen die möglich sind, andere überspringen
- Zuweisen bis es zum Fehler kommt
- Menüeintrag nur enable wenn alle Buchungen die gleich Buchungsart-Art (Einnahme, Ausgabe, Umbuchung) haben. Dann im Steuerdialog auch nur die für diese Art möglichen Steuern anzeigen