### PR TITLE
Sollbuchung Betrag runden

### DIFF
--- a/src/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -285,7 +285,7 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
   @Override
   public void setBetrag(Double d) throws RemoteException
   {
-    setAttribute(BETRAG, d);
+    setAttribute(BETRAG, Math.round(d * 100) / 100d);
   }
 
   @Override


### PR DESCRIPTION
Beim berechnen des Betrags der Sollbuchungen kann es zu Rundungsfehlern bei der Berechnung des Betrag kommen, so dass er zB. 9.999999999976 ist. Das führt 1. dazu, dass es bei Fehlbetrag bzw. Überzahlung angezeigt wird, 2. wird die Speichern-Verlassenmeldung angezeigt.
Hiermit runde ich den Betrag immer auf 2 Nachkommastellen.