### PR TITLE
Fehler in Umsatzsteuer Voranmeldung weiteren Salden behoben

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -286,7 +286,7 @@ public class Einstellungen
     UNTERSCHRIFT("unterschrift", String.class, ""),
 
     // Buchführung
-    BEGINNGESCHAEFTSJAHR("beginngeschaeftsjahr", String.class, "01.01"),
+    BEGINNGESCHAEFTSJAHR("beginngeschaeftsjahr", String.class, "01.01."),
     UNTERDRUECKUNGKONTEN("unterdrueckungkonten", Integer.class, "2"),
     UNTERDRUECKUNGLAENGE("unterdrueckunglaenge", Integer.class, "0"),
     AFARESTWERT("afarestwert", Double.class, "1"),

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -206,6 +206,16 @@ public class AnlagenlisteControl extends AbstractSaldoControl
     it.addGroupBy("konto.id");
     it.addGroupBy("konto.anlagenart");
     it.addGroupBy("konto.anlagenklasse");
+    it.addGroupBy("konto.bezeichnung");
+    it.addGroupBy("konto.nutzungsdauer");
+    it.addGroupBy("konto.anschaffung");
+    it.addGroupBy("konto.betrag");
+    it.addGroupBy("buchungsart.bezeichnung");
+    it.addGroupBy("buchungsart.nummer");
+    it.addGroupBy("buchungsklasse.bezeichnung");
+    it.addGroupBy("buchungsklasse.nummer");
+    it.addGroupBy("afaart.bezeichnung");
+    it.addGroupBy("afaart.nummer");
 
     return it;
   }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -446,6 +446,12 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       it.addGroupBy("buchungsart.buchungsklasse");
     }
     it.addGroupBy("buchungsart.id");
+    it.addGroupBy("buchungsklasse.bezeichnung");
+    it.addGroupBy("buchungsklasse.nummer");
+    it.addGroupBy("buchungsart.bezeichnung");
+    it.addGroupBy("buchungsart.art");
+    it.addGroupBy("buchungsart.status");
+    it.addGroupBy("buchungsart.nummer");
     // Ggf. Buchungsarten ausblenden
     if (unterdrueckung)
     {

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -198,6 +198,8 @@ public class KontensaldoControl extends AbstractSaldoControl
 
     it.addGroupBy("konto.id");
     it.addGroupBy("konto.kontoart");
+    it.addGroupBy("konto.bezeichnung");
+    it.addGroupBy("konto.nummer");
 
     it.setOrder("ORDER BY konto.nummer");
 

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -738,6 +738,7 @@ public class MittelverwendungControl extends AbstractSaldoControl
     ohneBuchungsartIt.addFilter("buchung.buchungsart is null");
 
     ohneBuchungsartIt.addGroupBy("konto.kontoart > " + Kontoart.LIMIT.getKey());
+    ohneBuchungsartIt.addGroupBy("konto.kontoart");
     ohneBuchungsartIt
         .setOrder("ORDER BY konto.kontoart > " + Kontoart.LIMIT.getKey());
 
@@ -1026,6 +1027,11 @@ public class MittelverwendungControl extends AbstractSaldoControl
     // nach Konto gruppieren
     it.addGroupBy("konto.id");
     it.addGroupBy("konto.kontoart");
+    it.addGroupBy("konto.bezeichnung");
+    it.addGroupBy("konto.kommentar");
+    it.addGroupBy("konto.zweck");
+    it.addGroupBy("buchungsklasse.bezeichnung");
+    it.addGroupBy("anfangsbestand.betrag");
 
     // nach Kontenart und Anlagenklasse sortieren
     it.setOrder("ORDER BY konto.kontoart, konto.anlagenklasse, konto.nummer");

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -45,6 +45,7 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     // Wir überschreiben das "buchungsklasse" Feld mit dem Projektname
      it.addColumn("projekt.bezeichnung as " + BUCHUNGSKLASSE);
      it.addGroupBy("projekt.id");
+     it.addGroupBy("projekt.bezeichnung");
      String on = "projekt.id = buchung.projekt ";
      if (mitSteuer)
      {

--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -39,11 +39,6 @@ import de.willuhn.util.ApplicationException;
 public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
 {
   /**
-   * Die Art der Buchung: Einnahme (0), Ausgabe (1), Umbuchung (2)
-   */
-  protected static final String ARTBUCHUNGSART = "art";
-
-  /**
    * Die Summe
    */
   public static final String SUMME = "summe";
@@ -206,7 +201,6 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
         "buchungsart");
     it.addColumn("steuer.name as " + STEUER);
-    it.addColumn("buchungsart.art as " + ARTBUCHUNGSART);
     it.addColumn("steuerbuchungsart.art as " + ARTSTEUERBUCHUNGSART);
     it.addColumn("COUNT(buchung.id) as " + ANZAHL);
 
@@ -260,6 +254,8 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
         "steuer.buchungsart = steuerbuchungsart.id");
 
     it.addGroupBy("steuer.id");
+    it.addGroupBy("steuerbuchungsart.art");
+    it.addGroupBy("steuer.name");
 
     it.setOrder("ORDER BY buchungsart.art, steuerbuchungsart.art, steuer.id");
 


### PR DESCRIPTION
Hab den Fehler aus #968 behoben. Außerde habe ich noch überall die GroupBy hinzugefügt, so das es bei MySQL auch bei gesetztem ONLY_FULL_GROUP_BY funktioniert, funktional ändert sich dadurch nichts.
Außerdem hab ich noch einen Fehler in der Default-Einstellung gefunden, hier muss es 01.01. statt 01.01 sein sonst hat die QuickAccess Buttons nicht funktioniert.

Bitte zukünftig die PRs auch Live testen und nicht nur den Code anschauen, dann wäre es zu diesem Fehler nicht in der herasugegebenen Version gekommen. Wir haben alle verschiedene Konstalationen von Betriebssystem und Datenbank da ist es gut wenn alle es wirklich testen.