### PR TITLE
DB Update Transaction

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/AbstractDDLUpdate.java
@@ -85,7 +85,7 @@ public abstract class AbstractDDLUpdate implements IDDLUpdate
     }
     try
     {
-      Logger.debug(statement);
+      Logger.info(statement);
       ScriptExecutor.execute(new StringReader(statement), conn, null);
       if (setVersion)
       {

--- a/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
+++ b/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.Variable.MitgliedVar;
 import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.keys.Zahlungsweg;
@@ -263,11 +264,19 @@ public class JVereinUpdateProvider
           monitor, conn);
       Method method = object.getClass().getMethod("run", new Class[] {});
       Object[] args = new Object[] {};
+      DBTransaction.starten();
       method.invoke(object, args);
+      DBTransaction.commit();
     }
     catch (ClassNotFoundException e)
     {
+      DBTransaction.rollback();
       return false;
+    }
+    catch (Exception e)
+    {
+      DBTransaction.rollback();
+      throw e;
     }
     return true;
   }


### PR DESCRIPTION
Da es immer mal wider Probleme beim Update gibt, wie zB. hier: https://www.jverein-forum.de/viewtopic.php?p=20778#p20778 denke ich, das es sinnvoll ist, die Updates in einer Transaction laufen zu lassen, so dass sie nur komplett durchlaufen und auch die Version erst am Ende hochgezählt wird. So kann das Update auch wiederholt werden.
Außerdem habe ich das Logging des Statements auf info erhöht, so kann bei Fehlern einfacher nach gesucht werden, ohne dass der Anwender das Loglevel ändern muss.