### PR TITLE
Fix Differenz Limit bei Kontoauszug

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
@@ -71,6 +71,7 @@ public class KontoauszugMailView extends AbstractView
       ColumnLayout cl = new ColumnLayout(group.getComposite(), 2);
       SimpleContainer left = new SimpleContainer(cl.getComposite());
       left.addInput(control.getDifferenz());
+      left.addLabelPair("Differenz Limit", control.getDoubleAusw());
 
       SimpleContainer right = new SimpleContainer(cl.getComposite());
       right.addInput(control.getDatumvon());


### PR DESCRIPTION
Wurde die Generierung der Kontoauszüge über das Kontextmenü der Mitglieder gestartet, dann fehlte im Kontoauszug Mail View das Filter Feld für das Differenz Limit.