### PR TITLE
Steuer Support ohne Umsatzsteuer Pflicht (implementiert #936)

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -297,6 +297,7 @@ public class Einstellungen
     KONTONUMMERINBUCHUNGSLISTE("kontonummer_in_buchungsliste", Boolean.class,
         "0"),
     OPTIERT("optiert", Boolean.class, "0"),
+    OPTIERTPFLICHT("optiertpflicht", Boolean.class, "0"),
     STEUERINBUCHUNG("steuerinbuchung", Boolean.class, "0"),
     BUCHUNGSKLASSEINBUCHUNG("bkinbuchung", Boolean.class, "0"),
     SPLITPOSITIONZWECK("splitpositionzweck", Boolean.class, "0"),

--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -80,7 +80,7 @@ public class RechnungMap extends AbstractMap
     }
     if (buchungDatum.size() > 1)
     {
-      if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERT))
+      if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT))
       {
         zweck.add("Rechnungsbetrag inkl. USt.");
       }
@@ -209,7 +209,7 @@ public class RechnungMap extends AbstractMap
         new Date[] { new Date(), new Date() });
     map.put(RechnungVar.ZAHLUNGSGRUND.getName(),
         new String[] { "Mitgliedsbeitrag", "Zusatzbetrag",
-            (Boolean) Einstellungen.getEinstellung(Property.OPTIERT)
+            (Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT)
                 ? "Rechnungsbetrag inkl. USt."
                 : "Summe" });
     map.put(RechnungVar.NETTOBETRAG.getName(),

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -79,7 +79,7 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
   public BuchungsklasseSaldoControl(AbstractView view) throws RemoteException
   {
     super(view);
-    mitSteuer = (Boolean) Einstellungen.getEinstellung(Property.OPTIERT);
+    mitSteuer = (Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -311,6 +311,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput optiert;
 
+  private CheckboxInput optiertpflicht;
+
   private CheckboxInput unterschriftdrucken;
   
   private ImageInput unterschrift;
@@ -812,10 +814,13 @@ public class EinstellungControl extends AbstractControl
     }
     optiert = new CheckboxInput(
         (Boolean) Einstellungen.getEinstellung(Property.OPTIERT));
-    optiert.setName("Umsatzsteueroption (Neustart erforderlich)");
+    optiert.setName("Umsatzsteuer Support (Neustart erforderlich)");
     optiert.addListener(e -> {
       try
       {
+        getOptiertPflicht().setValue(Boolean.FALSE);
+        getSteuerInBuchung().setValue(Boolean.FALSE);
+        getOptiertPflicht().setEnabled((boolean) optiert.getValue());
         getSteuerInBuchung().setEnabled((boolean) optiert.getValue());
       }
       catch (RemoteException e1)
@@ -826,6 +831,20 @@ public class EinstellungControl extends AbstractControl
     return optiert;
   }
   
+  public CheckboxInput getOptiertPflicht() throws RemoteException
+  {
+    if (optiertpflicht != null)
+    {
+      return optiertpflicht;
+    }
+    optiertpflicht = new CheckboxInput(
+        (Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT));
+    optiertpflicht.setName("Umsatzsteuer Pflicht");
+
+    optiertpflicht.setEnabled((boolean) getOptiert().getValue());
+    return optiertpflicht;
+  }
+
   public CheckboxInput getSteuerInBuchung() throws RemoteException
   {
     if (steuerInBuchung != null)
@@ -2577,6 +2596,8 @@ public class EinstellungControl extends AbstractControl
           (Boolean) kontonummer_in_buchungsliste.getValue());
       Einstellungen.setEinstellung(Property.OPTIERT,
           (Boolean) getOptiert().getValue());
+      Einstellungen.setEinstellung(Property.OPTIERTPFLICHT,
+          (Boolean) getOptiertPflicht().getValue());
       Einstellungen.setEinstellung(Property.STEUERINBUCHUNG,
           (Boolean) getSteuerInBuchung().getValue());
       Einstellungen.setEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG,

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -113,7 +113,7 @@ public class KontensaldoControl extends AbstractSaldoControl
   {
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("konto");
     boolean mitSteuer = (Boolean) Einstellungen
-        .getEinstellung(Property.OPTIERT);
+        .getEinstellung(Property.OPTIERTPFLICHT);
     if (mitSteuer)
     {
       // Bei Umbuchungen vom Geldkonto den Steueranteil nicht bei den

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -517,7 +517,7 @@ public class MittelverwendungControl extends AbstractSaldoControl
         Kontoart.SCHULDEN.getKey(), Kontoart.ANLAGE.getKey(),
         Anlagenzweck.NUTZUNGSGEBUNDEN.getKey());
 
-    if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERT))
+    if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT))
     {
       // Die Steuer bei Veräußerung von Anlagevermögen mit Steuer
       // Steuer Einnahmen bei Umbuchungen > 0 auf dem Geldkonto
@@ -560,7 +560,7 @@ public class MittelverwendungControl extends AbstractSaldoControl
         : 0d;
 
     // ggf. Steuern hinzurechnen
-    if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERT))
+    if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT))
     {
       if (fluss.getDouble("steuereinnahme") != null)
       {

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -48,6 +48,7 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     cont.addInput(control.getUnterdrueckungOhneBuchung());
     cont.addInput(control.getKontonummerInBuchungsliste());
     cont.addInput(control.getOptiert());
+    cont.addInput(control.getOptiertPflicht());
     cont.addInput(control.getSteuerInBuchung());
     cont.addInput(control.getFreieBuchungsklasse());
     cont.addInput(control.getSplitPositionZweck());

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0481.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0481.java
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0481 extends AbstractDDLUpdate
+{
+  public Update0481(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    try
+    {
+      ResultSet result = conn.createStatement()
+          .executeQuery("SELECT * FROM einstellungneu WHERE name = 'optiert'");
+
+      if (result.next())
+      {
+        String value = result.getBoolean(3) ? "1" : "0";
+        execute(
+            "INSERT INTO einstellungneu (name,wert) VALUES('optiertpflicht','"
+                + value + "')");
+      }
+    }
+    catch (SQLException e)
+    {
+      String fehler = "Fehler beim Update";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
+    }
+  }
+}


### PR DESCRIPTION
Es ist auch noch ein Fehler behoben.
Wenn Umsatzsteuer Support abgewählt wird, dann muss auch "Steuer individuell pro Buchung setzen" gelöscht werden.

Ich habe Update0481 genommen. Es kann also erst nach einem der Features mit Update480 übernommen werden.
Darum blocked.