### PR TITLE
Fehler DB Update behoben

### DIFF
--- a/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
+++ b/src/de/jost_net/JVerein/server/JVereinUpdateProvider.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.Variable.MitgliedVar;
 import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.keys.Zahlungsweg;
@@ -264,19 +263,13 @@ public class JVereinUpdateProvider
           monitor, conn);
       Method method = object.getClass().getMethod("run", new Class[] {});
       Object[] args = new Object[] {};
-      DBTransaction.starten();
+
       method.invoke(object, args);
-      DBTransaction.commit();
+      conn.commit();
     }
     catch (ClassNotFoundException e)
     {
-      DBTransaction.rollback();
       return false;
-    }
-    catch (Exception e)
-    {
-      DBTransaction.rollback();
-      throw e;
     }
     return true;
   }


### PR DESCRIPTION
#992 hatte nicht funktioniert. Jetzt habe ich das mit den Transactions bei jameica besser verstanden. Diese sind nur jameica intern und werden nicht an die DB übermittelt. Grundsätzlich ist überall ein Commit nötig. Vom DB Object Update/insert/delete wird das immer ausgeführt, wenn nicht per `transactionBegin()` eine Transaction gestartet wurde.
Auf die direkten DB Befehle beim Update hat das jedoch keinen Einfluss, hier muss immer händisch ein Commit ausgeführt werden. Daher habe ich es jetzt so geändert, dass nach dem Ausführen einer kompletten Update Datei ein Commit gesendet wird, und somit die Änderungen sauber in die DB geschrieben werden.