### PR TITLE
Salden Formattieren

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.SaldoFormatter;
 import de.jost_net.JVerein.io.AnlagenverzeichnisCSV;
 import de.jost_net.JVerein.io.AnlagenverzeichnisPDF;
 import de.jost_net.JVerein.io.ISaldoExport;
@@ -117,6 +118,7 @@ public class AnlagenlisteControl extends AbstractSaldoControl
           Column.ALIGN_LEFT);
       saldoList.setRememberColWidths(true);
       saldoList.removeFeature(FeatureSummary.class);
+      saldoList.setFormatter(new SaldoFormatter());
       return saldoList;
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.SaldoFormatter;
 import de.jost_net.JVerein.gui.parts.SaldoListTablePart;
 import de.jost_net.JVerein.io.BuchungsklassesaldoCSV;
 import de.jost_net.JVerein.io.BuchungsklassesaldoPDF;
@@ -117,6 +119,8 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       saldoList.setRememberOrder(true);
       saldoList.setRememberState(true);
       saldoList.addFeature(new FeatureSummary());
+      saldoList.setFormatter(new SaldoFormatter());
+
       return saldoList;
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.SaldoFormatter;
 import de.jost_net.JVerein.gui.parts.SaldoListTablePart;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.io.KontenSaldoCSV;
@@ -96,6 +97,7 @@ public class KontensaldoControl extends AbstractSaldoControl
       saldoList.setRememberColWidths(true);
       saldoList.setMulti(true);
       saldoList.addFeature(new FeatureSummary());
+      saldoList.setFormatter(new SaldoFormatter());
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/formatter/SaldoFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/SaldoFormatter.java
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.formatter;
+
+import java.rmi.RemoteException;
+
+import org.eclipse.swt.widgets.TableItem;
+
+import de.jost_net.JVerein.gui.control.AbstractSaldoControl;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.willuhn.jameica.gui.formatter.TableFormatter;
+import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.Font;
+import de.willuhn.logging.Logger;
+
+public class SaldoFormatter implements TableFormatter
+{
+  @Override
+  public void format(TableItem item)
+  {
+    if (item == null)
+      return;
+    try
+    {
+      PseudoDBObject o = (PseudoDBObject) item.getData();
+      if (o == null || o.getAttribute(AbstractSaldoControl.ART) == null)
+        return;
+
+      switch ((Integer) o.getAttribute(AbstractSaldoControl.ART))
+      {
+        case AbstractSaldoControl.ART_HEADER:
+          item.setBackground(Color.COMMENT.getSWTColor());
+          break;
+        case AbstractSaldoControl.ART_SALDOFOOTER:
+        case AbstractSaldoControl.ART_SALDOGEWINNVERLUST:
+        case AbstractSaldoControl.ART_GESAMTSALDOFOOTER:
+        case AbstractSaldoControl.ART_GESAMTGEWINNVERLUST:
+          item.setFont(Font.BOLD.getSWTFont());
+          break;
+        case AbstractSaldoControl.ART_NICHTZUGEORDNETEBUCHUNGEN:
+          item.setFont(Font.ITALIC.getSWTFont());
+          break;
+        case AbstractSaldoControl.ART_DETAIL:
+        case AbstractSaldoControl.ART_LEERZEILE:
+          break;
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler beim Formattieren des Saldos", e);
+    }
+  }
+}


### PR DESCRIPTION
Ich habe einen Formatter für die Salden hinzugefügt, damit es leichter ersichtlich ist, was Summen etc. sind. 
![Bildschirmfoto zu 2025-06-21 12-01-09](https://github.com/user-attachments/assets/b951bfad-11f6-4a0a-ba26-3464d1edc8ab)

Ob man wirklich den Header farblich hinterlegen soll, weiß ich nicht, da es je nach System andere Farben sind.