### PR TITLE
Eindeutigkeit überprüfen

### DIFF
--- a/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/BeitragsgruppeImpl.java
@@ -72,6 +72,20 @@ public class BeitragsgruppeImpl extends AbstractJVereinDBObject
       {
         throw new ApplicationException("Bitte Bezeichnung eingeben");
       }
+      DBIterator<Beitragsgruppe> gruppeIt = Einstellungen.getDBService()
+          .createList(Beitragsgruppe.class);
+      while (gruppeIt.hasNext())
+      {
+        Beitragsgruppe test = gruppeIt.next();
+        if (test.getBezeichnung().equalsIgnoreCase(getBezeichnung()))
+        {
+          if (!test.getID().equalsIgnoreCase(this.getID()))
+          {
+            throw new ApplicationException(
+                "Bitte eindeutige Bezeichnung eingeben!");
+          }
+        }
+      }
       switch (Beitragsmodel.getByKey(
           (Integer) Einstellungen.getEinstellung(Property.BEITRAGSMODEL)))
       {

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Steuer;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -69,6 +70,19 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
       if (getNummer() < 0)
       {
         throw new ApplicationException("Nummer nicht gültig");
+      }
+      DBIterator<Buchungsart> artIt = Einstellungen.getDBService()
+          .createList(Buchungsart.class);
+      while (artIt.hasNext())
+      {
+        Buchungsart test = artIt.next();
+        if (test.getNummer() == getNummer())
+        {
+          if (!test.getID().equalsIgnoreCase(this.getID()))
+          {
+            throw new ApplicationException("Bitte eindeutige Nummer eingeben!");
+          }
+        }
       }
       if (getSteuer() != null
           && getSteuer().getBuchungsart().getArt() != getArt())

--- a/src/de/jost_net/JVerein/server/BuchungsklasseImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsklasseImpl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -62,6 +64,19 @@ public class BuchungsklasseImpl extends AbstractJVereinDBObject
       if (getNummer() < 0)
       {
         throw new ApplicationException("Nummer nicht gültig");
+      }
+      DBIterator<Buchungsklasse> klassenIt = Einstellungen.getDBService()
+          .createList(Buchungsklasse.class);
+      while (klassenIt.hasNext())
+      {
+        Buchungsklasse test = klassenIt.next();
+        if (test.getNummer() == getNummer())
+        {
+          if (!test.getID().equalsIgnoreCase(this.getID()))
+          {
+            throw new ApplicationException("Bitte eindeutige Nummer eingeben!");
+          }
+        }
       }
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/server/EigenschaftGruppeImpl.java
+++ b/src/de/jost_net/JVerein/server/EigenschaftGruppeImpl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -59,6 +61,20 @@ public class EigenschaftGruppeImpl extends AbstractJVereinDBObject
       if (getBezeichnung() == null)
       {
         throw new ApplicationException("Bitte Bezeichnung eingeben");
+      }
+      DBIterator<EigenschaftGruppe> gruppeIt = Einstellungen.getDBService()
+          .createList(EigenschaftGruppe.class);
+      while (gruppeIt.hasNext())
+      {
+        EigenschaftGruppe test = gruppeIt.next();
+        if (test.getBezeichnung().equalsIgnoreCase(getBezeichnung()))
+        {
+          if (!test.getID().equalsIgnoreCase(this.getID()))
+          {
+            throw new ApplicationException(
+                "Bitte eindeutige Bezeichnung eingeben!");
+          }
+        }
       }
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/server/EigenschaftImpl.java
+++ b/src/de/jost_net/JVerein/server/EigenschaftImpl.java
@@ -18,8 +18,10 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Eigenschaft;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -76,6 +78,20 @@ public class EigenschaftImpl extends AbstractJVereinDBObject
     if (getEigenschaftGruppe() == null)
     {
       throw new ApplicationException("Bitte Eigenschaftengruppe auswählen");
+    }
+    DBIterator<Eigenschaft> eigIt = Einstellungen.getDBService()
+        .createList(Eigenschaft.class);
+    while (eigIt.hasNext())
+    {
+      Eigenschaft test = eigIt.next();
+      if (test.getBezeichnung().equalsIgnoreCase(getBezeichnung()))
+      {
+        if (!test.getID().equalsIgnoreCase(this.getID()))
+        {
+          throw new ApplicationException(
+              "Bitte eindeutige Bezeichnung eingeben!");
+        }
+      }
     }
   }
 

--- a/src/de/jost_net/JVerein/server/FormularImpl.java
+++ b/src/de/jost_net/JVerein/server/FormularImpl.java
@@ -62,13 +62,17 @@ public class FormularImpl extends AbstractJVereinDBObject implements Formular
       {
         throw new ApplicationException("Bitte gültigen Dateinamen angeben!");
       }
+      if (getBezeichnung() == null || getBezeichnung().length() == 0)
+      {
+        throw new ApplicationException("Bitte eine Bezeichnung eingeben");
+      }
       DBIterator<Formular> it = Einstellungen.getDBService()
           .createList(Formular.class);
       it.addFilter("bezeichnung = ?", getBezeichnung());
       if (it.hasNext())
       {
         throw new ApplicationException(
-            "Diese Bezeichnung wird schon verwendet, bitte eine Andere verwenden.");
+            "Bitte eindeutige Bezeichnung eingeben!");
       }
     }
     catch (RemoteException e)
@@ -85,8 +89,7 @@ public class FormularImpl extends AbstractJVereinDBObject implements Formular
     {
       if (getBezeichnung() == null || getBezeichnung().length() == 0)
       {
-        throw new ApplicationException(
-            "Bitte eine eindeutige Bezeichnung eingeben");
+        throw new ApplicationException("Bitte eine Bezeichnung eingeben");
       }
     }
     catch (RemoteException e)

--- a/src/de/jost_net/JVerein/server/MitgliedstypImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedstypImpl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -71,6 +73,20 @@ public class MitgliedstypImpl extends AbstractJVereinDBObject
       if (getBezeichnung() == null || getBezeichnung().length() == 0)
       {
         throw new ApplicationException("Bitte Bezeichnung eingeben");
+      }
+      DBIterator<Mitgliedstyp> typIt = Einstellungen.getDBService()
+          .createList(Mitgliedstyp.class);
+      while (typIt.hasNext())
+      {
+        Mitgliedstyp test = typIt.next();
+        if (test.getBezeichnung().equalsIgnoreCase(getBezeichnung()))
+        {
+          if (!test.getID().equalsIgnoreCase(this.getID()))
+          {
+            throw new ApplicationException(
+                "Bitte eindeutige Bezeichnung eingeben!");
+          }
+        }
       }
     }
     catch (RemoteException e)


### PR DESCRIPTION
Bei einigen Objekten wurde beim Speichern nicht auf eindeutige Bezeichnung bzw. Nummer überprüft.
Darum gab es hier nur eine DB Fehlermeldung und keine genaue Fehlerursache.