### PR TITLE
Rechnung Verlassenmeldung

### DIFF
--- a/src/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/de/jost_net/JVerein/server/RechnungImpl.java
@@ -407,6 +407,7 @@ public class RechnungImpl extends AbstractJVereinDBObject
     setIBAN(mitglied.getIban());
     setZahlungsweg(sollb.getZahlungsweg());
     setBetrag(sollb.getBetrag());
+    setKommentar("");
   }
 
   @Override


### PR DESCRIPTION
Bei den Rechnungen muss beim erstellen der Kommentar auf "" gesetzt werden, sonst kommt immer die Verlassenmedung.