### PR TITLE
MySQL Transaction Isonlation Level fehler behoben

### DIFF
--- a/src/de/jost_net/JVerein/server/JVereinDBServiceImpl.java
+++ b/src/de/jost_net/JVerein/server/JVereinDBServiceImpl.java
@@ -87,6 +87,14 @@ public class JVereinDBServiceImpl extends DBServiceImpl implements
     return SETTINGS.getBoolean("autocommit", super.getAutoCommit());
   }
 
+  /**
+   * @see de.willuhn.datasource.db.DBServiceImpl#getTransactionIsolationLevel()
+   */
+  protected int getTransactionIsolationLevel() throws RemoteException
+  {
+    return this.driver.getTransactionIsolationLevel();
+  }
+
   @Override
   protected String getJdbcDriver()
   {


### PR DESCRIPTION
Bei der Verwendung von MySQL/MariaDB wurden Änderungen die von einem anderen Programm an der DB gemacht wurden erst bei einem neustart von Jameica gelesen. Eigentlich war der Code dafür schon da, es hat nur in `JVereinDBServiceImpl.java` das überschreiben der Funktion gefehlt, damit die Einstellung auch aus `DBSupportMySqlImpl` gelesen wir.