### PR TITLE
Überall SaveNext Buttons

### DIFF
--- a/src/de/jost_net/JVerein/gui/input/SaveNeuButton.java
+++ b/src/de/jost_net/JVerein/gui/input/SaveNeuButton.java
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.input;
+
+import java.rmi.RemoteException;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.gui.action.NewAction;
+import de.jost_net.JVerein.gui.control.Savable;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Fertig konfigurierter Speichern und Neu Button
+ */
+public class SaveNeuButton extends Button
+{
+
+  /**
+   * Erstellt den Speichern un NeuButton
+   * 
+   * @param control
+   *          Das control
+   */
+  public SaveNeuButton(Savable control)
+  {
+    this(control, true);
+  }
+
+  /**
+   * Erstellt den Speichern un NeuButton
+   * 
+   * @param control
+   *          Das control
+   * @param noHistory
+   *          Keine View Historie
+   */
+  public SaveNeuButton(Savable control, boolean noHistory)
+  {
+    super("Speichern und neu", context -> {
+      try
+      {
+        control.handleStore();
+        AbstractView view = GUI.getCurrentView();
+        DBObject object = (DBObject) view.getCurrentObject();
+        new NewAction(view.getClass(), object.getClass(), noHistory)
+            .handleAction(null);
+        GUI.getStatusBar().setSuccessText("Gespeichert");
+      }
+      catch (ApplicationException ae)
+      {
+        GUI.getStatusBar().setErrorText(ae.getMessage());
+      }
+    }, null, false, "go-next.png");
+  }
+
+  @Override
+  public void paint(Composite parent) throws RemoteException
+  {
+    if (((DBObject) GUI.getCurrentView().getCurrentObject()).isNewObject())
+    {
+      super.paint(parent);
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -48,6 +48,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.MitgliedDokument;
 import de.jost_net.JVerein.server.MitgliedUtils;
 import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.Input;
@@ -253,7 +254,17 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
       {
         GUI.getStatusBar().setErrorText(e.getMessage());
       }
-    }, null, false, "go-next.png"));
+    }, null, false, "go-next.png")
+    {
+      @Override
+      public void paint(Composite parent) throws RemoteException
+      {
+        if (((DBObject) getCurrentObject()).isNewObject())
+        {
+          super.paint(parent);
+        }
+      }
+    });
 
     buttons.paint(parent);
   }

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.ArbeitseinsatzControl;
 import de.jost_net.JVerein.gui.parts.ArbeitseinsatzPart;
 import de.willuhn.jameica.gui.GUI;
@@ -45,6 +46,7 @@ public class ArbeitseinsatzDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeDetailView.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.BeitragsgruppeControl;
 import de.jost_net.JVerein.gui.util.SimpleVerticalContainer;
 import de.jost_net.JVerein.keys.Beitragsmodel;
@@ -120,6 +121,7 @@ public class BeitragsgruppeDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/BuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungDetailView.java
@@ -114,7 +114,10 @@ public class BuchungDetailView extends AbstractDetailView
       }
     }, null, false, "go-next.png");
     saveNextButton.setEnabled(editable);
-    buttons.addButton(saveNextButton);
+    if (control.getBuchung().isNewObject())
+    {
+      buttons.addButton(saveNextButton);
+    }
 
     buttons.paint(getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartDetailView.java
@@ -19,16 +19,13 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
-import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.BuchungsartControl;
-import de.jost_net.JVerein.rmi.Buchungsart;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
-import de.willuhn.util.ApplicationException;
 
 public class BuchungsartDetailView extends AbstractDetailView
 {
@@ -65,22 +62,7 @@ public class BuchungsartDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
-
-    buttons.addButton(new Button("Speichern und neu", context -> {
-      try
-      {
-        control.handleStore();
-
-        new NewAction(BuchungsartDetailView.class, Buchungsart.class, true)
-            .handleAction(null);
-        GUI.getStatusBar().setSuccessText("Buchungsart gespeichert");
-      }
-      catch (ApplicationException e)
-      {
-        GUI.getStatusBar().setErrorText(e.getMessage());
-      }
-    }, null, false, "go-next.png"));
-
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.BuchungsklasseControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -46,6 +47,7 @@ public class BuchungsklasseDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.EigenschaftControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -46,6 +47,7 @@ public class EigenschaftDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.EigenschaftGruppeControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -47,6 +48,7 @@ public class EigenschaftGruppeDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.gui.action.FormularfelderExportAction;
 import de.jost_net.JVerein.gui.action.FormularfelderImportAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.FormularControl;
 import de.jost_net.JVerein.rmi.Formular;
 import de.willuhn.jameica.gui.GUI;
@@ -89,6 +90,7 @@ public class FormularDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/FormularfeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularfeldDetailView.java
@@ -18,11 +18,14 @@ package de.jost_net.JVerein.gui.view;
 
 import java.rmi.RemoteException;
 
+import org.eclipse.swt.widgets.Composite;
+
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.FormularfeldNeuAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.FormularfeldControl;
 import de.jost_net.JVerein.rmi.Formularfeld;
+import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -84,7 +87,17 @@ public class FormularfeldDetailView extends AbstractDetailView
       {
         GUI.getStatusBar().setErrorText(e.getMessage());
       }
-    }, null, false, "go-next.png"));
+    }, null, false, "go-next.png")
+    {
+      @Override
+      public void paint(Composite parent) throws RemoteException
+      {
+        if (((DBObject) getCurrentObject()).isNewObject())
+        {
+          super.paint(parent);
+        }
+      }
+    });
 
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/KontoDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoDetailView.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.KontoControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -88,6 +89,7 @@ public class KontoDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
@@ -17,19 +17,16 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
-import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.KursteilnehmerControl;
-import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.ScrolledContainer;
 import de.willuhn.jameica.gui.util.SimpleContainer;
