### PR TITLE
Verlassen Meldung bei Mitglied duplizieren

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
@@ -17,6 +17,7 @@
 package de.jost_net.JVerein.gui.action;
 
 import de.jost_net.JVerein.gui.view.NichtMitgliedDetailView;
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.view.MitgliedDetailView;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
@@ -34,11 +35,11 @@ public class MitgliedDuplizierenAction implements Action
     {
       throw new ApplicationException("kein Mitglied ausgewählt");
     }
-    Mitglied m = null;
+    Mitglied m;
     try
     {
-      m = (Mitglied) context;
-      m.setID(null);
+      m = Einstellungen.getDBService().createObject(Mitglied.class, null);
+      m.overwrite((Mitglied) context);
       if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.MITGLIED)
       {
         GUI.startView(new MitgliedDetailView(), m);


### PR DESCRIPTION
Beim duplizieren eines Mitglieds kam immer die Speichernabfrage. Jetzt bearbeite ich nicht das alte Mitglied sondern überschreibe es in ein neues, dann kommt die Meldung nicht mehr.