### PR TITLE
Import von Mitglieds-Eigenschaften etc.

### DIFF
--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -37,6 +37,7 @@ import de.jost_net.OBanToo.SEPA.IBAN;
 import de.jost_net.OBanToo.SEPA.SEPAException;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.ObjectNotFoundException;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
@@ -67,6 +68,24 @@ public class MitgliederImport implements Importer
       Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
           ResultSet.CONCUR_READ_ONLY);
       results = stmt.executeQuery("SELECT * FROM " + fil.substring(0, pos));
+
+      try
+      {
+        results.findColumn("id");
+        YesNoDialog dialog = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+        dialog.setTitle("Mitglieder überschreiben");
+        dialog.setText("In der Importdatei ist die Spalte \"id\" vorhanden,\n"
+            + "es werden die Felder der existierenden Mitglieder mit dieser ID\n"
+            + "geändert und ggf. geleert.\n" + "Soll fortgefahren werden?");
+        if (!(boolean) dialog.open())
+        {
+          throw new ApplicationException("Import abgebrochen");
+        }
+      }
+      catch (SQLException e)
+      {
+        // id nicht vorhanden
+      }
 
       /* Zusatzfelder ermitteln und in Liste ablegen */
       DBIterator<Felddefinition> felddefinitionIt = Einstellungen.getDBService()
@@ -118,20 +137,39 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Eigenschaft nicht vorhanden
+          // Sekundaere Beitragsgruppe nicht vorhanden
         }
       }
 
       DBTransaction.starten();
       int anz = 0;
+      int zeilen = results.getFetchSize();
       while (results.next())
       {
         anz++;
-        monitor.setPercentComplete(anz * 10);
+        monitor.setPercentComplete(anz * 100 / zeilen);
 
-        Mitglied m = (Mitglied) Einstellungen.getDBService()
-            .createObject(Mitglied.class, null);
-
+        String id = null;
+        try
+        {
+          // Wenn die Spalte id existiert, sollen bestehende Mitglieder
+          // überschrieben werden, dann nehmen wir die ID
+          id = results.getString("id");
+        }
+        catch (SQLException ignore)
+        {
+        }
+        Mitglied m = null;
+        try
+        {
+          m = (Mitglied) Einstellungen.getDBService()
+            .createObject(Mitglied.class, id);
+        }
+        catch (ObjectNotFoundException e)
+        {
+          throw new ApplicationException(
+              "Mitglied mit ID " + id + " nicht vorhanden.");
+        }
         try
         {
           String mitgliedstyp = results.getString("adresstyp");
@@ -154,8 +192,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Wenn Adresstyp nicht vorhanden speichern wir es als Mitglied
-          m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+          if (id == null)
+          {
+            // Wenn Adresstyp nicht vorhanden speichern wir es als Mitglied
+            m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+          }
         }
 
         try
@@ -170,9 +211,12 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Wenn Personenart nicht vorhanden speichern wir es als natürliche
-          // Person
-          m.setPersonenart("N");
+          if (id == null)
+          {
+            // Wenn Personenart nicht vorhanden speichern wir es als natürliche
+            // Person
+            m.setPersonenart("N");
+          }
         }
 
         try
@@ -182,8 +226,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler parameter, ignorieren wir
-          m.setAdressierungszusatz("");
+          if (id == null)
+          {
+            // Optionaler parameter, ignorieren wir
+            m.setAdressierungszusatz("");
+          }
         }
 
         if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
@@ -210,8 +257,11 @@ public class MitgliederImport implements Importer
           }
           catch (SQLException e)
           {
-            throw new ApplicationException(
-                "Mitglied muss ein Eintrittsdatum haben!");
+            if (id == null)
+            {
+              throw new ApplicationException(
+                  "Mitglied muss ein Eintrittsdatum haben!");
+            }
           }
         }
 
@@ -247,8 +297,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler parameter, ignorieren wir
-          m.setAnrede("");
+          if (id == null)
+          {
+            // Optionaler parameter, ignorieren wir
+            m.setAnrede("");
+          }
         }
 
         try
@@ -277,7 +330,10 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          throw new ApplicationException("Beitragsgruppe fehlt");
+          if (id == null)
+          {
+            throw new ApplicationException("Beitragsgruppe fehlt");
+          }
         }
 
         try
@@ -323,8 +379,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Wenn nicht vorhanden Standartwert aus Einstellungen nehmen
-          m.setZahlungsweg(Einstellungen.getEinstellung().getZahlungsweg());
+          if (id == null)
+          {
+            // Wenn nicht vorhanden Standartwert aus Einstellungen nehmen
+            m.setZahlungsweg(Einstellungen.getEinstellung().getZahlungsweg());
+          }
         }
 
         try
