### PR TITLE
Vor Zurück Buttons

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -25,6 +25,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.Vector;
@@ -66,6 +67,7 @@ import de.jost_net.JVerein.io.BuchungsjournalPDF;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.AbstractInputAuswahl;
+import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -85,7 +87,7 @@ import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
-import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -120,7 +122,7 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
-public class BuchungsControl extends AbstractControl
+public class BuchungsControl extends VorZurueckControl
     implements Savable
 {
 
@@ -2292,7 +2294,7 @@ public class BuchungsControl extends AbstractControl
     return settingsprefix;
   }
 
-  public ToolTipButton getZurueckButton()
+  public ToolTipButton getTTZurueckButton()
   {
     return new ToolTipButton("", new Action()
     {
@@ -2337,7 +2339,7 @@ public class BuchungsControl extends AbstractControl
     }, null, false, "go-previous.png");
   }
 
-  public ToolTipButton getVorButton()
+  public ToolTipButton getTTVorButton()
   {
     return new ToolTipButton("", new Action()
     {
@@ -2413,4 +2415,27 @@ public class BuchungsControl extends AbstractControl
     }
   }
 
+  @SuppressWarnings("unchecked")
+  public LinkedList<Long> getKontoIds(Kontenfilter art)
+  {
+    try
+    {
+      String sql;
+      final DBService service = Einstellungen.getDBService();
+      switch (art)
+      {
+        case ANLAGEKONTO:
+          sql = "SELECT id FROM konto WHERE kontoart = ?";
+          break;
+        default:
+          sql = "SELECT id FROM konto WHERE kontoart != ?";
+      }
+      return (LinkedList<Long>) service.execute(sql,
+          new Object[] { Kontoart.ANLAGE.getKey() }, rs);
+    }
+    catch (RemoteException e)
+    {
+      return null;
+    }
+  }
 }

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -57,7 +57,6 @@ import de.willuhn.datasource.GenericObjectNode;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.ObjectNotFoundException;
-import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.formatter.TreeFormatter;
@@ -75,7 +74,7 @@ import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public abstract class FilterControl extends AbstractControl
+public abstract class FilterControl extends VorZurueckControl
 {
   public final static String ALLE = "Alle";
 

--- a/src/de/jost_net/JVerein/gui/control/VorZurueckControl.java
+++ b/src/de/jost_net/JVerein/gui/control/VorZurueckControl.java
@@ -1,0 +1,180 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.datasource.rmi.ResultSetExtractor;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.Button;
+
+public class VorZurueckControl extends AbstractControl
+{
+  private Class<? extends AbstractView> viewClass;
+
+  private Class<? extends DBObject> objectClass;
+
+  private LinkedList<Long> objektListe = null;
+
+  public VorZurueckControl(AbstractView view)
+  {
+    super(view);
+    if (view != null)
+    {
+      this.viewClass = view.getClass();
+    }
+  }
+
+  ResultSetExtractor rs = new ResultSetExtractor()
+  {
+    @Override
+    public Object extract(ResultSet rs) throws RemoteException, SQLException
+    {
+      LinkedList<Long> list = new LinkedList<>();
+      while (rs.next())
+      {
+        list.add(rs.getLong(1));
+      }
+      return list;
+    }
+  };
+
+  @SuppressWarnings("unchecked")
+  public void setObjektListe(Class<? extends DBObject> objectClass,
+      String tabelle, String order, String filter, Object objekt)
+  {
+    this.objectClass = objectClass;
+    try
+    {
+      final DBService service = Einstellungen.getDBService();
+
+      String sql = "SELECT id FROM " + tabelle;
+      if (filter != null)
+      {
+        sql += " WHERE " + filter;
+      }
+      if (order != null)
+      {
+        sql += " ORDER BY (" + order + ")";
+      }
+
+      if (objekt == null)
+      {
+        objektListe = (LinkedList<Long>) service.execute(sql, new Object[] {},
+            rs);
+      }
+      else if (filter != null && objekt != null)
+      {
+        objektListe = (LinkedList<Long>) service.execute(sql,
+            new Object[] { objekt }, rs);
+      }
+
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
+  }
+
+  /**
+   * Buttons
+   */
+  public Button getZurueckButton()
+  {
+    Button button = new Button("", context -> {
+      if (objektListe == null || viewClass == null)
+      {
+        return;
+      }
+      DBObject object = (DBObject) getCurrentObject();
+      try
+      {
+        int index = objektListe.indexOf(Long.valueOf(object.getID()));
+        if (index > 0 && index < objektListe.size())
+        {
+          DBObject instanz = Einstellungen.getDBService()
+              .createObject(objectClass, objektListe.get(index - 1).toString());
+          GUI.startView(viewClass, instanz);
+        }
+      }
+      catch (RemoteException e)
+      {
+        //
+      }
+
+    }, null, false, "go-previous.png");
+    try
+    {
+      if (((DBObject) getCurrentObject()).isNewObject())
+      {
+        button.setEnabled(false);
+      }
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
+    return button;
+  }
+
+  public Button getVorButton()
+  {
+    Button button = new Button("", context -> {
+      if (objektListe == null || viewClass == null)
+      {
+        return;
+      }
+      DBObject object = (DBObject) getCurrentObject();
+      try
+      {
+        int index = objektListe.indexOf(Long.valueOf(object.getID()));
+        if (index >= 0 && index < objektListe.size() - 1)
+        {
+          DBObject instanz = Einstellungen.getDBService()
+              .createObject(objectClass, objektListe.get(index + 1).toString());
+          GUI.startView(viewClass, instanz);
+        }
+      }
+      catch (RemoteException e)
+      {
+        //
+      }
+
+    }, null, false, "go-next.png");
+    try
+    {
+      if (((DBObject) getCurrentObject()).isNewObject())
+      {
+        button.setEnabled(false);
+      }
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
+    return button;
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -191,6 +191,20 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIED, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    String filter;
+    if (isMitgliedDetail())
+    {
+      filter = Mitglied.MITGLIEDSTYP + " = 1";
+    }
+    else
+    {
+      filter = Mitglied.MITGLIEDSTYP + " != 1";
+    }
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter
+    control.setObjektListe(Mitglied.class, "mitglied", "name, vorname",
+        filter, null);
     if (!control.getMitglied().isNewObject())
     {
       buttons.addButton(new Button("Kontoauszug", new KontoauszugAction(),

--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
@@ -75,9 +75,9 @@ public class AnlagenbuchungListeView extends AbstractView
     right.addLabelPair("Betrag", control.getSuchBetrag());
     
     ButtonArea buttons1 = new ButtonArea();
-    ToolTipButton zurueck = control.getZurueckButton();
+    ToolTipButton zurueck = control.getTTZurueckButton();
     buttons1.addButton(zurueck);
-    ToolTipButton vor = control.getVorButton();
+    ToolTipButton vor = control.getTTVorButton();
     buttons1.addButton(vor);
     Button reset = new Button("Filter-Reset", new Action()
     {

--- a/src/de/jost_net/JVerein/gui/view/BuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungDetailView.java
@@ -17,6 +17,10 @@
 package de.jost_net.JVerein.gui.view;
 
 import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.LinkedList;
+
+import org.apache.commons.lang.StringUtils;
 
 import de.jost_net.JVerein.gui.action.BuchungNeuAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
@@ -29,6 +33,7 @@ import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.SplitbuchungTyp;
 import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -62,6 +67,16 @@ public class BuchungDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.BUCHUNGEN, false, "question-circle.png");
+
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    LinkedList<Long> ids = control.getKontoIds(art);
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Buchung.class, "buchung", "datum",
+        "konto in (" + StringUtils.join(ids, ",") + ") AND datum >= ?",
+        gj.getBeginnLetztesGeschaeftsjahr());
 
     Button saveButton = new Button("Speichern", context -> {
       try

--- a/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
@@ -82,9 +82,9 @@ public class BuchungListeView extends AbstractView
     right.addLabelPair("Mitglied Name", control.getMitglied());
     
     ButtonArea buttons1 = new ButtonArea();
-    ToolTipButton zurueck = control.getZurueckButton();
+    ToolTipButton zurueck = control.getTTZurueckButton();
     buttons1.addButton(zurueck);
-    ToolTipButton vor = control.getVorButton();
+    ToolTipButton vor = control.getTTVorButton();
     buttons1.addButton(vor);
     Button reset = new Button("Filter-Reset", new Action()
     {

--- a/src/de/jost_net/JVerein/gui/view/KontoDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoDetailView.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.gui.control.KontoControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -83,6 +84,11 @@ public class KontoDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KONTEN, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Konto.class, "konto", "bezeichnung", null, null);
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
@@ -16,12 +16,15 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
 import de.jost_net.JVerein.gui.control.KursteilnehmerControl;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -76,6 +79,14 @@ public class KursteilnehmerDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KURSTEILNEHMER, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Kursteilnehmer.class, "kursteilnehmer",
+        "eingabedatum, name, vorname", "eingabedatum >= ?",
+        gj.getBeginnLetztesGeschaeftsjahr());
     buttons.addButton(new SaveButton(control));
 
     buttons.addButton(new Button("Speichern und neu", context -> {

--- a/src/de/jost_net/JVerein/gui/view/LastschriftDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftDetailView.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.LastschriftControl;
+import de.jost_net.JVerein.rmi.Lastschrift;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -68,6 +69,15 @@ public class LastschriftDetailView extends AbstractView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LASTSCHRIFT, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    // Wir unterstützen bis zu 3 Abrechnungsläufe zurück!
+    control.setObjektListe(Lastschrift.class, "lastschrift",
+        "abrechnungslauf, name, vorname", "abrechnungslauf >= ?",
+        Long.valueOf(control.getLastschrift().getAbrechnungslauf().getID())
+            - 3);
     buttons.paint(this.getParent());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangDetailView.java
@@ -16,9 +16,13 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.rmi.Lehrgang;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.jost_net.JVerein.gui.control.LehrgangControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -45,6 +49,13 @@ public class LehrgangDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LEHRGANG, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Lehrgang.class, "lehrgang", "von, mitglied",
+        "von >= ?", gj.getBeginnLetztesGeschaeftsjahr());
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/RechnungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungDetailView.java
@@ -16,10 +16,14 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.rmi.Rechnung;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
@@ -77,6 +81,13 @@ public class RechnungDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.RECHNUNG, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Rechnung.class, "rechnung", "datum, name, vorname",
+        "datum >= ?", gj.getBeginnLetztesGeschaeftsjahr());
     buttons.addButton(control.getRechnungDruckUndMailButton());
     buttons.addButton(control.getMahnungDruckUndMailButton());
     buttons.addButton(new SaveButton(control));

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -16,6 +16,8 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -26,6 +28,8 @@ import de.jost_net.JVerein.gui.action.SollbuchungPositionNeuAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.SollbuchungControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.rmi.Sollbuchung;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -88,7 +92,13 @@ public class SollbuchungDetailView extends AbstractDetailView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.MITGLIEDSKONTO_UEBERSICHT, false,
         "question-circle.png");
-
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Sollbuchung.class, Sollbuchung.TABLE_NAME,
+        "datum, mitglied", "datum >= ?", gj.getBeginnLetztesGeschaeftsjahr());
     Button save = new SaveButton(control);
     save.setEnabled(!hasRechnung);
     buttons.addButton(save);

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungDetailView.java
@@ -16,12 +16,15 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
@@ -98,6 +101,14 @@ public class SpendenbescheinigungDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.SPENDENBESCHEINIGUNG, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Spendenbescheinigung.class, "spendenbescheinigung",
+        "spendedatum, zeile2", "spendedatum >= ?",
+        gj.getBeginnLetztesGeschaeftsjahr());
     buttons.addButton(control.getDruckUndMailButton());
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlageDetailView.java
@@ -16,10 +16,14 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Date;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.WiedervorlageControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.rmi.Wiedervorlage;
+import de.jost_net.JVerein.util.Geschaeftsjahr;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -43,6 +47,13 @@ public class WiedervorlageDetailView extends AbstractDetailView
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.WIEDERVORLAGE, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getVorButton());
+    Geschaeftsjahr gj = new Geschaeftsjahr(new Date());
+    // Parameter: Objekt Klasse, Tabellen Name, Order By, Filter,
+    // Filter Parameter
+    control.setObjektListe(Wiedervorlage.class, "wiedervorlage",
+        "datum, mitglied", "datum >= ?", gj.getBeginnLetztesGeschaeftsjahr());
     buttons.addButton(new SaveButton(control));
     buttons.paint(getParent());
   }

--- a/src/de/jost_net/JVerein/util/Geschaeftsjahr.java
+++ b/src/de/jost_net/JVerein/util/Geschaeftsjahr.java
@@ -72,6 +72,14 @@ public class Geschaeftsjahr
     return beginnGeschaeftsjahr;
   }
 
+  public Date getBeginnLetztesGeschaeftsjahr()
+  {
+    Calendar cal = Calendar.getInstance();
+    cal.setTime(beginnGeschaeftsjahr);
+    cal.add(Calendar.YEAR, -1);
+    return cal.getTime();
+  }
+
   public int getBeginnGeschaeftsjahrjahr()
   {
     return beginnGeschaeftsjahrjahr;


### PR DESCRIPTION
Wie im Forum (https://jverein-forum.de/viewtopic.php?t=7478) gewünscht und ich auch schon gerne gehabt hätte habe ich jetzt in den unten genannten Views Vor und Zurück Buttons unten in der Buttonliste eingebaut.
Wir haben das ja auch schon einmal bei der Diskussion zu Mittelverwendung diskutiert.
![Bildschirmfoto_20250709_121336](https://github.com/user-attachments/assets/7a599ac0-e295-4893-86d2-9594041321c5)
Man kann damit zum nächsten Eintrag oder vorhergehenden zurück. Die Liste der Einträge benutzt keine Filter aus den Listen weil man ja von unterschiedlichen Stellen aus einen Eintrag öffnen kann.
Aus Performance Gründen werden bei den Einträgen mit Datum nur welche  aus dem aktuellen und letzten Geschäftsjahr angezeigt. Bei Konten sind alle dabei und bei Lastschriften die ab den letzten drei Abrechnungsläufen der selektierten Lastschrift.
Bei einem neuen Eintrag sind die Buttons disabled. Sie haben ja noch keine Id.

Unterstützte Views sind:
* Mitglied
* Nicht-Mitglied
* Kursteilnehmer
* Sollbuchung
* Rechnung
* Spendenbescheinigung
* Wiedervorlage
* Lehrgang
* Konto
* Buchung
* Anlagenbuchung
* Lastschrift

Etwas unschön ist noch, dass bei jedem neuen Fenster die Liste neu aufgebaut wird. Man könnte sie static machen. Die Frage ist aber wann man sie löschen muss weil Instanzen erzeugt oder gelöscht wurden.