### PR TITLE
Fehler bei Einstellungen behoben

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2292,6 +2292,10 @@ public class EinstellungControl extends AbstractControl
             ib.toUpperCase().replace(" ", ""));
       Einstellungen.setEinstellung(Property.GLAEUBIGERID,
           (String) getGlaeubigerID().getValue());
+      if (getStaat().getValue() == null)
+      {
+        throw new ApplicationException("Bitte Staat auswählen");
+      }
       Einstellungen.setEinstellung(Property.STAAT,
           ((Staat) getStaat().getValue()).getKey());
       Einstellungen.setEinstellung(Property.USTID,
@@ -2573,6 +2577,8 @@ public class EinstellungControl extends AbstractControl
           (Boolean) kontonummer_in_buchungsliste.getValue());
       Einstellungen.setEinstellung(Property.OPTIERT,
           (Boolean) getOptiert().getValue());
+      Einstellungen.setEinstellung(Property.STEUERINBUCHUNG,
+          (Boolean) getSteuerInBuchung().getValue());
       Einstellungen.setEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG,
           (Boolean) getFreieBuchungsklasse().getValue());
       Einstellungen.setEinstellung(Property.SPLITPOSITIONZWECK,
@@ -2642,15 +2648,13 @@ public class EinstellungControl extends AbstractControl
   public void handleStoreMitgliederSpalten()
   {
     try
-    {// TODO
+    {
       spalten.save();
-      DBTransaction.commit();
 
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");
     }
-    catch (RemoteException | ApplicationException e)
+    catch (RemoteException e)
     {
-      DBTransaction.rollback();
       Logger.error("Speichern felgeschlagen", e);
       GUI.getStatusBar().setErrorText(e.getMessage());
     }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0479.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0479.java
@@ -69,7 +69,7 @@ public class Update0479 extends AbstractDDLUpdate
           .executeQuery("SELECT * FROM einstellung WHERE id = 1");
 
       if (!result.next())
-        throw new ApplicationException("Keine Einstellung vorhanden");
+        return;
 
       ResultSetMetaData m = result.getMetaData();
 


### PR DESCRIPTION
Ich habe die Fehler aus #940 behoben die durch die neuen Einstellungen und den SttatInput gekommen sind:

- Update nicht abbrechen wenn keine Einstellungen vorliegen
- SteuerInBuchung speichern war durch den Merge verloren gegangen
- Einstellungen-Allgemein Speichern Fehlermeldung bei fehlendem Staat ausgeben (getKey kann nur hier zu null kommen, da in den Dropdowns immer ein Rückgabewert vorhanden ist)