### PR TITLE
Filter bei Anlagenbuchungen Liste View analog zu Buchungen Liste View

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
@@ -37,7 +37,6 @@ import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.ColumnLayout;
-import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.util.ApplicationException;
@@ -57,9 +56,8 @@ public class AnlagenbuchungListeView extends AbstractView
     folder.setBackground(Color.BACKGROUND.getSWTColor());
 
     // Erster Tab
-    TabGroup tabAllgemein = new TabGroup(folder, "Suche Buchungen", true, 1);
-    LabelGroup labelgroup1 = new LabelGroup(tabAllgemein.getComposite(), "Filter");
-    ColumnLayout cl = new ColumnLayout(labelgroup1.getComposite(), 2);
+    TabGroup tabAllgemein = new TabGroup(folder, "Filter", true, 2);
+    ColumnLayout cl = new ColumnLayout(tabAllgemein.getComposite(), 2);
     SimpleContainer left = new SimpleContainer(cl.getComposite());
     SimpleContainer right = new SimpleContainer(cl.getComposite());
 
@@ -100,16 +98,15 @@ public class AnlagenbuchungListeView extends AbstractView
       }
     }, null, true, "search.png");
     buttons1.addButton(suchen);
-    labelgroup1.addButtonArea(buttons1);
+    tabAllgemein.addButtonArea(buttons1);
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
     // Zweiter Tab
     final BuchungsHeaderControl headerControl = new BuchungsHeaderControl(
         this, control);
-    TabGroup tabKonto = new TabGroup(folder, "Konto Kenndaten", true, 1);
-    LabelGroup labelgroup2 = new LabelGroup(tabKonto.getComposite(), "");
-    ColumnLayout c2 = new ColumnLayout(labelgroup2.getComposite(), 2);
+    TabGroup tabKonto = new TabGroup(folder, "Konto Kenndaten", true, 4);
+    ColumnLayout c2 = new ColumnLayout(tabKonto.getComposite(), 2);
     SimpleContainer left2 = new SimpleContainer(c2.getComposite());
     SimpleContainer right2 = new SimpleContainer(c2.getComposite());
     left2.addLabelPair("Konto:", headerControl.getKontoNameInput());


### PR DESCRIPTION
Ich hatte vor einiger Zeit den Filter Bereich der Buchungen Liste View überarbeitet, dies aber beim Anlagenbuchungen Liste View übersehen.
In diesem View habe ich den Filter Bereich jetzt analog zum Buchungen Liste View implementiert. Damit haben sie das gleiche Aussehen.

Das betrifft die Tabs und Rahmen:
Alt:
![Bildschirmfoto_20250701_111610](https://github.com/user-attachments/assets/5eaccb76-74ac-4b44-9a34-af681026a530)
Neu:
![Bildschirmfoto_20250701_111706](https://github.com/user-attachments/assets/cca1a048-7be8-455c-ac28-f6282af3cdb2)
