### PR TITLE
Kontoarten fuer Verbindlichkeiten und Forderungen

### DIFF
--- a/src/de/jost_net/JVerein/keys/Kontoart.java
+++ b/src/de/jost_net/JVerein/keys/Kontoart.java
@@ -37,7 +37,9 @@ public enum Kontoart
   RUECKLAGE_ERWERB(107, "Rücklage für Gesellschaftsrechte nach § 62 Abs. 1 Nr. 4 AO"),
   VERMOEGEN(108, "Vermögen nach § 62 Abs. 3 und 4 AO"),
   RUECKLAGE_SONSTIG(109, "Sonstige Rücklagen und Vermögen"),
-  LIMIT_RUECKLAGE(200, "-- Limit Rücklage --");
+  LIMIT_RUECKLAGE(200, "-- Limit Rücklage --"),
+  VERBINDLICHKEITEN(201, "Verbindlichkeiten"),
+  FORDERUNGEN(202, "Forderungen");
 
   private final String text;
 


### PR DESCRIPTION
Mit dem PR führe ich die zwei Kontoarten für Verbindlichkeiten und Forderungen aus #525 ein.
Diese Konten dienen nur zur Dokumentation, sie gehen nicht in das Buchungsklassensaldo ein weil in der einfachen Buchführung das Zuflussprinzip gilt, also immer so gebucht wird wie das Geld auf dem Bankkonto bewegt wird.

Die Konten werden auch für Scenarien wie sie  in #525 angedacht sind benötigt.

Wegen eines falschen Buchung in meiner Vergangenheit die nicht dem Zuflussprinzip entspricht und inzwischen verjährt ist kann ich diese Konten auch brauchen. Da #525 evtl. nicht mehr in die nächste Release kommt habe ich dieses hier vorgezogen.