-import de.willuhn.util.ApplicationException;
 
 public class KursteilnehmerDetailView extends AbstractDetailView
 {
@@ -80,21 +77,7 @@ public class KursteilnehmerDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
-    buttons.addButton(new Button("Speichern und neu", context -> {
-      try
-      {
-        control.handleStore();
-
-        new NewAction(KursteilnehmerDetailView.class, Kursteilnehmer.class,
-            true).handleAction(null);
-        GUI.getStatusBar().setSuccessText("Kursteilnehmer gespeichert");
-      }
-      catch (ApplicationException e)
-      {
-        GUI.getStatusBar().setErrorText(e.getMessage());
-      }
-    }, null, false, "go-next.png"));
-
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/LehrgangDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.LehrgangControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -49,6 +50,7 @@ public class LehrgangDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/LehrgangsartDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangsartDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.LehrgangsartControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -48,6 +49,7 @@ public class LehrgangsartDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlageDetailView.java
@@ -23,6 +23,7 @@ import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.MailVorlageControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -63,6 +64,7 @@ public class MailVorlageDetailView extends AbstractDetailView
         .addButton(new Button("Vorschau", new MailTextVorschauAction(map, true),
             control, false, "edit-copy.png"));
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/MitgliedstypDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedstypDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.MitgliedstypControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -47,6 +48,7 @@ public class MitgliedstypDetailView extends AbstractDetailView
     buttons.addButton(control.getVorButton());
     SaveButton saveButton = new SaveButton(control);
     buttons.addButton(saveButton);
+    buttons.addButton(new SaveNeuButton(control));
     if (control.getMitgliedstyp().getJVereinid() > 0)
     {
       saveButton.setEnabled(false);

--- a/src/de/jost_net/JVerein/gui/view/ProjektDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.ProjektControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -48,6 +49,7 @@ public class ProjektDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungPositionDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungPositionDetailView.java
@@ -18,12 +18,15 @@ package de.jost_net.JVerein.gui.view;
 
 import java.rmi.RemoteException;
 
+import org.eclipse.swt.widgets.Composite;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.SollbuchungPositionNeuAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.SollbuchungPositionControl;
+import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -99,7 +102,17 @@ public class SollbuchungPositionDetailView extends AbstractDetailView
             .setErrorText("Fehler beim Speichern der Sollbuchungsposition: "
                 + e.getMessage());
       }
-    }, null, false, "go-next.png"));
+    }, null, false, "go-next.png")
+    {
+      @Override
+      public void paint(Composite parent) throws RemoteException
+      {
+        if (((DBObject) getCurrentObject()).isNewObject())
+        {
+          super.paint(parent);
+        }
+      }
+    });
     buttons.paint(this.getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlageDetailView.java
@@ -20,6 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.WiedervorlageControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -47,6 +48,7 @@ public class WiedervorlageDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragDetailView.java
@@ -21,6 +21,7 @@ import de.jost_net.JVerein.gui.action.ZusatzbetragVorlageAuswahlAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.ZusatzbetragControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.parts.ZusatzbetragPart;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -52,6 +53,7 @@ public class ZusatzbetragDetailView extends AbstractDetailView
     buttons.addButton("Vorlagen", new ZusatzbetragVorlageAuswahlAction(part),
         null, false, "view-refresh.png");
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageDetailView.java
@@ -22,6 +22,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.control.ZusatzbetragVorlageControl;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
@@ -58,6 +59,7 @@ public class ZusatzbetragVorlageDetailView extends AbstractDetailView
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ZUSATZBETRAEGE_VORLAGE, false, "question-circle.png");
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(getParent());
   }
 

--- a/src/de/jost_net/JVerein/gui/view/ZusatzfeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzfeldDetailView.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.input.SaveButton;
+import de.jost_net.JVerein.gui.input.SaveNeuButton;
 import de.jost_net.JVerein.gui.control.FelddefinitionControl;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -49,6 +50,7 @@ public class ZusatzfeldDetailView extends AbstractDetailView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
     buttons.paint(this.getParent());
   }
 


### PR DESCRIPTION
Ich habe jetzt die "Speichern und neu" Buttons überall hinzugefügt. 
Wie in #952 besprochen werden sie nur beim Erzeugen eines neuen Objekts angezeigt.

Es gibt noch eine Sache die mir nicht gefällt.
Mit den Vor und Zurück Buttons und auch beim SaveNeuButton werden sie nur entweder bei bestehenden Objekten oder neuen Objekten gezeichnet. Dazu haben wir die paint Methode überschrieben.  Die Button Area berechnet aber die Anzahl der Spalten anhand der hinzugefügten Buttons. Sie ist also größer als die wirklich angezeigten Buttons. Das führt dazu, dass die Buttons nicht mehr ganz rechts angezeigt werden.
Gibt es eine Möglichkeit das in der Button Area zu erkennen und die Anzahl richtig zu berechnen?
Wenn nicht, ist die Frage ob wir das so akzeptieren oder ob ich doch in den Detail Views die Abfrage nach isNewObject mache und die Buttons nur dann hinzufüge wenn sie auch angezeigt werden sollen.
