### PR TITLE
Verlassenmeldung bei Rechung behoben

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0480.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0480.java
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.datasource.rmi.DBService;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+import java.sql.Connection;
+
+public class Update0480 extends AbstractDDLUpdate
+{
+  protected DBService service;
+
+  public Update0480(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute("update rechnung set kommentar = '' where kommentar is NULL");
+  }
+}


### PR DESCRIPTION
Wie in #931 geschrieben, kam es zu Verlassen Meldung bei alten Rechnungen. Durch diesen PR wird in der DB der Kommentar auf "" statt auf NULL gesetzt und die Meldung kommt nichtmehr