### PR TITLE
Fix Sollbuchung Jameica  Zurueck Button

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -173,6 +173,7 @@ public class SollbuchungControl extends DruckMailControl
     }
     sollbuchung = Einstellungen.getDBService().createObject(Sollbuchung.class,
         ((Sollbuchung) getCurrentObject()).getID());
+    GUI.getCurrentView().setCurrentObject(sollbuchung);
     return sollbuchung;
   }
 


### PR DESCRIPTION
Der PR löst das Sollbuchung Problem aus #931.
Änderungen in der Sollbuchungen wurden bei der Zurück Aktion (grüner Pfeil oben) nicht erkannt.