@@ -371,8 +430,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // wenn nicht vorhanden Monatlich als default nehmen
-          m.setZahlungsrhythmus(Zahlungsrhythmus.MONATLICH);
+          if (id == null)
+          {
+            // wenn nicht vorhanden Monatlich als default nehmen
+            m.setZahlungsrhythmus(Zahlungsrhythmus.MONATLICH);
+          }
         }
 
         try
@@ -397,8 +459,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // wenn nicht vorhanden Monatlich als default nehmen
-          m.setZahlungstermin(Zahlungstermin.MONATLICH.getKey());
+          if (id == null)
+          {
+            // wenn nicht vorhanden Monatlich als default nehmen
+            m.setZahlungstermin(Zahlungstermin.MONATLICH.getKey());
+          }
         }
 
         try
@@ -418,7 +483,7 @@ public class MitgliederImport implements Importer
         catch (SQLException e)
         {
           // Nur bei Zahlungsweg Lastschrift pflicht
-          if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
+          if (id == null && m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
               && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException("Mandatdatum fehlt");
@@ -441,7 +506,7 @@ public class MitgliederImport implements Importer
         catch (SQLException e)
         {
           // Nur bei Zahlungsweg Lastschrift nötig. 0 als default nehmen
-          if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
+          if (id == null && m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
               && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             m.setMandatVersion(0);
@@ -476,7 +541,7 @@ public class MitgliederImport implements Importer
         catch (SQLException e)
         {
           // Nur bei Zahlungsweg Lastschrift nötig
-          if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
+          if (id == null && m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
               && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
           {
             throw new ApplicationException("IBAN fehlt");
@@ -492,7 +557,8 @@ public class MitgliederImport implements Importer
           }
           else
           {
-            if (m.getBic() == "" && m.getIban() != null && m.getIban().length() > 0)
+            if (m.getBic() == "" && m.getIban() != null
+                && m.getIban().length() > 0)
             {
               IBAN i = new IBAN(m.getIban());
               m.setBic(i.getBIC());
@@ -502,7 +568,8 @@ public class MitgliederImport implements Importer
         catch (SQLException e)
         {
           // Optionaler Parameter
-          if (m.getBic() == "" && m.getIban() != null && m.getIban().length() != 0)
+          if (id == null && m.getBic() == "" && m.getIban() != null
+              && m.getIban().length() != 0)
           {
             IBAN i = new IBAN(m.getIban());
             m.setBic(i.getBIC());
@@ -522,8 +589,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setEmail("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setEmail("");
+          }
         }
 
         if (Einstellungen.getEinstellung().getExterneMitgliedsnummer())
@@ -548,7 +618,10 @@ public class MitgliederImport implements Importer
         }
         else
         {
-          m.setExterneMitgliedsnummer(null);
+          if (id == null)
+          {
+            m.setExterneMitgliedsnummer(null);
+          }
         }
 
         try
@@ -568,7 +641,8 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          if (Einstellungen.getEinstellung().getGeburtsdatumPflicht()
+          if (id == null
+              && Einstellungen.getEinstellung().getGeburtsdatumPflicht()
               && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
             throw new ApplicationException("Geburtsdatum fehlt");
         }
@@ -590,7 +664,10 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          m.setGeschlecht("o");
+          if (id == null)
+          {
+            m.setGeschlecht("o");
+          }
         }
 
         try
@@ -605,8 +682,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiAdressierungszusatz("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiAdressierungszusatz("");
+          }
         }
 
         try
@@ -619,8 +699,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiAnrede("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiAnrede("");
+          }
         }
 
         try
@@ -636,8 +719,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiEmail("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiEmail("");
+          }
         }
 
         try
@@ -650,8 +736,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiName("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiName("");
+          }
         }
 
         try
@@ -664,8 +753,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiOrt("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiOrt("");
+          }
         }
 
         try
@@ -696,8 +788,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiPlz("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiPlz("");
+          }
         }
 
         try
@@ -705,24 +800,28 @@ public class MitgliederImport implements Importer
           String ktoistaat = results.getString("ktoistaat");
           if (ktoistaat != null && ktoistaat.length() != 0)
           {
-            if(Staat.getByText(ktoistaat.toUpperCase()) != null)
+            if (Staat.getByText(ktoistaat.toUpperCase()) != null)
             {
               m.setKtoiStaat(Staat.getByText(ktoistaat.toUpperCase()).getKey());
             }
-            else if(Staat.getByKey(ktoistaat.toUpperCase()) != null)
+            else if (Staat.getByKey(ktoistaat.toUpperCase()) != null)
             {
               m.setKtoiStaat(ktoistaat.toUpperCase());
             }
             else
             {
-              throw new ApplicationException("Zeile " + anz + ": Kontoinhaber Staat nicht erkannt: " + ktoistaat);
+              throw new ApplicationException("Zeile " + anz
+                  + ": Kontoinhaber Staat nicht erkannt: " + ktoistaat);
             }
           }
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiStaat("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiStaat("");
+          }
         }
 
         try
@@ -735,8 +834,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiStrasse("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiStrasse("");
+          }
         }
 
         try
