### PR TITLE
Steuer auch In Zusatzbeträgen und Beitragsgruppen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -54,6 +54,7 @@ import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.IBANInput;
 import de.jost_net.JVerein.gui.input.KontoauswahlInput;
 import de.jost_net.JVerein.gui.input.SollbuchungAuswahlInput;
+import de.jost_net.JVerein.gui.input.SteuerInput;
 import de.jost_net.JVerein.gui.menu.BuchungMenu;
 import de.jost_net.JVerein.gui.menu.SplitBuchungMenu;
 import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
@@ -917,25 +918,8 @@ public class BuchungsControl extends AbstractControl
     {
       return steuer;
     }
-    DBIterator<Steuer> it = Einstellungen.getDBService()
-        .createList(Steuer.class);
-    String steuerId = "0";
-    if (getBuchung().getSteuer() != null)
-    {
-      steuerId = getBuchung().getSteuer().getID();
-    }
-    String steuerBuchunsartId = "0";
-    if (getBuchung().getBuchungsart() != null
-        && getBuchung().getBuchungsart().getSteuer() != null)
-    {
-      steuerBuchunsartId = getBuchung().getBuchungsart().getSteuer().getID();
-    }
-    it.addFilter("aktiv = true or id = ? or id = ?", steuerId,
-        steuerBuchunsartId);
 
-    steuer = new SelectInput(PseudoIterator.asList(it),
-        getBuchung().getSteuer());
-
+    steuer = new SteuerInput(getBuchung().getSteuer());
     steuer.setAttribute("name");
     steuer.setPleaseChoose("Keine Steuer");
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -31,6 +31,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
+import de.jost_net.JVerein.gui.input.SteuerInput;
 import de.jost_net.JVerein.gui.menu.BuchungsartMenu;
 import de.jost_net.JVerein.gui.view.BuchungsartDetailView;
 import de.jost_net.JVerein.io.FileViewer;
@@ -211,13 +212,7 @@ public class BuchungsartControl extends FilterControl
     {
       return steuer;
     }
-    DBIterator<Steuer> it = Einstellungen.getDBService()
-        .createList(Steuer.class);
-    it.addFilter("aktiv = true or id = ?",
-        (getBuchungsart().getSteuer() == null ? 0
-            : getBuchungsart().getSteuer().getID()));
-    steuer = new SelectInput(PseudoIterator.asList(it),
-        getBuchungsart().getSteuer());
+    steuer = new SteuerInput(getBuchungsart().getSteuer());
 
     steuer.setAttribute("name");
     steuer.setPleaseChoose("Keine Steuer");

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2518,8 +2518,9 @@ public class EinstellungControl extends AbstractControl
         dialog.setTitle("Migration Steuer in Buchung");
 
         dialog.setText("Soll die Steuer aus den Buchungsarten in die\n"
-            + "Buchungen und Sollbuchungspositionen übernommen werden?\n"
-            + "Das wird für alle bisherigen Buchungen und Sollbuchungspositionen gemacht,\n"
+            + "Buchungen, Sollbuchungspositionen, Zusatzbeträge und Beitragsgruppen\n"
+            + "übernommen werden?\n"
+            + "Das wird für alle bisherigen Einträge gemacht,\n"
             + "so dass die bisherige Steuer erhalten bleibt.");
         try
         {
@@ -2527,7 +2528,7 @@ public class EinstellungControl extends AbstractControl
           {
             int anzahl = SteuerUtil.setSteuerToBuchung();
             successText = "Steuer in " + anzahl
-                + " Buchungen und Sollbuchungspositionen übernommen. ";
+                + " Einträgen übernommen. ";
           }
         }
         catch (Exception ex)

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungPositionControl.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Listener;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
+import de.jost_net.JVerein.gui.input.SteuerInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
@@ -33,8 +34,6 @@ import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.rmi.Steuer;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.willuhn.datasource.pseudo.PseudoIterator;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.input.AbstractInput;
@@ -185,13 +184,7 @@ public class SollbuchungPositionControl extends AbstractControl
     {
       return steuer;
     }
-    DBIterator<Steuer> it = Einstellungen.getDBService()
-        .createList(Steuer.class);
-    it.addFilter("aktiv = true or id = ?",
-        (getPosition().getSteuer() == null ? 0
-            : getPosition().getSteuer().getID()));
-    steuer = new SelectInput(PseudoIterator.asList(it),
-        getPosition().getSteuer());
+    steuer = new SteuerInput(getPosition().getSteuer());
 
     steuer.setAttribute("name");
     steuer.setPleaseChoose("Keine Steuer");

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -48,6 +48,7 @@ import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Steuer;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.jost_net.JVerein.util.Dateiname;
@@ -65,6 +66,7 @@ import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
 import de.willuhn.jameica.system.Application;
