### PR TITLE
Fehler SQL-Befehl in Update0482

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0482.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0482.java
@@ -30,6 +30,6 @@ public class Update0482 extends AbstractDDLUpdate
   public void run() throws ApplicationException
   {
     execute(
-        "UPDATE abrechnungslauf set bemerkung is '' where bemerkung is null");
+        "UPDATE abrechnungslauf set bemerkung = '' where bemerkung is null");
   }
 }


### PR DESCRIPTION
„is” wurde durch „=“ ersetzt