### PR TITLE
Progressbar bei Steuerzuordnung korrigiert

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungSteuerZuordnenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSteuerZuordnenAction.java
@@ -124,6 +124,8 @@ public class BuchungSteuerZuordnenAction implements Action
                   monitor.setStatusText(fehler);
                   Logger.error(fehler, e);
                 }
+                monitor.setPercentComplete(
+                    100 * (count + skip) / buchungen.length);
               }
               if (buchungen.length > 1)
               {
@@ -184,6 +186,8 @@ public class BuchungSteuerZuordnenAction implements Action
                   monitor.setStatusText(fehler);
                   Logger.error(fehler, e);
                 }
+                monitor.setPercentComplete(
+                    100 * (count + skip) / buchungen.length);
               }
               if (buchungen.length > 1)
               {


### PR DESCRIPTION
Der monitor hat bereits nach der ersten Buchung 100% angezeigt.
Außerdem zeige ich ihn jetzt nur noch bei mehr als einer Buchung an.