@@ -203,6 +205,10 @@ public class ZusatzbetragControl extends AbstractControl
     z.setBetrag((Double) getZusatzbetragPart().getBetrag().getValue());
     z.setZahlungsweg(
         (Zahlungsweg) getZusatzbetragPart().getZahlungsweg().getValue());
+    if (getZusatzbetragPart().isSteuerActive())
+    {
+      z.setSteuer((Steuer) getZusatzbetragPart().getSteuer().getValue());
+    }
   }
 
   public void handleStore() throws ApplicationException
@@ -241,6 +247,10 @@ public class ZusatzbetragControl extends AbstractControl
         zv.setBuchungsart(z.getBuchungsart());
         zv.setBuchungsklasseId(z.getBuchungsklasseId());
         zv.setZahlungsweg(z.getZahlungsweg());
+        if (getZusatzbetragPart().isSteuerActive())
+        {
+          zv.setSteuer(z.getSteuer());
+        }
         zv.store();
       }
     }
@@ -288,6 +298,24 @@ public class ZusatzbetragControl extends AbstractControl
       }
       zusatzbetraegeList.addColumn("Buchungsart", "buchungsart",
           new BuchungsartFormatter());
+      if (Einstellungen.getEinstellung().getSteuerInBuchung())
+      {
+        zusatzbetraegeList.addColumn("Steuer", "steuer", o -> {
+          if (o == null)
+          {
+            return "";
+          }
+          try
+          {
+            return ((Steuer) o).getName();
+          }
+          catch (RemoteException e)
+          {
+            Logger.error("Fehler", e);
+          }
+          return "";
+        }, false, Column.ALIGN_RIGHT);
+      }
       zusatzbetraegeList
           .setContextMenu(new ZusatzbetraegeMenu(zusatzbetraegeList));
       zusatzbetraegeList.setRememberColWidths(true);

--- a/src/de/jost_net/JVerein/gui/dialogs/ImportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ImportDialog.java
@@ -234,6 +234,7 @@ public class ImportDialog extends AbstractDialog<Object>
         }
         catch (ApplicationException ae)
         {
+          monitor.setStatus(ProgressMonitor.STATUS_ERROR);
           GUI.getStatusBar().setErrorText(ae.getMessage());
           throw ae;
         }

--- a/src/de/jost_net/JVerein/gui/input/SteuerInput.java
+++ b/src/de/jost_net/JVerein/gui/input/SteuerInput.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.input;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.rmi.Steuer;
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.input.SelectInput;
+
+/**
+ * Combo-Box, fuer die Auswahl der Steuer
+ */
+public class SteuerInput extends SelectInput
+{
+
+  /**
+   * Steuer Select Input
+   * 
+   * @param def
+   *          die vorausgewählte Steuer
+   * @throws RemoteException
+   */
+  public SteuerInput(Steuer def) throws RemoteException
+  {
+    super(init(def) != null ? PseudoIterator.asList(init(def)) : null, def);
+  }
+
+  /**
+   * @return initialisiert die Liste der Optionen.
+   * @param def
+   *          Die Vorausgewählte Steuer (Wird immer angezeigt, auch wen inaktiv)
+   * @throws RemoteException
+   */
+  private static GenericIterator<Steuer> init(Steuer def) throws RemoteException
+  {
+    DBIterator<Steuer> it = Einstellungen.getDBService()
+        .createList(Steuer.class);
+    if (def == null)
+    {
+      it.addFilter("aktiv = true");
+    }
+    else
+    {
+      it.addFilter("aktiv = true or id = ?", def.getID());
+    }
+
+    return it;
+  }
+}

--- a/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ZusatzbetragPart.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
 import de.jost_net.JVerein.gui.input.BuchungsklasseInput;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
+import de.jost_net.JVerein.gui.input.SteuerInput;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -74,6 +75,8 @@ public class ZusatzbetragPart implements Part
 
   private SelectInput zahlungsweg;
 