@@ -749,8 +851,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiTitel("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiTitel("");
+          }
         }
 
         try
@@ -763,8 +868,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiVorname("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiVorname("");
+          }
         }
 
         try
@@ -782,8 +890,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setKtoiGeschlecht("o");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setKtoiGeschlecht("o");
+          }
         }
 
         try
@@ -824,7 +935,10 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          throw new ApplicationException("Name fehlt");
+          if (id == null)
+          {
+            throw new ApplicationException("Name fehlt");
+          }
         }
 
         try
@@ -834,8 +948,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setOrt("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setOrt("");
+          }
         }
 
         try
@@ -845,8 +962,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setPlz("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setPlz("");
+          }
         }
 
         try
@@ -854,24 +974,28 @@ public class MitgliederImport implements Importer
           String staat = results.getString("staat");
           if (staat != null && staat.length() != 0)
           {
-            if(Staat.getByKey(staat.toUpperCase()) != null)
+            if (Staat.getByKey(staat.toUpperCase()) != null)
             {
               m.setStaat(staat.toUpperCase());
             }
-            else if(Staat.getByText(staat.toUpperCase()) != null)
+            else if (Staat.getByText(staat.toUpperCase()) != null)
             {
               m.setStaat(Staat.getByText(staat.toUpperCase()).getKey());
             }
             else
             {
-              throw new ApplicationException("Zeile " + anz + ": Staat nicht erkannt: " + staat);
+              throw new ApplicationException(
+                  "Zeile " + anz + ": Staat nicht erkannt: " + staat);
             }
           }
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setStaat("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setStaat("");
+          }
         }
 
         try
@@ -881,8 +1005,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setStrasse("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setStrasse("");
+          }
         }
 
         try
@@ -895,8 +1022,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setTelefondienstlich("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setTelefondienstlich("");
+          }
         }
 
         try
@@ -909,8 +1039,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setTelefonprivat("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setTelefonprivat("");
+          }
         }
 
         try
@@ -923,8 +1056,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setHandy("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setHandy("");
+          }
         }
 
         try
@@ -937,8 +1073,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setTitel("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setTitel("");
+          }
         }
 
         try
@@ -951,8 +1090,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setVermerk1("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setVermerk1("");
+          }
         }
 
         try
@@ -965,8 +1107,11 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          // Optionaler Parameter
-          m.setVermerk2("");
+          if (id == null)
+          {
+            // Optionaler Parameter
+            m.setVermerk2("");
+          }
         }
 
         try
@@ -981,22 +1126,47 @@ public class MitgliederImport implements Importer
         }
         catch (SQLException e)
         {
-          throw new ApplicationException("Vorname fehlt");
+          if (id == null)
+          {
+            throw new ApplicationException("Vorname fehlt");
+          }
         }
 
