### PR TITLE
Workaround für Lizenzen View

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,10 +13,6 @@
       <item name="Über"
             action="de.jost_net.JVerein.gui.action.AboutAction" 
             icon="gtk-info.png" />
-      <item name="-" />
-      <item name="Lizenzinformationen"
-            action="de.jost_net.JVerein.gui.action.LizenzAction"
-            icon="text-x-generic.png" />
     </item>
   </menu>
   <classfinder>


### PR DESCRIPTION
Ich schlage vor erst einmal den Button weg zu machen. Dann kann man sich überlegen wie er neu implementiert wird wenn nötig.