### PR TITLE
Erweiterung und Fixes bei Mitglied Anzeige

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -127,7 +127,7 @@ public class DokumentControl extends AbstractControl
       {
         GUI.startView(new DokumentDetailView(verzeichnis), doc);
       }
-    }, null);
+    }, null, false, "document-new.png");
     neuButton.setEnabled(enabled);
     return neuButton;
   }

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -293,6 +293,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput ZeigeArbeitseinsatzInTabInput;
 
+  private CheckboxInput ZeigeDokumenteInTabInput;
+
   private CheckboxInput zusatzbetragAusgetretene;
 
   private SelectInput altersmodel;
@@ -1799,6 +1801,17 @@ public class EinstellungControl extends AbstractControl
     return ZeigeArbeitseinsatzInTabInput;
   }
 
+  public CheckboxInput getZeigeDokumenteInTabCheckbox() throws RemoteException
+  {
+    if (ZeigeDokumenteInTabInput != null)
+    {
+      return ZeigeDokumenteInTabInput;
+    }
+    ZeigeDokumenteInTabInput = new CheckboxInput(
+        Einstellungen.getSettingBoolean("ZeigeDokumenteInTab", true));
+    return ZeigeDokumenteInTabInput;
+  }
+
   public SelectInput getBuchungBuchungsartAuswahl() throws RemoteException
   {
     if (null != buchungBuchungsartAuswahl)
@@ -2875,6 +2888,8 @@ public class EinstellungControl extends AbstractControl
           (Boolean) getZeigeLesefelderInTabCheckbox().getValue());
       Einstellungen.setSettingBoolean("ZeigeArbeitseinsatzInTab",
           (Boolean) getZeigeArbeitseinsatzInTabCheckbox().getValue());
+      Einstellungen.setSettingBoolean("ZeigeDokumenteInTab",
+          (Boolean) getZeigeDokumenteInTabCheckbox().getValue());
 
       GUI.getStatusBar().setSuccessText("Einstellungen gespeichert");
     }

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -161,8 +161,11 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
     showInTab = Einstellungen.getSettingBoolean("ZeigeLesefelderInTab", true);
     zeichneLesefelder(showInTab ? folder : oben.getComposite(), anzahlSpalten);
 
-    zeichneMitgliedDetail(showInTab ? folder : oben.getComposite());
+    showInTab = Einstellungen.getSettingBoolean("ZeigeArbeitseinsatzInTab",
+        true);
+    zeichneArbeitseinsaetze(showInTab ? folder : oben.getComposite());
 
+    showInTab = Einstellungen.getSettingBoolean("ZeigeDokumenteInTab", true);
     zeichneDokumente(showInTab ? folder : oben.getComposite());
 
     // Aktivier zuletzt ausgewählten Tab.
@@ -270,14 +273,19 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
           .createObject(MitgliedDokument.class, null);
       mido.setReferenz(Long.valueOf(control.getMitglied().getID()));
       DokumentControl dcontrol = new DokumentControl(this, "mitglieder", true);
-      cont.addPart(dcontrol.getDokumenteList(mido));
+
       ButtonArea butts = new ButtonArea();
       butts.addButton(dcontrol.getNeuButton(mido));
       butts.paint(cont.getComposite());
+
+      cont.getComposite().setLayoutData(new GridData(GridData.FILL_VERTICAL));
+      cont.getComposite().setLayout(new GridLayout(1, false));
+
+      cont.addPart(dcontrol.getDokumenteList(mido));
     }
   }
 
-  private void zeichneMitgliedDetail(Composite parentComposite)
+  private void zeichneArbeitseinsaetze(Composite parentComposite)
       throws RemoteException
   {
     if (isMitgliedDetail()

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenMitgliedAnsichtView.java
@@ -113,6 +113,10 @@ public class EinstellungenMitgliedAnsichtView extends AbstractView
       leftTab.addLabelPair("Zeige Arbeitseinsatz in Tab",
           control.getZeigeArbeitseinsatzInTabCheckbox());
 
+    if ((Boolean) Einstellungen.getEinstellung(Property.DOKUMENTENSPEICHERUNG))
+      leftTab.addLabelPair("Zeige Dokumente in Tab",
+          control.getZeigeDokumenteInTabCheckbox());
+
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN_ANSICHT, false, "question-circle.png");


### PR DESCRIPTION
Bei Mitglied Anzeige habe ich einiges korrigiert:
* Im Dokumente Tab habe ich den Button nach oben rechts verschoben so wie bei den anderen Tabs üblich
* Das Icon für "Neues Dokument" habe ich an das übliche Icon angepasst
* In den Einstellungen Mitglieder Ansicht fehlte die Checkbox für "Zeige Dokumente in Tab"
* zeichneMitgliedDetail habe ich in zeichneArbeitseinsaetze umbenannt, weil es ganau das macht
* Bei Arbeitseinsätzen und Dokumenten wurde showInTab vor der Anzeige nicht initialisiert. Dadurch wurde die Einstellung von Lesefeldern genommen

Den Bug des letzten Punktes fixe ich nur in 3.2, er ist ja wohl noch nie aufgefallen.