-        m.setEingabedatum();
+        if (id == null)
+        {
+          m.setEingabedatum();
+        }
         m.setLetzteAenderung();
         m.store();
 
         for (Felddefinition f : zusfeldList)
         {
           String inhalt = results.getString("zusatzfeld_" + f.getName());
+
+          Zusatzfelder zusatzfeld = null;
+          // Bei vorhandenen Mitgliedern bereits vorhandenes Zusatzfeld suchen
+          if (id != null)
+          {
+            DBIterator<Zusatzfelder> itZusatzfeld = Einstellungen.getDBService()
+                .createList(Zusatzfelder.class);
+            itZusatzfeld.addFilter("mitglied = ?", m.getID());
+            itZusatzfeld.addFilter("felddefinition = ? ", f.getID());
+            if (itZusatzfeld.hasNext())
+            {
+              zusatzfeld = itZusatzfeld.next();
+            }
+          }
           if (inhalt.length() != 0)
           {
-            Zusatzfelder zusatzfeld = (Zusatzfelder) Einstellungen
-                .getDBService().createObject(Zusatzfelder.class, null);
-            zusatzfeld.setMitglied(Integer.parseInt(m.getID()));
-            zusatzfeld.setFelddefinition(Integer.parseInt(f.getID()));
+
+            if (zusatzfeld == null)
+            {
+              zusatzfeld = (Zusatzfelder) Einstellungen
+                  .getDBService().createObject(Zusatzfelder.class, null);
+              zusatzfeld.setMitglied(Integer.parseInt(m.getID()));
+              zusatzfeld.setFelddefinition(Integer.parseInt(f.getID()));
+            }
+            
             switch (f.getDatentyp())
             {
               case Datentyp.DATUM:
@@ -1058,20 +1228,44 @@ public class MitgliederImport implements Importer
             }
             zusatzfeld.store();
           }
+          // Wenn bei Existierenden Mitgliedern das Zusatzfeld in der
+          // Importdatei leer ist, wird es gelöscht
+          else if (id != null)
+          {
+            zusatzfeld.delete();
+          }
         }
 
         for (Eigenschaft e : eigenschaftList)
         {
           String inhalt = results
               .getString("eigenschaft_" + e.getBezeichnung());
-          if (inhalt.length() != 0 && !inhalt.equalsIgnoreCase("false")
-              && !inhalt.equalsIgnoreCase("nein"))
+          // Bei vorhandenen Mitgliedern bereits vorhandene Eigenschaft suchen
+          Eigenschaften eigenschaften = null;
+          if (id != null)
           {
-            Eigenschaften eigenschaften = (Eigenschaften) Einstellungen
+            DBIterator<Eigenschaften> itEigenschaften = Einstellungen
+                .getDBService().createList(Eigenschaften.class);
+            itEigenschaften.addFilter("mitglied = ?", m.getID());
+            itEigenschaften.addFilter("eigenschaft = ? ", e.getID());
+            if (itEigenschaften.hasNext())
+            {
+              eigenschaften = itEigenschaften.next();
+            }
+          }
+          if (inhalt.length() != 0 && !inhalt.equalsIgnoreCase("false")
+              && !inhalt.equalsIgnoreCase("nein") && eigenschaften == null)
+          {
+            eigenschaften = (Eigenschaften) Einstellungen
                 .getDBService().createObject(Eigenschaften.class, null);
             eigenschaften.setMitglied(m.getID());
             eigenschaften.setEigenschaft(e.getID());
             eigenschaften.store();
+          }
+          // Vorhandene Eigenschaft ggf. entfernen
+          else if (id != null)
+          {
+            eigenschaften.delete();
           }
         }
         // Sekundaere-Beitragsgruppe nur bei Mitgliedern möglich
@@ -1081,22 +1275,47 @@ public class MitgliederImport implements Importer
           {
             String inhalt = results
                 .getString("sekundaer_" + bg.getBezeichnung());
-            if (inhalt.length() != 0 && !inhalt.equalsIgnoreCase("false")
-                && !inhalt.equalsIgnoreCase("nein"))
+            SekundaereBeitragsgruppe sekundaer = null;
+            if (id != null)
             {
-              SekundaereBeitragsgruppe sekundaer = (SekundaereBeitragsgruppe) Einstellungen
+              DBIterator<SekundaereBeitragsgruppe> itSekundaer = Einstellungen
+                  .getDBService().createList(SekundaereBeitragsgruppe.class);
+              itSekundaer.addFilter("mitglied = ?", m.getID());
+              itSekundaer.addFilter("beitragsgruppe = ? ", bg.getID());
+              if (itSekundaer.hasNext())
+              {
+                sekundaer = itSekundaer.next();
+              }
+            }
+            if (inhalt.length() != 0 && !inhalt.equalsIgnoreCase("false")
+                && !inhalt.equalsIgnoreCase("nein") && sekundaer == null)
+            {
+              sekundaer = (SekundaereBeitragsgruppe) Einstellungen
                   .getDBService()
                   .createObject(SekundaereBeitragsgruppe.class, null);
               sekundaer.setMitglied(Integer.parseInt(m.getID()));
               sekundaer.setBeitragsgruppe(Integer.parseInt(bg.getID()));
               sekundaer.store();
             }
+            // Ggf. vorhandene Sekundäre Beitragsgruppe entfernen
+            else if (id != null)
+            {
+              sekundaer.delete();
+            }
           }
         }
-
-        monitor.setPercentComplete(10 + (anz * 10));
-        monitor.setStatusText(String.format("Mitglied %s importiert.",
-            Adressaufbereitung.getNameVorname(m)));
+        String text = "";
+        if (id == null)
+        {
+          text = "Mitglied %s importiert.";
+        }
+        else
+        {
+          text = "Mitglied %s geändert.";
+        }
+        monitor.setPercentComplete(100);
+        monitor.setStatusText(
+            String.format(text, Adressaufbereitung.getNameVorname(m)));
       }
       results.close();
       stmt.close();


### PR DESCRIPTION
Ich habe den Mitgelider Import so erweitert, dass auch die Daten von bereits existierenden Mitgliedern geändert werden können. Dazu muss in der Importdatei die Spalte `id` hinzugefügt werden. Dann werden alle angegebenen Felder bei dem entsprechenden Mitglied geändert, ggf. auch geleert oder gelöscht. Es gibt dann keine Pflichtspalten, es kann also zB. auch nur eine Eigenschaft importiert werden.
```
id;eigenschaft_vorstand;
3;0;
5;1;
8;1;
```