### PR TITLE
Dokument Spalte bei Mitglieder und Nicht-Mitglieder

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -1405,6 +1405,16 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
         return false;
       }
     }
+    if ("document".equals(fieldName))
+    {
+      DBIterator<MitgliedDokument> list = Einstellungen.getDBService()
+          .createList(MitgliedDokument.class);
+      list.addFilter("referenz = ?", Long.valueOf(getID()));
+      if (list.size() > 0)
+        return list.size();
+      else
+        return "";
+    }
     return super.getAttribute(fieldName);
   }
 

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -62,6 +62,17 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
     {
       //
     }
+    try
+    {
+      if (Einstellungen.getEinstellung().getDokumentenspeicherung())
+      {
+        add("D", "document", false, true);
+      }
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
     add("Anrede", "anrede", false, true);
     add("Titel", "titel", false, true);
     add("Name", "name", true, true);


### PR DESCRIPTION
Wie bei Buchungen schon implementiert wird hier eine Spalte "D" im MitgliederListeView und NichtmitgliederListeView eingefügt welche die Anzahl der bei dem Mitglied hinterlegten Dokumente anzeigt.
Die Spalte ist per default nicht angezeigt und wird nur angeboten wenn Dokumentspeicherung aktiv ist.