+  private SelectInput steuer = null;
+
   public ZusatzbetragPart(Zusatzbetrag zusatzbetrag, boolean mitMitglied)
   {
     this.zusatzbetrag = zusatzbetrag;
@@ -97,6 +100,10 @@ public class ZusatzbetragPart implements Part
     group.addLabelPair("Buchungsart", getBuchungsart());
     if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
       group.addLabelPair("Buchungsklasse", getBuchungsklasse());
+    if (Einstellungen.getEinstellung().getSteuerInBuchung())
+    {
+      group.addLabelPair("Steuer", getSteuer());
+    }
     group.addLabelPair("Zahlungsweg", getZahlungsweg());
   }
 
@@ -288,6 +295,19 @@ public class ZusatzbetragPart implements Part
         }
       }
     });
+    buchungsart.addListener(e -> {
+      if (steuer != null && buchungsart.getValue() != null)
+      {
+        try
+        {
+          steuer.setValue(((Buchungsart) buchungsart.getValue()).getSteuer());
+        }
+        catch (RemoteException e1)
+        {
+          Logger.error("Fehler", e1);
+        }
+      }
+    });
     return buchungsart;
   }
   
@@ -339,6 +359,25 @@ public class ZusatzbetragPart implements Part
     return zahlungsweg;
   }
   
+  public SelectInput getSteuer() throws RemoteException
+  {
+    if (steuer != null)
+    {
+      return steuer;
+    }
+    steuer = new SteuerInput(zusatzbetrag.getSteuer());
+
+    steuer.setAttribute("name");
+    steuer.setPleaseChoose("Keine Steuer");
+
+    return steuer;
+  }
+
+  public boolean isSteuerActive()
+  {
+    return steuer != null;
+  }
+
   public Input getMitglied() throws RemoteException
   {
     if (mitglied != null)

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
@@ -75,6 +75,10 @@ public class BeitragsgruppeDetailView extends AbstractDetailView
     {
       group.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
     }
+    if (Einstellungen.getEinstellung().getSteuerInBuchung())
+    {
+      group.addLabelPair("Steuer", control.getSteuer());
+    }
 
     if(Einstellungen.getEinstellung().getBeitragsmodel() != Beitragsmodel.FLEXIBEL
         && Einstellungen.getEinstellung().getGeburtsdatumPflicht())

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageDetailView.java
@@ -46,6 +46,10 @@ public class ZusatzbetragVorlageDetailView extends AbstractDetailView
     group.addLabelPair("Buchungsart", control.getBuchungsart());
     if (Einstellungen.getEinstellung().getBuchungsklasseInBuchung())
       group.addLabelPair("Buchungsklasse", control.getBuchungsklasse());
+    if (Einstellungen.getEinstellung().getSteuerInBuchung())
+    {
+      group.addLabelPair("Steuer", control.getSteuer());
+    }
     group.addLabelPair("Zahlungsweg", control.getZahlungsweg());
 
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -623,6 +623,10 @@ public class AbrechnungSEPA
         zahler.setVerwendungszweck(bg.getBezeichnung());
       }
       zahler.setName(mZahler.getKontoinhaber(1));
+      if (Einstellungen.getEinstellung().getSteuerInBuchung())
+      {
+        zahler.setSteuer(bg.getSteuer());
+      }
     }
     catch (Exception e)
     {
@@ -722,6 +726,11 @@ public class AbrechnungSEPA
           }
           zahler.setDatum(z.getFaelligkeit());
           zahler.setMitglied(m);
+
+          if (Einstellungen.getEinstellung().getSteuerInBuchung())
+          {
+            zahler.setSteuer(z.getSteuer());
+          }
 
           ArrayList<JVereinZahler> zlist = zahlermap
               .get(zahler.getPersonTyp() + zahler.getPersonId());
@@ -1037,13 +1046,9 @@ public class AbrechnungSEPA
         .createObject(SollbuchungPosition.class, null);
     sp.setBetrag(zahler.getBetrag().doubleValue());
     sp.setBuchungsartId(zahler.getBuchungsartId());
-    // TODO Wir nehmen die Steuer der Buchungsart. Ggf. könnte man zukünftig
-    // auch die Steuer in der Beitragsgruppe und Zusatzbetrag definieren, und
-    // diese hier verwenden.
-    if (zahler.getBuchungsartId() != null
-        && Einstellungen.getEinstellung().getSteuerInBuchung())
+    if (Einstellungen.getEinstellung().getSteuerInBuchung())
     {
-      sp.setSteuer(sp.getBuchungsart().getSteuer());
+      sp.setSteuer(zahler.getSteuer());
     }
     sp.setBuchungsklasseId(zahler.getBuchungsklasseId());
     sp.setDatum(zahler.getDatum());

