### PR TITLE
Fix Exception bei Abbruch im File Dialog

### DIFF
--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -55,10 +55,18 @@ public class FreiesFormularAusgabe
     {
       case DRUCK:
         file = getDateiAuswahl("pdf", formular.getBezeichnung());
+        if (file == null)
+        {
+          return;
+        }
         formularaufbereitung = new FormularAufbereitung(file, false, false);
         break;
       case MAIL:
         file = getDateiAuswahl("zip", formular.getBezeichnung());
+        if (file == null)
+        {
+          return;
+        }
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
     }

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -71,10 +71,18 @@ public class Rechnungsausgabe
     {
       case DRUCK:
         file = getDateiAuswahl("pdf");
+        if (file == null)
+        {
+          return;
+        }
         formularaufbereitung = new FormularAufbereitung(file, true, false);
         break;
       case MAIL:
         file = getDateiAuswahl("zip");
+        if (file == null)
+        {
+          return;
+        }
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
     }


### PR DESCRIPTION
Beim Drucken oder Mailen von Rechnung, Mahnung oder FreiesFormular kommt es zu einer Exception wenn man im File Auswahl Dialog auf Abbruch klickt. Dann ist das file attribut null.
Bei Abbruch wird jetzt einfach die Ausgabe beendet.