### PR TITLE
Salden Buchungsartformatter, Sortierung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.AnlagenverzeichnisCSV;
 import de.jost_net.JVerein.io.AnlagenverzeichnisPDF;
 import de.jost_net.JVerein.io.ISaldoExport;
+import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.KontoImpl;
@@ -131,13 +132,46 @@ public class AnlagenlisteControl extends AbstractSaldoControl
   {
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("konto");
 
-    it.addColumn("buchungsart.bezeichnung AS " + BUCHUNGSART);
-    it.addColumn("buchungsklasse.bezeichnung AS " + BUCHUNGSKLASSE);
+    switch (Einstellungen.getEinstellung().getBuchungsartSort())
+    {
+      case BuchungsartSort.NACH_NUMMER:
+        it.addColumn(
+            "CONCAT(buchungsart.nummer,' - ',buchungsart.bezeichnung) as "
+                + BUCHUNGSART);
+        it.addColumn(
+            "CONCAT(buchungsklasse.nummer,' - ',buchungsklasse.bezeichnung) as "
+                + BUCHUNGSKLASSE);
+        it.addColumn(
+            "CONCAT(afaart.nummer,' - ',afaart.bezeichnung) as " + AFAART);
+        it.setOrder(
+            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC, konto.nummer");
+        break;
+      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        it.addColumn(
+            "CONCAT(buchungsart.bezeichnung,' (',buchungsart.nummer,')') as "
+                + BUCHUNGSART);
+        it.addColumn(
+            "CONCAT(buchungsklasse.bezeichnung,' (',buchungsklasse.nummer,')') as "
+                + BUCHUNGSKLASSE);
+        it.addColumn(
+            "CONCAT(afaart.bezeichnung,' (',afaart.nummer,')') as " + AFAART);
+        it.setOrder(
+            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.nummer");
+        break;
+      default:
+        it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
+        it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
+        it.addColumn("afaart.bezeichnung as " + AFAART);
+        it.setOrder(
+            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.nummer");
+        break;
+    }
     it.addColumn("konto.bezeichnung AS " + KONTO);
     it.addColumn("konto.id AS " + KONTO_ID);
     it.addColumn("konto.nutzungsdauer AS " + NUTZUNGSDAUER);
     it.addColumn("konto.anschaffung AS " + ANSCHAFFUNG_DATUM);
-    it.addColumn("afaart.bezeichnung AS " + AFAART);
     it.addColumn("konto.betrag AS " + BETRAG);
 
     it.addColumn(
@@ -169,9 +203,6 @@ public class AnlagenlisteControl extends AbstractSaldoControl
     it.addGroupBy("konto.id");
     it.addGroupBy("konto.anlagenart");
     it.addGroupBy("konto.anlagenklasse");
-
-    it.setOrder(
-        "ORDER BY buchungsklasse.nummer, buchungsart.nummer, konto.nummer");
 
     return it;
   }

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -144,7 +144,7 @@ public class AnlagenlisteControl extends AbstractSaldoControl
         it.addColumn(
             "CONCAT(afaart.nummer,' - ',afaart.bezeichnung) as " + AFAART);
         it.setOrder(
-            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC, konto.nummer");
+            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC, konto.anschaffung");
         break;
       case BuchungsartSort.NACH_BEZEICHNUNG_NR:
         it.addColumn(
@@ -157,7 +157,7 @@ public class AnlagenlisteControl extends AbstractSaldoControl
             "CONCAT(afaart.bezeichnung,' (',afaart.nummer,')') as " + AFAART);
         it.setOrder(
             "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.nummer");
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.anschaffung");
         break;
       default:
         it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
@@ -165,7 +165,7 @@ public class AnlagenlisteControl extends AbstractSaldoControl
         it.addColumn("afaart.bezeichnung as " + AFAART);
         it.setOrder(
             "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.nummer");
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.anschaffung");
         break;
     }
     it.addColumn("konto.bezeichnung AS " + KONTO);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.io.BuchungsklassesaldoCSV;
 import de.jost_net.JVerein.io.BuchungsklassesaldoPDF;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.StatusBuchungsart;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
@@ -357,8 +358,37 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
 
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
         "buchungsart");
-    it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
-    it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
+    switch (Einstellungen.getEinstellung().getBuchungsartSort())
+    {
+      case BuchungsartSort.NACH_NUMMER:
+        it.addColumn(
+            "CONCAT(buchungsart.nummer,' - ',buchungsart.bezeichnung) as "
+                + BUCHUNGSART);
+        it.addColumn(
+            "CONCAT(buchungsklasse.nummer,' - ',buchungsklasse.bezeichnung) as "
+                + BUCHUNGSKLASSE);
+        it.setOrder(
+            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC ");
+        break;
+      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        it.addColumn(
+            "CONCAT(buchungsart.bezeichnung,' (',buchungsart.nummer,')') as "
+                + BUCHUNGSART);
+        it.addColumn(
+            "CONCAT(buchungsklasse.bezeichnung,' (',buchungsklasse.nummer,')') as "
+                + BUCHUNGSKLASSE);
+        it.setOrder(
+            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung ");
+        break;
+      default:
+        it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
+        it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
+        it.setOrder(
+            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung ");
+        break;
+    }
     it.addColumn("buchungsart.art as " + ARTBUCHUNGSART);
     it.addColumn("COUNT(buchung.id) as " + ANZAHL);
     it.addColumn("buchungsart.status");
@@ -423,8 +453,6 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           "anzahl > 0 OR abs(" + SUMME + ") >= 0.01 OR buchungsart.status != ?",
           StatusBuchungsart.INACTIVE);
     }
-    it.setOrder(
-        "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC ");
 
     // Für die Steuerbträge auf der Steuerbuchungsart machen wir ein Subselect
     if (mitSteuer)

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -194,7 +194,7 @@ public class KontensaldoControl extends AbstractSaldoControl
     it.addGroupBy("konto.id");
     it.addGroupBy("konto.kontoart");
 
-    it.setOrder("ORDER BY konto.bezeichnung");
+    it.setOrder("ORDER BY konto.nummer");
 
     return it;
   }

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -17,6 +17,9 @@
 package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.willuhn.jameica.gui.AbstractView;
@@ -47,7 +50,19 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
        on += " OR projekt.id = st.projekt";
      }
      it.join("projekt", on);
-     it.setOrder("ORDER BY projekt.bezeichnung, -buchungsart.nummer DESC ");
+
+     switch (Einstellungen.getEinstellung().getBuchungsartSort())
+     {
+       case BuchungsartSort.NACH_NUMMER:
+         it.setOrder("ORDER BY projekt.bezeichnung, -buchungsart.nummer DESC ");
+         break;
+       case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+       default:
+         it.setOrder(
+             "ORDER BY projekt.bezeichnung, buchungsart.bezeichnung is NUll,"
+                 + "buchungsart.bezeichnung ");
+         break;
+     }
      return it;
    }
 

--- a/src/de/jost_net/JVerein/gui/control/SteuerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SteuerControl.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.menu.SteuerMenue;
@@ -86,7 +87,8 @@ public class SteuerControl extends AbstractControl implements Savable
             return (Double) o + "%";
           }, false,
           Column.ALIGN_RIGHT);