--- a/src/de/jost_net/JVerein/io/JVereinZahler.java
+++ b/src/de/jost_net/JVerein/io/JVereinZahler.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Steuer;
 import de.jost_net.OBanToo.SEPA.Basislastschrift.Zahler;
 
 public class JVereinZahler extends Zahler
@@ -38,6 +39,8 @@ public class JVereinZahler extends Zahler
   private Date datum;
 
   private Mitglied mitglied;
+
+  private Steuer steuer;
 
   public JVereinZahler()
   {
@@ -113,4 +116,13 @@ public class JVereinZahler extends Zahler
     this.mitglied = mitglied;
   }
 
+  public Steuer getSteuer()
+  {
+    return steuer;
+  }
+
+  public void setSteuer(Steuer steuer)
+  {
+    this.steuer = steuer;
+  }
 }

--- a/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
+++ b/src/de/jost_net/JVerein/rmi/Beitragsgruppe.java
@@ -89,4 +89,7 @@ public interface Beitragsgruppe extends JVereinDBObject
 
   public Altersstaffel getAltersstaffel(int nummer) throws RemoteException;
 
+  public Steuer getSteuer() throws RemoteException;
+
+  void setSteuer(Steuer steuer) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
+++ b/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
@@ -80,4 +80,8 @@ public interface Zusatzbetrag extends JVereinDBObject
   public Zahlungsweg getZahlungsweg() throws RemoteException;
 
   void setZahlungsweg(Zahlungsweg zahlungsweg) throws RemoteException;
+
+  public Steuer getSteuer() throws RemoteException;
+
+  void setSteuer(Steuer steuer) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/rmi/ZusatzbetragVorlage.java
+++ b/src/de/jost_net/JVerein/rmi/ZusatzbetragVorlage.java
@@ -64,4 +64,8 @@ public interface ZusatzbetragVorlage extends DBObject
   public Zahlungsweg getZahlungsweg() throws RemoteException;
 
   public void setZahlungsweg(Zahlungsweg value) throws RemoteException;
+
+  public Steuer getSteuer() throws RemoteException;
+
+  void setSteuer(Steuer steuer) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -24,7 +24,6 @@ import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Steuer;
-import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0476.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0476.java
@@ -1,0 +1,71 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.jost_net.JVerein.server.DDLTool.Index;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0476 extends AbstractDDLUpdate
+{
+  public Update0476(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    // Beitragsgruppe
+    Column colBeitragsgruppe = new Column("steuer", COLTYPE.BIGINT, 10, "null",
+        false, false);
+    execute(addColumn("beitragsgruppe", colBeitragsgruppe));
+
+    Index idxBeitragsgruppe = new Index("ixBeitragsgruppeSteuer", false);
+    idxBeitragsgruppe.add(colBeitragsgruppe);
+    execute(idxBeitragsgruppe.getCreateIndex("beitragsgruppe"));
+
+    execute(createForeignKey("fkBeitragsgruppeSteuer", "beitragsgruppe",
+        "steuer", "steuer", "id", "RESTRICT", "NO ACTION"));
+
+    // Zusatzbetrag
+    Column colZusatzbetrag = new Column("steuer", COLTYPE.BIGINT, 10, "null",
+        false, false);
+    execute(addColumn("zusatzabbuchung", colZusatzbetrag));
+
+    Index idxZusatzbetrag = new Index("ixZusatzbetragSteuer", false);
+    idxZusatzbetrag.add(colZusatzbetrag);
+    execute(idxZusatzbetrag.getCreateIndex("zusatzabbuchung"));
+
+    execute(createForeignKey("fkZusatzbetragSteuer", "zusatzabbuchung",
+        "steuer", "steuer", "id", "RESTRICT", "NO ACTION"));
+
+    // Zusatzbetrag Vorlage
+    Column colZusatzvorlage = new Column("steuer", COLTYPE.BIGINT, 10, "null",
+        false, false);
+    execute(addColumn("zusatzbetragvorlage", colZusatzvorlage));
+
+    Index idxZusatzvorlage = new Index("ixZusatzbetragvorlageSteuer", false);
+    idxZusatzvorlage.add(colZusatzvorlage);
+    execute(idxZusatzvorlage.getCreateIndex("zusatzbetragvorlage"));
+
+    execute(
+        createForeignKey("fkZusatzbetragvorlageSteuer", "zusatzbetragvorlage",
+        "steuer", "steuer", "id", "RESTRICT", "NO ACTION"));
+  }
+}

