### PR TITLE
Workaround für bsh Fehler #811

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,6 @@
       <version>1.1.1</version>
     </dependency>
     <dependency>
-      <groupId>org.beanshell</groupId>
-      <artifactId>bsh-core</artifactId>
-      <version>2.0b4</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.zxing</groupId>
       <artifactId>core</artifactId>
       <version>3.5.3</version>


### PR DESCRIPTION
Der PR ist ein aktueller Workaround für #811.
Ich habe die bsh-core aus dem pom.xml entfernt weil wir ja eine neuere Version im git haben. Dadurch wird verhindert, dass noch eine zweite bsh-core hinzugefügt wird.

Wenn es eine Lösung gibt die Version 3 über das pom.xml zu generieren kann diese wieder hier aufgenommen werden und dafür die in unserem GIT gelöscht werden.

Ohne diesem PR funktionieren unsere Produktionen z.B. Nightlies nicht.