### PR TITLE
Speichern bei verlassen bei neuen Objekten

### DIFF
--- a/src/de/jost_net/JVerein/server/AbstractJVereinDBObject.java
+++ b/src/de/jost_net/JVerein/server/AbstractJVereinDBObject.java
@@ -21,6 +21,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.rmi.JVereinDBObject;
 import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.util.ApplicationException;
 
 /**
  * Basis-Code fuer alle DB-Klassen in JVerein.
@@ -56,5 +57,23 @@ public abstract class AbstractJVereinDBObject extends AbstractDBObject
   public boolean isChanged() throws RemoteException
   {
     return hasChanged();
+  }
+
+  @Override
+  public void store() throws RemoteException, ApplicationException
+  {
+    if (isNewObject())
+    {
+      super.store();
+      // Das ist hier nötig, da AbstractDBObject blöderweise die Properties beim
+      // Insert nicht in der Map speichert und somit keine Änderungsüberwachnung
+      // möglich ist. Wir laden das Object einfach neu aus der DB dabei wird die
+      // Map gefüllt.
+      load(getID());
+    }
+    else
+    {
+      super.store();
+    }
   }
 }


### PR DESCRIPTION
Momentan funktioniert der Test ob das Objekt vor dem Verlassen gespeichert wurde bei neuen Objekten nicht, hier wird immer die Meldung angezeigt.
Das liegt daran, dass in `AbstractDBObject` leider die `origProperties` nicht beim `insert` gefüllt wird  (nur bei `update` und `fill`) . @willuhn könnte man das noch einbauen, oder ist das absichtlich nicht da drin?
Als Workaround hab ich es jetzt so gemacht, dass beim speichern eines neuen Objekts dieses sofort aus der Datenbank gelesen wird, dann wird die Map gefüllt und die Speichern-Abfrage funktioniert.