-      steuerList.addColumn("Buchungsart", "buchungsart");
+      steuerList.addColumn("Buchungsart", "buchungsart",
+          new BuchungsartFormatter());
       steuerList.addColumn("Aktiv", "aktiv", new JaNeinFormatter());
       steuerList.setContextMenu(new SteuerMenue());
       steuerList.setRememberColWidths(true);


### PR DESCRIPTION
Hierdurch werden die Buchungsart und Buchungsklasse auch in den Salden angezeigt und sortiert wie es in den Einstellungen festgelegt wurde.
Bei Buchungsart und Buchungsklasse ist die Nummer eine Zahl, d.h. dass aktuell keine führenden Nullen verwendet werden können, ich frage mich, ob wir das nicht ändern sollten, da in vielen Kontorahmen führende nullen vorgesehen sind. Das würde dann aber für die Sortierung bedeuten, dass auch alphabetisch und nicht mehr nummerisch sortiert würde (zB. 10,110,20...).
Bei Konten ist die Nummer ein String, hier sortiere ich jetzt auch nach Nummer, es wird also auch alphabetisch sortiert.
Im Anlageverzeichnis sortiere ich jetzt nach dem Anschaffungsdatum.

In der Steuerliste hatte ich den BuchungsartFormatter vergessen, das habe ich hier noch nachgeholt.