### PR TITLE
BSH korrigiert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ bin
 bin.test
 releases
 lib
+!lib/bsh-3.0.0-20230205.094654-3.jar
+!lib/nc.jar
 lib.test
 lib.src
 nbproject/private/

--- a/build/build.xml
+++ b/build/build.xml
@@ -45,6 +45,7 @@
       <path refid="cp" />
       <fileset dir="${lib.dir}">
         <include name="nc.jar" />
+        <include name="bsh-3.0.0-20230205.094654-3.jar" />
       </fileset>
       <fileset dir="../hibiscus/lib">
         <include name="**/*.jar" />
@@ -169,6 +170,7 @@
     <delete includeemptydirs="true">
       <fileset dir="${lib.dir}">
         <exclude name="nc.jar" />
+        <exclude name="bsh-3.0.0-20230205.094654-3.jar" />
       </fileset>
     </delete>
     <delete dir="lib.test" />


### PR DESCRIPTION
Die Korrektur von BSH hatte noch nicht geklappt, da auch die neue Version nicht enthalten ist.