### PR TITLE
Doku Link angepasst

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -24,7 +24,7 @@ public class DokumentationUtil
   
   //private static final String ALLGEMEIN = "allgemein/";
   
-  private static final String FUNKTIONEN = "v3.1.x/";
+  private static final String FUNKTIONEN = "versionen/v3.1.x/";
   
   private static final String ADMIN = "administration/";
   


### PR DESCRIPTION
Der richtige Link zur Doku ist https://openjverein.gitbook.io/doku/versionen/v3.1.x , es wird eigentlich umgeleitet, manchmal klappt es jedoch nicht und es wird eine Error 404 angezeigt, beim reload geht es. So ist es aber sicherer.