### PR TITLE
Fehler Speichern bei Verlassen beim Abrechnungslauf

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -1044,6 +1044,7 @@ public class AbrechnungSEPA
     abrl.setZahlungsgrund(getVerwendungszweck(param));
     abrl.setZusatzbetraege(param.zusatzbetraege);
     abrl.setAbgeschlossen(false);
+    abrl.setBemerkung("");
     abrl.store();
     return abrl;
   }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0482.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0482.java
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0482 extends AbstractDDLUpdate
+{
+  public Update0482(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(
+        "UPDATE abrechnungslauf set bemerkung is '' where bemerkung is null");
+  }
+}


### PR DESCRIPTION
Hab die bemerkung per DB-Update auf "" gesetzt und beim Abrechungslauf erstellen die Bemerkung auch als "" eintragen hinzugefügt. So kommt die Speichern-Bei-Verlassen Meldung nicht wen nicht nötig.