--- a/src/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
@@ -26,7 +26,6 @@ import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.rmi.Steuer;
-import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -20,11 +20,13 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Steuer;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.util.Datum;
 import de.willuhn.logging.Logger;
@@ -121,6 +123,33 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
         {
           throw new ApplicationException(
               "Beim Mitglied ist keine IBAN oder Mandatdatum hinterlegt.");
+        }
+      }
+      if (Einstellungen.getEinstellung().getSteuerInBuchung())
+      {
+        if (getSteuer() != null && getBuchungsart() != null && getSteuer()
+            .getBuchungsart().getArt() != getBuchungsart().getArt())
+        {
+          switch (getBuchungsart().getArt())
+          {
+            case ArtBuchungsart.AUSGABE:
+              throw new ApplicationException(
+                  "Umsatzsteuer statt Vorsteuer gewählt.");
+            case ArtBuchungsart.EINNAHME:
+              throw new ApplicationException(
+                  "Vorsteuer statt Umsatzsteuer gewählt.");
+            // Umbuchung ist bei Anlagebuchungen möglich,
+            // Hier ist eine Vorsteuer (Kauf) und Umsatzsteuer (Verkauf) möglich
+            case ArtBuchungsart.UMBUCHUNG:
+              break;
+          }
+        }
+        if (getSteuer() != null && getBuchungsart() != null
+            && (getBuchungsart().getSpende()
+                || getBuchungsart().getAbschreibung()))
+        {
+          throw new ApplicationException(
+              "Bei Spenden und Abschreibungen ist keine Steuer möglich.");
         }
       }
     }
@@ -332,6 +361,10 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
     {
       return getBuchungsklasse();
     }
+    if (fieldName.equals("steuer"))
+    {
+      return getSteuer();
+    }
     return super.getAttribute(fieldName);
   }
 
@@ -445,5 +478,24 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
     {
       setAttribute("zahlungsweg", zahlungsweg.getKey());
     }
+  }
+
+  @Override
+  public Steuer getSteuer() throws RemoteException
+  {
+    Object l = (Object) super.getAttribute("steuer");
+    if (l == null)
+    {
+      return null; // Keine Steuer zugeordnet
+    }
+
+    Cache cache = Cache.get(Steuer.class, true);
+    return (Steuer) cache.get(l);
+  }
+
+  @Override
+  public void setSteuer(Steuer steuer) throws RemoteException
+  {
+    setAttribute("steuer", steuer);
   }
 }

--- a/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragVorlageImpl.java
@@ -19,10 +19,13 @@ package de.jost_net.JVerein.server;
 import java.rmi.RemoteException;
 import java.util.Date;
 
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.IntervallZusatzzahlung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.jost_net.JVerein.rmi.Steuer;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.willuhn.datasource.db.AbstractDBObject;
 import de.willuhn.logging.Logger;
@@ -73,6 +76,33 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject
       if (getBetrag() <= 0)
       {
         throw new ApplicationException("Betrag nicht gültig");
+      }
+      if (Einstellungen.getEinstellung().getSteuerInBuchung())
+      {
+        if (getSteuer() != null && getBuchungsart() != null && getSteuer()
+            .getBuchungsart().getArt() != getBuchungsart().getArt())
+        {
+          switch (getBuchungsart().getArt())
+          {
+            case ArtBuchungsart.AUSGABE:
+              throw new ApplicationException(
+                  "Umsatzsteuer statt Vorsteuer gewählt.");
+            case ArtBuchungsart.EINNAHME:
+              throw new ApplicationException(
+                  "Vorsteuer statt Umsatzsteuer gewählt.");
+            // Umbuchung ist bei Anlagebuchungen möglich,
+            // Hier ist eine Vorsteuer (Kauf) und Umsatzsteuer (Verkauf) möglich
+            case ArtBuchungsart.UMBUCHUNG:
+              break;
+          }
+        }
+        if (getSteuer() != null && getBuchungsart() != null
+            && (getBuchungsart().getSpende()
+                || getBuchungsart().getAbschreibung()))
+        {
+          throw new ApplicationException(
+              "Bei Spenden und Abschreibungen ist keine Steuer möglich.");
+        }
       }
     }
     catch (RemoteException e)
@@ -230,6 +260,10 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject
     {
       return getBuchungsklasse();
     }
+    if (fieldName.equals("steuer"))
+    {
+      return getSteuer();
+    }
     return super.getAttribute(fieldName);
   }
 
@@ -255,5 +289,24 @@ public class ZusatzbetragVorlageImpl extends AbstractDBObject
     {
       setAttribute("zahlungsweg", zahlungsweg.getKey());
     }
+  }
+
+  @Override
+  public Steuer getSteuer() throws RemoteException
+  {
+    Object l = (Object) super.getAttribute("steuer");
+    if (l == null)
+    {
+      return null; // Keine Steuer zugeordnet
+    }
+
+    Cache cache = Cache.get(Steuer.class, true);
+    return (Steuer) cache.get(l);
+  }
+
+  @Override
+  public void setSteuer(Steuer steuer) throws RemoteException
+  {
+    setAttribute("steuer", steuer);
   }
 }

--- a/src/de/jost_net/JVerein/util/SteuerUtil.java
+++ b/src/de/jost_net/JVerein/util/SteuerUtil.java
@@ -32,6 +32,7 @@ public class SteuerUtil
   public static int setSteuerToBuchung() throws RemoteException
   {
     // Nur Buchungen auf Geldkonten können Steuern haben
+    // Buchungen
     String sql = "update buchung "
         + "set steuer = (select buchungsart.steuer from buchungsart "
         + "where buchung.buchungsart = buchungsart.id) "
@@ -43,6 +44,7 @@ public class SteuerUtil
 
     int anzahlBuchungen = Einstellungen.getDBService().executeUpdate(sql, null);
 
+    // Sollbuchungspositionen
     sql = "update sollbuchungposition "
         + "set steuer = (select buchungsart.steuer from buchungsart "
         + "where sollbuchungposition.buchungsart = buchungsart.id) "
@@ -53,6 +55,40 @@ public class SteuerUtil
     int anzahlSollbuchungpositionen = Einstellungen.getDBService()
         .executeUpdate(sql, null);
 
-    return anzahlBuchungen + anzahlSollbuchungpositionen;
+    // Zusatzbeträge
+    sql = "update zusatzabbuchung "
+        + "set steuer = (select buchungsart.steuer from buchungsart "
+        + "where zusatzabbuchung.buchungsart = buchungsart.id) "
+        + "where exists (select id from buchungsart where buchungsart.id = zusatzabbuchung.buchungsart "
+        + "and steuer is not null)"
+        + "and buchungsart is not null and steuer is null";
+
+    int anzahlZusatzbetraege = Einstellungen.getDBService().executeUpdate(sql,
+        null);
+
+    // Zusatzbeträge-Vorlagen
+    sql = "update zusatzbetragvorlage "
+        + "set steuer = (select buchungsart.steuer from buchungsart "
+        + "where zusatzbetragvorlage.buchungsart = buchungsart.id) "
+        + "where exists (select id from buchungsart where buchungsart.id = zusatzbetragvorlage.buchungsart "
+        + "and steuer is not null)"
+        + "and buchungsart is not null and steuer is null";
+
+    int anzahlZusatzbetraegeVorlagen = Einstellungen.getDBService()
+        .executeUpdate(sql, null);
+
+    // Beitragsgruppen
+    sql = "update beitragsgruppe "
+        + "set steuer = (select buchungsart.steuer from buchungsart "
+        + "where beitragsgruppe.buchungsart = buchungsart.id) "
+        + "where exists (select id from buchungsart where buchungsart.id = beitragsgruppe.buchungsart "
+        + "and steuer is not null)"
+        + "and buchungsart is not null and steuer is null";
+
+    int anzahlZusatzbeträge = Einstellungen.getDBService().executeUpdate(sql,
+        null);
+
+    return anzahlBuchungen + anzahlSollbuchungpositionen + anzahlZusatzbetraege
+        + anzahlZusatzbetraegeVorlagen + anzahlZusatzbeträge;
   }
 }


### PR DESCRIPTION
Hier habe ich das steuerfeld auch bei Zusatzbeträgen, Zusatzbetrag-Vorlagen und Beitragsgruppen hinzugefügt. So kann, wenn "Steuer-in-Buchung" aktiviert ist, schon im Zusatzbetrag festgelegt werden, welche Steuer dieser Betrag haben soll.
Um Doppelten Code zu vermeiden habe ich einen SteuerInut eingeführt.
Das Errorhandling in DefaultZusatzbetraegeImport war etwas merkwürdig, das habe ich verbessert.