### PR TITLE
Empfänger Liste Vorschau in den DruckMail Views

### DIFF
--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -30,12 +30,17 @@ import org.apache.commons.lang.StringUtils;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.FilterControl;
+import de.jost_net.JVerein.gui.control.SollbuchungControl.DIFFERENZ;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
+import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
+import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.server.EigenschaftenNode;
+import de.jost_net.JVerein.server.ExtendedDBIterator;
+import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
@@ -400,6 +405,62 @@ public class MitgliedQuery
         bedingungen.toArray(), rs);
 
     String eigenschaftenString = control.getEigenschaftenString();
+
+    if (control.isDifferenzAktiv()
+        && control.getDifferenz().getValue() != DIFFERENZ.EGAL)
+    {
+      Double limit = Double.valueOf(0d);
+      if (control.isDoubleAuswAktiv()
+          && control.getDoubleAusw().getValue() != null)
+      {
+        // Es ist egal ob der Betrag positiv oder negativ eingetragen wurde
+        limit = Math.abs((Double) control.getDoubleAusw().getValue());
+      }
+      ArrayList<Long> mitgliederNeuIds = new ArrayList<>();
+      for (Long l : mitgliederIds)
+      {
+        ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+            Sollbuchung.TABLE_NAME);
+        it.addColumn("sum(cast(COALESCE(buchung.ist,0) - COALESCE("
+            + Sollbuchung.T_BETRAG + ",0) AS DECIMAL(10,2))) as dif");
+        it.leftJoin(
+            "(SELECT sum(COALESCE((betrag),0)) AS ist," + Buchung.T_SOLLBUCHUNG
+                + " FROM buchung GROUP BY " + Buchung.T_SOLLBUCHUNG
+                + ") AS buchung",
+            Buchung.T_SOLLBUCHUNG + " = " + Sollbuchung.TABLE_NAME_ID);
+        if (control.isDatumvonAktiv()
+            && control.getDatumvon().getValue() != null)
+        {
+          it.addFilter(Sollbuchung.T_DATUM + " >= ?",
+              (Date) control.getDatumvon().getValue());
+        }
+        if (control.isDatumbisAktiv()
+            && control.getDatumbis().getValue() != null)
+        {
+          it.addFilter(Sollbuchung.T_DATUM + " <= ?",
+              (Date) control.getDatumbis().getValue());
+        }
+        it.addFilter(Sollbuchung.T_MITGLIED + " = " + l.toString());
+        it.addGroupBy(Sollbuchung.T_MITGLIED);
+
+        if (it.hasNext())
+        {
+          PseudoDBObject o = it.next();
+          Double dif = o.getDouble("dif");
+          if (control.getDifferenz().getValue() == DIFFERENZ.FEHLBETRAG
+              && dif < -limit)
+          {
+            mitgliederNeuIds.add(l);
+          }
+          if (control.getDifferenz().getValue() == DIFFERENZ.UEBERZAHLUNG
+              && dif > limit)
+          {
+            mitgliederNeuIds.add(l);
+          }
+        }
+      }
+      mitgliederIds = mitgliederNeuIds;
+    }
 
     if (control.isEigenschaftenAuswahlAktiv()
         && eigenschaftenString.length() > 0)

--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -415,19 +415,20 @@ public class MitgliedQuery
         it.addFilter(Sollbuchung.T_DATUM + " <= ?",
             (Date) control.getDatumbis().getValue());
       }
+      if (control.getDifferenz().getValue() == DIFFERENZ.FEHLBETRAG)
+      {
+        it.addHaving("dif < -" + limit.toString());
+      }
+      else
+      {
+        it.addHaving("dif > " + limit.toString());
+      }
       it.addGroupBy(Sollbuchung.T_MITGLIED);
       ArrayList<String> diffIds = new ArrayList<>();
       while (it.hasNext())
       {
         PseudoDBObject o = it.next();
-        Double dif = o.getDouble("dif");
-        if ((control.getDifferenz().getValue() == DIFFERENZ.FEHLBETRAG
-            && dif < -limit)
-            || (control.getDifferenz().getValue() == DIFFERENZ.UEBERZAHLUNG
-                && dif > limit))
-        {
-          diffIds.add(String.valueOf(o.getAttribute("mid")));
-        }
+        diffIds.add(String.valueOf(o.getAttribute("mid")));
       }
 
       if (diffIds.size() == 0)

--- a/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DruckMailControl.java
@@ -237,7 +237,7 @@ public abstract class DruckMailControl extends FilterControl
 
   public Button getDruckMailMitgliederButton(final Object object, String option)
   {
-    Button button = new Button("Mitglieder Liste", new Action()
+    Button button = new Button("Empfaenger Liste", new Action()
     {
 
       @Override

--- a/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
@@ -103,9 +103,13 @@ public class FreieFormulareControl extends DruckMailControl
         }
       }
     }
-    if (ohneMail > 0)
+    if (ohneMail == 1)
     {
-      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+      text = ohneMail + " Mitglied hat keine Mail Adresse.";
+    }
+    else if (ohneMail > 1)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse.";
     }
     return new DruckMailEmpfaenger(mitglieder, text);
   }

--- a/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
@@ -1,8 +1,13 @@
 package de.jost_net.JVerein.gui.control;
 
-import java.io.IOException;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
 
+import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.io.FreiesFormularAusgabe;
+import de.jost_net.JVerein.keys.Ausgabeart;
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
@@ -44,9 +49,64 @@ public class FreieFormulareControl extends DruckMailControl
   }
 
   private void generiereFreieFormulare(Object currentObject)
-      throws IOException, ApplicationException
   {
-    saveDruckMailSettings();
-    new FreiesFormularAusgabe(this);
+    try
+    {
+      saveDruckMailSettings();
+      new FreiesFormularAusgabe(getMitglieder(currentObject), this);
+    }
+    catch (ApplicationException ae)
+    {
+      GUI.getStatusBar().setErrorText(ae.getMessage());
+    }
+    catch (Exception e)
+    {
+      Logger.error("", e);
+      GUI.getStatusBar().setErrorText(e.getMessage());
+    }
+  }
+
+  private ArrayList<Mitglied> getMitglieder(Object object)
+      throws RemoteException, ApplicationException
+  {
+    Mitgliedstyp mitgliedstyp = (Mitgliedstyp) getSuchMitgliedstyp(
+        Mitgliedstypen.ALLE).getValue();
+    int type = -1;
+    if (mitgliedstyp != null)
+    {
+      type = Integer.parseInt(mitgliedstyp.getID());
+    }
+    ArrayList<Mitglied> mitglieder = new MitgliedQuery(this).get(type, null);
+    if (mitglieder.size() == 0)
+    {
+      throw new ApplicationException(
+          "Für die gewählten Filterkriterien wurden keine Mitglieder gefunden.");
+    }
+    return mitglieder;
+  }
+
+  @Override
+  DruckMailEmpfaenger getDruckMailMitglieder(Object object, String option)
+      throws RemoteException, ApplicationException
+  {
+    ArrayList<Mitglied> mitglieder = getMitglieder(object);
+    String text = null;
+    int ohneMail = 0;
+    if (getAusgabeart().getValue() == Ausgabeart.MAIL)
+    {
+      for (Mitglied m : mitglieder)
+      {
+        String mail = m.getEmail();
+        if (mail == null || mail.isEmpty())
+        {
+          ohneMail++;
+        }
+      }
+    }
+    if (ohneMail > 0)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+    }
+    return new DruckMailEmpfaenger(mitglieder, text);
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -335,11 +335,14 @@ public class MitgliedControl extends FilterControl implements Savable
 
   private String eigenschaftenHash;
 
+  public static MitgliedControl control = null;
+
   public MitgliedControl(AbstractView view)
   {
     super(view);
     settings = new Settings(this.getClass());
     settings.setStoreWhenRead(true);
+    control = this;
   }
 
   public Mitglied getMitglied()

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -23,6 +23,7 @@ import java.rmi.RemoteException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
@@ -51,6 +52,7 @@ import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
+import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.JVDateFormatDATETIME;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -65,7 +67,6 @@ import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
-import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -83,6 +84,12 @@ public class PreNotificationControl extends DruckMailControl
   private SelectInput ct1ausgabe;
 
   private TextInput verwendungszweck;
+
+  public enum TYP
+  {
+    DRUCKMAIL,
+    CENT1
+  }
 
   public PreNotificationControl(AbstractView view)
   {
@@ -153,40 +160,31 @@ public class PreNotificationControl extends DruckMailControl
         try
         {
           saveDruckMailSettings();
-          Object object = currentObject;
-          if (object == null)
-          {
-            if (abrechnungslaufausw != null
-                && abrechnungslaufausw.getValue() != null)
-            {
-              object = abrechnungslaufausw.getValue();
-            }
-            else
-            {
-              GUI.getStatusBar().setErrorText(
-                  "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
-              return;
-            }
-          }
+
           String val = (String) getOutput().getValue();
           String pdfMode = (String) getPdfModus().getValue();
 
           settings.setAttribute(settingsprefix + "tab.selection",
               folder.getSelectionIndex());
-          saveDruckMailSettings();
 
+          boolean mitMail = true;
           if (val.equals(PDF1))
           {
-            generierePDF(object, false, pdfMode);
+            mitMail = false;
           }
-          if (val.equals(PDF2))
+
+          if (val.equals(PDF1) || val.equals(PDF2))
           {
-            generierePDF(object, true, pdfMode);
+            generierePDF(getLastschriften(currentObject, mitMail), pdfMode);
           }
           if (val.equals(EMAIL))
           {
-            generiereEMail(object);
+            generiereEMail(getLastschriften(currentObject, true));
           }
+        }
+        catch (ApplicationException ae)
+        {
+          GUI.getStatusBar().setErrorText(ae.getMessage());
         }
         catch (Exception e)
         {
@@ -209,21 +207,7 @@ public class PreNotificationControl extends DruckMailControl
         try
         {
           saveDruckMailSettings();
-          Object object = currentObject;
-          if (object == null)
-          {
-            if (abrechnungslaufausw != null
-                && abrechnungslaufausw.getValue() != null)
-            {
-              object = abrechnungslaufausw.getValue();
-            }
-            else
-            {
-              GUI.getStatusBar().setErrorText(
-                  "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
-              return;
-            }
-          }
+
           Ct1Ausgabe aa = (Ct1Ausgabe) ct1ausgabe.getValue();
           settings.setAttribute(settingsprefix + "ct1ausgabe", aa.getKey());
           if (ausfuehrungsdatum.getValue() == null)
@@ -238,11 +222,11 @@ public class PreNotificationControl extends DruckMailControl
               (String) getVerwendungszweck().getValue());
           settings.setAttribute(settingsprefix + "tab.selection",
               folder.getSelectionIndex());
-          generiere1ct(object);
+          generiere1ct(getLastschriften1ct(currentObject));
         }
-        catch (OperationCanceledException oce)
+        catch (ApplicationException ae)
         {
-          throw oce;
+          GUI.getStatusBar().setErrorText(ae.getMessage());
         }
         catch (Exception e)
         {
@@ -254,95 +238,9 @@ public class PreNotificationControl extends DruckMailControl
     return button;
   }
 
-  private void generierePDF(Object currentObject, boolean mitMail,
-      String pdfMode) throws IOException, ApplicationException
+  private void generierePDF(List<Lastschrift> lastschriften, String pdfMode)
+      throws IOException, ApplicationException
   {
-    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
-    if (currentObject instanceof Abrechnungslauf)
-    {
-      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
-      DBIterator<Lastschrift> it = Einstellungen.getDBService()
-          .createList(Lastschrift.class);
-      it.addFilter("abrechnungslauf = ?", abrl.getID());
-      if (!mitMail)
-      {
-        it.addFilter("(email is null or length(email)=0)");
-      }
-      it.setOrder("order by name, vorname");
-      while (it.hasNext())
-      {
-        lastschriften.add((Lastschrift) it.next());
-      }
-
-      if (lastschriften.size() == 0 && !mitMail)
-      {
-        GUI.getStatusBar().setErrorText(
-            "Der Abrechnungslauf hat keine Lastschriften ohne Mailadresse");
-        return;
-      }
-      if (lastschriften.size() == 0)
-      {
-        GUI.getStatusBar()
-            .setErrorText("Der Abrechnungslauf hat keine Lastschriften");
-        return;
-      }
-    }
-    else if (currentObject instanceof Lastschrift)
-    {
-      Lastschrift lastschrift = (Lastschrift) currentObject;
-      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
-      if (abrl.getAbgeschlossen())
-      {
-        GUI.getStatusBar().setErrorText(
-            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
-        return;
-      }
-      if (!mitMail && lastschrift.getEmail() != null
-          && !lastschrift.getEmail().isEmpty())
-      {
-        GUI.getStatusBar()
-            .setErrorText("Die ausgewählte Lastschrift hat eine Mail Adresse");
-        return;
-      }
-      else
-      {
-        lastschriften.add(lastschrift);
-      }
-    }
-    else if (currentObject instanceof Lastschrift[])
-    {
-      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
-      for (Lastschrift lastschrift : lastschriftarray)
-      {
-        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
-            .getAbrechnungslauf();
-        if (abrl.getAbgeschlossen())
-        {
-          GUI.getStatusBar()
-              .setErrorText("Die ausgewählte Lastschrift mit der Nr "
-                  + lastschrift.getID() + " ist bereits abgeschlossen");
-          return;
-        }
-        if (!(!mitMail && lastschrift.getEmail() != null
-            && !lastschrift.getEmail().isEmpty()))
-        {
-          lastschriften.add(lastschrift);
-        }
-      }
-      if (lastschriften.size() == 0)
-      {
-        GUI.getStatusBar().setErrorText(
-            "Alle ausgewählten Lastschriften haben eine Mail Adresse");
-        return;
-      }
-    }
-    else
-    {
-      GUI.getStatusBar().setErrorText(
-          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
-      return;
-    }
-
     boolean einzelnePdfs = false;
     if (pdfMode.equals(EINZELN_NUMMERIERT)
         || pdfMode.equals(EINZELN_MITGLIEDSNUMMER)
@@ -427,62 +325,9 @@ public class PreNotificationControl extends DruckMailControl
 
   }
 
-  private void generiere1ct(Object currentObject) throws Exception
+  private void generiere1ct(ArrayList<Lastschrift> lastschriften)
+      throws Exception
   {
-    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
-    if (currentObject instanceof Abrechnungslauf)
-    {
-      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
-      DBIterator<Lastschrift> it = Einstellungen.getDBService()
-          .createList(Lastschrift.class);
-      it.addFilter("abrechnungslauf = ?", abrl.getID());
-      it.setOrder("order by name, vorname");
-      while (it.hasNext())
-      {
-        lastschriften.add((Lastschrift) it.next());
-      }
-      if (lastschriften.size() == 0)
-      {
-        GUI.getStatusBar()
-            .setErrorText("Der Abrechnungslauf hat keine Lastschriften");
-        return;
-      }
-    }
-    else if (currentObject instanceof Lastschrift)
-    {
-      Lastschrift lastschrift = (Lastschrift) currentObject;
-      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
-      if (abrl.getAbgeschlossen())
-      {
-        GUI.getStatusBar().setErrorText(
-            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
-        return;
-      }
-      lastschriften.add((Lastschrift) currentObject);
-    }
-    else if (currentObject instanceof Lastschrift[])
-    {
-      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
-      for (Lastschrift lastschrift : lastschriftarray)
-      {
-        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
-            .getAbrechnungslauf();
-        if (abrl.getAbgeschlossen())
-        {
-          GUI.getStatusBar()
-              .setErrorText("Die ausgewählte Lastschrift mit der Nr "
-                  + lastschrift.getID() + " ist bereits abgeschlossen");
-          return;
-        }
-        lastschriften.add(lastschrift);
-      }
-    }
-    else
-    {
-      GUI.getStatusBar().setErrorText(
-          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
-      return;
-    }
 
     File file = null;
     Ct1Ausgabe aa = Ct1Ausgabe.getByKey(settings
@@ -527,82 +372,9 @@ public class PreNotificationControl extends DruckMailControl
     GUI.getStatusBar().setSuccessText("Anzahl Überweisungen: " + anzahl);
   }
 
-  private void generiereEMail(Object currentObject) throws IOException
+  private void generiereEMail(ArrayList<Lastschrift> lastschriften)
+      throws IOException
   {
-    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
-    if (currentObject instanceof Abrechnungslauf)
-    {
-      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
-      DBIterator<Lastschrift> it = Einstellungen.getDBService()
-          .createList(Lastschrift.class);
-      it.addFilter("abrechnungslauf = ?", abrl.getID());
-      it.addFilter("email is not null and length(email) > 0");
-      it.setOrder("order by name, vorname");
-      while (it.hasNext())
-      {
-        lastschriften.add((Lastschrift) it.next());
-      }
-      if (lastschriften.size() == 0)
-      {
-        GUI.getStatusBar().setErrorText(
-            "Der Abrechnungslauf hat keine Lastschriften mit Mail Adresse");
-        return;
-      }
-    }
-    else if (currentObject instanceof Lastschrift)
-    {
-      Lastschrift lastschrift = (Lastschrift) currentObject;
-      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
-      if (abrl.getAbgeschlossen())
-      {
-        GUI.getStatusBar().setErrorText(
-            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
-        return;
-      }
-      if (lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
-      {
-        lastschriften.add(lastschrift);
-      }
-      else
-      {
-        GUI.getStatusBar()
-            .setErrorText("Die ausgewählte Lastschrift hat keine Mail Adresse");
-        return;
-      }
-    }
-    else if (currentObject instanceof Lastschrift[])
-    {
-      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
-      for (Lastschrift lastschrift : lastschriftarray)
-      {
-        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
-            .getAbrechnungslauf();
-        if (abrl.getAbgeschlossen())
-        {
-          GUI.getStatusBar()
-              .setErrorText("Die ausgewählte Lastschrift mit der Nr "
-                  + lastschrift.getID() + " ist bereits abgeschlossen");
-          return;
-        }
-        if (lastschrift.getEmail() != null && !lastschrift.getEmail().isEmpty())
-        {
-          lastschriften.add(lastschrift);
-        }
-      }
-      if (lastschriften.size() == 0)
-      {
-        GUI.getStatusBar().setErrorText(
-            "Keine der ausgewählten Lastschriften hat eine Mail Adresse");
-        return;
-      }
-    }
-    else
-    {
-      GUI.getStatusBar().setErrorText(
-          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
-      return;
-    }
-
     String betr = (String) getBetreff().getValue();
     String text = (String) getTxt().getValue();
     sendeMail(lastschriften, betr, text);
@@ -671,6 +443,10 @@ public class PreNotificationControl extends DruckMailControl
           int size = lastschriften.size();
           for (Lastschrift ls : lastschriften)
           {
+            if (ls.getEmail() == null || ls.getEmail().isEmpty())
+            {
+              continue;
+            }
             if (isInterrupted())
             {
               monitor.setStatus(ProgressMonitor.STATUS_ERROR);
@@ -771,6 +547,221 @@ public class PreNotificationControl extends DruckMailControl
       }
     };
     Application.getController().start(t);
+  }
+
+  ArrayList<Lastschrift> getLastschriften(Object currentObject, boolean mitMail)
+      throws RemoteException, ApplicationException
+  {
+    if (currentObject == null)
+    {
+      if (abrechnungslaufausw != null && abrechnungslaufausw.getValue() != null)
+      {
+        currentObject = abrechnungslaufausw.getValue();
+      }
+      else
+      {
+        throw new ApplicationException(
+            "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+      }
+    }
+
+    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
+    if (currentObject instanceof Abrechnungslauf)
+    {
+      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+      DBIterator<Lastschrift> it = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", abrl.getID());
+      if (!mitMail)
+      {
+        it.addFilter("(email is null or length(email)=0)");
+      }
+      it.setOrder("order by name, vorname");
+      while (it.hasNext())
+      {
+        lastschriften.add((Lastschrift) it.next());
+      }
+
+      if (lastschriften.size() == 0 && !mitMail)
+      {
+        throw new ApplicationException(
+            "Der Abrechnungslauf hat keine Lastschriften ohne Mailadresse");
+      }
+      if (lastschriften.size() == 0)
+      {
+        throw new ApplicationException(
+            "Der Abrechnungslauf hat keine Lastschriften");
+      }
+    }
+    else if (currentObject instanceof Lastschrift)
+    {
+      Lastschrift lastschrift = (Lastschrift) currentObject;
+      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+      if (abrl.getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
+      }
+      if (!mitMail && lastschrift.getEmail() != null
+          && !lastschrift.getEmail().isEmpty())
+      {
+        throw new ApplicationException(
+            "Die ausgewählte Lastschrift hat eine Mail Adresse");
+      }
+      else
+      {
+        lastschriften.add(lastschrift);
+      }
+    }
+    else if (currentObject instanceof Lastschrift[])
+    {
+      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
+      for (Lastschrift lastschrift : lastschriftarray)
+      {
+        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
+            .getAbrechnungslauf();
+        if (abrl.getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID()
+                  + " ist bereits abgeschlossen");
+        }
+        if (!(!mitMail && lastschrift.getEmail() != null
+            && !lastschrift.getEmail().isEmpty()))
+        {
+          lastschriften.add(lastschrift);
+        }
+      }
+      if (lastschriften.size() == 0)
+      {
+        throw new ApplicationException(
+            "Alle ausgewählten Lastschriften haben eine Mail Adresse");
+      }
+    }
+    else
+    {
+      throw new ApplicationException(
+          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+    }
+    return lastschriften;
+  }
+
+  ArrayList<Lastschrift> getLastschriften1ct(Object currentObject)
+      throws RemoteException, ApplicationException
+  {
+    if (currentObject == null)
+    {
+      if (abrechnungslaufausw != null && abrechnungslaufausw.getValue() != null)
+      {
+        currentObject = abrechnungslaufausw.getValue();
+      }
+      else
+      {
+        throw new ApplicationException(
+            "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+      }
+    }
+
+    ArrayList<Lastschrift> lastschriften = new ArrayList<>();
+    if (currentObject instanceof Abrechnungslauf)
+    {
+      Abrechnungslauf abrl = (Abrechnungslauf) currentObject;
+      DBIterator<Lastschrift> it = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", abrl.getID());
+      it.setOrder("order by name, vorname");
+      while (it.hasNext())
+      {
+        lastschriften.add((Lastschrift) it.next());
+      }
+      if (lastschriften.size() == 0)
+      {
+        throw new ApplicationException(
+            "Der Abrechnungslauf hat keine Lastschriften");
+      }
+    }
+    else if (currentObject instanceof Lastschrift)
+    {
+      Lastschrift lastschrift = (Lastschrift) currentObject;
+      Abrechnungslauf abrl = (Abrechnungslauf) lastschrift.getAbrechnungslauf();
+      if (abrl.getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Die ausgewählte Lastschrift ist bereits abgeschlossen");
+      }
+      lastschriften.add((Lastschrift) currentObject);
+    }
+    else if (currentObject instanceof Lastschrift[])
+    {
+      Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
+      for (Lastschrift lastschrift : lastschriftarray)
+      {
+        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
+            .getAbrechnungslauf();
+        if (abrl.getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID()
+                  + " ist bereits abgeschlossen");
+        }
+        lastschriften.add(lastschrift);
+      }
+    }
+    else
+    {
+      throw new ApplicationException(
+          "Kein Abrechnungslauf oder keine Lastschrift ausgewählt");
+    }
+    return lastschriften;
+  }
+
+  @Override
+  DruckMailEmpfaenger getDruckMailMitglieder(Object currentObject,
+      String option) throws RemoteException, ApplicationException
+  {
+    ArrayList<Mitglied> mitglieder = new ArrayList<>();
+    String text = null;
+    int ohneMail = 0;
+    String val = (String) getOutput().getValue();
+    List<Lastschrift> lastschriften;
+    if (option.equals(TYP.CENT1.toString()))
+    {
+      lastschriften = getLastschriften1ct(currentObject);
+    }
+    else if (val.equals(EMAIL))
+    {
+      lastschriften = getLastschriften(currentObject, true);
+    }
+    else
+    {
+      boolean mitMail = true;
+      if (val.equals(PDF1))
+      {
+        mitMail = false;
+      }
+      lastschriften = getLastschriften(currentObject, mitMail);
+    }
+    for (Lastschrift l : lastschriften)
+    {
+      Mitglied m = l.getMitglied();
+      // Die Mail geht an die Adresse in der Lastschrift
+      // Darum zeigen wir diese im Vorschau Dialog an
+      m.setEmail(l.getEmail());
+      mitglieder.add(m);
+      if (val.equals(EMAIL))
+      {
+        String mail = l.getEmail();
+        if (mail == null || mail.isEmpty())
+        {
+          ohneMail++;
+        }
+      }
+    }
+    if (ohneMail > 0 && !option.equals(TYP.CENT1.toString()))
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+    }
+    return new DruckMailEmpfaenger(mitglieder, text);
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -844,9 +844,13 @@ public class RechnungControl extends DruckMailControl implements Savable
         }
       }
     }
-    if (ohneMail > 0)
+    if (ohneMail == 1)
     {
-      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+      text = ohneMail + " Mitglied hat keine Mail Adresse.";
+    }
+    else if (ohneMail > 1)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse.";
     }
     return new DruckMailEmpfaenger(mitglieder, text);
   }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.StringTokenizer;
@@ -30,6 +31,7 @@ import org.eclipse.swt.widgets.TreeItem;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.Messaging.MitgliedskontoMessage;
+import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.Queries.SollbuchungQuery;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.EditAction;
@@ -47,10 +49,12 @@ import de.jost_net.JVerein.gui.view.BuchungDetailView;
 import de.jost_net.JVerein.gui.view.SollbuchungDetailView;
 import de.jost_net.JVerein.gui.view.SollbuchungPositionDetailView;
 import de.jost_net.JVerein.io.Kontoauszug;
+import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -420,6 +424,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
           }
         }
       }
+
     };
     mitgliedskontoTree.setMulti(true);
     mitgliedskontoTree.addColumn("Name, Vorname", "name");
@@ -677,7 +682,11 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         try
         {
           saveDruckMailSettings();
-          new Kontoauszug(currentObject, control);
+          new Kontoauszug(getMitglieder(currentObject), control);
+        }
+        catch (ApplicationException ae)
+        {
+          GUI.getStatusBar().setErrorText(ae.getMessage());
         }
         catch (Exception e)
         {
@@ -935,4 +944,70 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         getDatumbis().getValue(), getMailauswahl().getValue() };
   }
 
+  private List<Mitglied> getMitglieder(Object object)
+      throws RemoteException, ApplicationException
+  {
+    ArrayList<Mitglied> mitglieder = new ArrayList<>();
+    if (object == null && isSuchMitgliedstypActive()
+        && getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue() != null)
+    {
+      Mitgliedstyp mt = (Mitgliedstyp) getSuchMitgliedstyp(Mitgliedstypen.ALLE)
+          .getValue();
+      mitglieder = new MitgliedQuery(this).get(Integer.parseInt(mt.getID()),
+          null);
+      if (mitglieder == null || mitglieder.isEmpty())
+      {
+        throw new ApplicationException(
+            "Für die gewählten Filterkriterien wurden keine Mitglieder gefunden.");
+      }
+    }
+    else if (object == null && isSuchMitgliedstypActive()
+        && getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue() == null)
+    {
+      mitglieder = new MitgliedQuery(this).get(-1, null);
+      if (mitglieder == null || mitglieder.isEmpty())
+      {
+        throw new ApplicationException(
+            "Für die gewählten Filterkriterien wurden keine Mitglieder gefunden.");
+      }
+    }
+    else if (object != null && object instanceof Mitglied)
+    {
+      mitglieder.add((Mitglied) object);
+    }
+    else if (object != null && object instanceof Mitglied[])
+    {
+      mitglieder = new ArrayList<>(Arrays.asList((Mitglied[]) object));
+    }
+    else
+    {
+      throw new ApplicationException("Kein Mitglied ausgewählt!");
+    }
+    return mitglieder;
+  }
+
+  @Override
+  DruckMailEmpfaenger getDruckMailMitglieder(Object object, String option)
+      throws RemoteException, ApplicationException
+  {
+    List<Mitglied> mitglieder = getMitglieder(object);
+    String text = null;
+    int ohneMail = 0;
+    if (getAusgabeart().getValue() == Ausgabeart.MAIL)
+    {
+      for (Mitglied m : mitglieder)
+      {
+        String mail = m.getEmail();
+        if (mail == null || mail.isEmpty())
+        {
+          ohneMail++;
+        }
+      }
+    }
+    if (ohneMail > 0)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+    }
+    return new DruckMailEmpfaenger(mitglieder, text);
+  }
 }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -1004,9 +1004,13 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         }
       }
     }
-    if (ohneMail > 0)
+    if (ohneMail == 1)
     {
-      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+      text = ohneMail + " Mitglied hat keine Mail Adresse.";
+    }
+    else if (ohneMail > 1)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse.";
     }
     return new DruckMailEmpfaenger(mitglieder, text);
   }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -1088,7 +1088,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
       throws RemoteException, ApplicationException
   {
     List<Mitglied> mitglieder = new ArrayList<>();
-    String text = null;
+    String text = "";
     int ohneMail = 0;
     int ohneMitglied = 0;
     Spendenbescheinigung[] spbs = getSpbArray(object);
@@ -1115,27 +1115,61 @@ public class SpendenbescheinigungControl extends DruckMailControl
     }
     if (ohneMail > 0 && ohneMitglied == 0)
     {
-      text = ohneMail + " Mitglieder haben keine Mail Adresse!";
+      text = getMailText(ohneMail, false);
     }
     if (ohneMail == 0 && ohneMitglied > 0)
     {
-      if (getAusgabeart().getValue() == Ausgabeart.MAIL)
-      {
-        text = ohneMitglied
-            + " Spendenbescheinigungen haben kein Mitglied gesetzt!";
-      }
-      else
-      {
-        text = ohneMitglied
-            + " Spendenbescheinigungen haben kein Mitglied gesetzt, werden aber gedruckt!";
-      }
+      text = getMitgliedText(ohneMitglied,
+          getAusgabeart().getValue() != Ausgabeart.MAIL);
     }
     if (ohneMail > 0 && ohneMitglied > 0)
     {
-      text = ohneMail + " Mitglieder haben keine Mail Adresse und "
-          + ohneMitglied
-          + " Spendenbescheinigungen haben kein Mitglied gesetzt!";
+      text = getMailText(ohneMail, true) + getMitgliedText(ohneMitglied, false);
     }
     return new DruckMailEmpfaenger(mitglieder, text);
+  }
+
+  private String getMailText(int ohneMail, boolean druck)
+  {
+    String text = "";
+    String zusatz = ".";
+    if (druck)
+    {
+      zusatz = " und ";
+    }
+    if (ohneMail == 1)
+    {
+      text = ohneMail + " Mitglied hat keine Mail Adresse" + zusatz;
+    }
+    else if (ohneMail > 1)
+    {
+      text = ohneMail + " Mitglieder haben keine Mail Adresse" + zusatz;
+    }
+    return text;
+  }
+
+  private String getMitgliedText(int ohneMitglied, boolean druck)
+  {
+    String text = "";
+    String zusatz = ".";
+    if (druck && ohneMitglied == 1)
+    {
+      zusatz = ", wird aber gedruckt.";
+    }
+    if (druck && ohneMitglied > 1)
+    {
+      zusatz = ", werden aber gedruckt.";
+    }
+    if (ohneMitglied == 1)
+    {
+      text = ohneMitglied + " Spendenbescheinigung hat kein Mitglied gesetzt"
+          + zusatz;
+    }
+    else if (ohneMitglied > 1)
+    {
+      text = ohneMitglied
+          + " Spendenbescheinigungen haben kein Mitglied gesetzt" + zusatz;
+    }
+    return text;
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
@@ -1,0 +1,92 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.rmi.Mitglied;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.LabelInput;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+/**
+ * Ein Dialog, ueber den man Empfänger für eine Mail auswählen kann.
+ */
+public class DruckMailMitgliedDialog extends AbstractDialog<Object>
+{
+  private List<Mitglied> mitglieder = null;
+
+  private String text = "";
+
+  public DruckMailMitgliedDialog(List<Mitglied> mitglieder, String text,
+      int position)
+  {
+    super(position);
+    setTitle("Mitglieder Liste");
+    setSize(700, 450);
+    this.mitglieder = mitglieder;
+    this.text = text;
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    LabelGroup group = new LabelGroup(parent, "");
+    LabelInput textFeld = new LabelInput(text);
+    if (text != null && !text.isEmpty())
+    {
+      textFeld.setColor(Color.ERROR);
+    }
+    group.addLabelPair("", textFeld);
+
+    TablePart empfaenger = new TablePart(mitglieder, null);
+    empfaenger.addColumn("EMail", "email");
+    empfaenger.addColumn("Name", "name");
+    empfaenger.addColumn("Vorname", "vorname");
+    empfaenger.addColumn("Mitgliedstyp", Mitglied.MITGLIEDSTYP);
+    empfaenger.setRememberOrder(true);
+    empfaenger.setRememberColWidths(true);
+    empfaenger.setRememberOrder(true);
+    empfaenger.paint(parent);
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Schließen", new Action()
+    {
+      @Override
+      public void handleAction(Object context)
+      {
+        close();
+      }
+    }, null, false, "process-stop.png");
+
+    buttons.paint(parent);
+  }
+
+  @Override
+  protected Object getData() throws Exception
+  {
+    return null;
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
@@ -27,7 +27,6 @@ import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.LabelInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
-import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.LabelGroup;
 
 /**
@@ -54,10 +53,6 @@ public class DruckMailMitgliedDialog extends AbstractDialog<Object>
   {
     LabelGroup group = new LabelGroup(parent, "");
     LabelInput textFeld = new LabelInput(text);
-    if (text != null && !text.isEmpty())
-    {
-      textFeld.setColor(Color.ERROR);
-    }
     group.addLabelPair("", textFeld);
 
     TablePart empfaenger = new TablePart(mitglieder, null);

--- a/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
@@ -42,7 +42,7 @@ public class DruckMailMitgliedDialog extends AbstractDialog<Object>
       int position)
   {
     super(position);
-    setTitle("Mitglieder Liste");
+    setTitle("Empfaenger Liste");
     setSize(700, 450);
     this.mitglieder = mitglieder;
     this.text = text;

--- a/src/de/jost_net/JVerein/gui/view/FreiesFormularMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FreiesFormularMailView.java
@@ -92,6 +92,8 @@ public class FreiesFormularMailView extends AbstractView
         new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
             control, false, "document-new.png"));
     buttons.addButton(
+        control.getDruckMailMitgliederButton(this.getCurrentObject(), null));
+    buttons.addButton(
         control.getStartFreieFormulareButton(this.getCurrentObject(), control));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoauszugMailView.java
@@ -113,6 +113,8 @@ public class KontoauszugMailView extends AbstractView
         new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
             control, false, "document-new.png"));
     buttons.addButton(
+        control.getDruckMailMitgliederButton(this.getCurrentObject(), null));
+    buttons.addButton(
         control.getStartKontoauszugButton(this.getCurrentObject(), control));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/MahnungMailView.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
 import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
+import de.jost_net.JVerein.gui.control.RechnungControl.TYP;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -110,6 +111,8 @@ public class MahnungMailView extends AbstractView
      * EXPORT_TYP.MAHNUNGEN, getCurrentObject()), control, false,
      * "document-save.png"));
      */
+    buttons.addButton(control.getDruckMailMitgliederButton(
+        this.getCurrentObject(), TYP.MAHNUNG.toString()));
     buttons.addButton(control.getStartMahnungButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedListeView.java
@@ -88,7 +88,7 @@ public class MitgliedListeView extends AbstractMitgliedListeView
     right.addInput(control.getStichtag());
 
     // Zeiter Tab
-    TabGroup tab2 = new TabGroup(folder, "Erweitert", true, 3);
+    TabGroup tab2 = new TabGroup(folder, "Datum", true, 3);
     SimpleContainer left2 = new SimpleContainer(tab2.getComposite());
     left2.addInput(control.getGeburtsdatumvon());
     left2.addInput(control.getGeburtsdatumbis());
@@ -100,6 +100,16 @@ public class MitgliedListeView extends AbstractMitgliedListeView
     SimpleContainer right2 = new SimpleContainer(tab2.getComposite());
     right2.addInput(control.getAustrittvon());
     right2.addInput(control.getAustrittbis());
+
+    // Dritter Tab
+    TabGroup tab3 = new TabGroup(folder, "Mitgliedskonto", true, 2);
+    SimpleContainer left3 = new SimpleContainer(tab3.getComposite());
+    left3.addInput(control.getDifferenz());
+    left3.addLabelPair("Differenz Limit", control.getDoubleAusw());
+
+    SimpleContainer right3 = new SimpleContainer(tab3.getComposite());
+    right3.addInput(control.getDatumvon());
+    right3.addInput(control.getDatumbis());
 
     // Buttons
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/gui/view/PreNotificationMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/PreNotificationMailView.java
@@ -34,6 +34,7 @@ import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
 import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.PreNotificationControl;
+import de.jost_net.JVerein.gui.control.PreNotificationControl.TYP;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -98,6 +99,8 @@ public class PreNotificationMailView extends AbstractView
     buttons1.addButton(
         new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
             control, false, "document-new.png"));
+    buttons1.addButton(control.getDruckMailMitgliederButton(
+        this.getCurrentObject(), TYP.DRUCKMAIL.toString()));
     buttons1.addButton(control.getStartButton(this.getCurrentObject()));
     addButtonArea(buttons1, grtabMailPDF.getComposite());
 
@@ -110,6 +113,8 @@ public class PreNotificationMailView extends AbstractView
     ButtonArea buttons2 = new ButtonArea();
     buttons2.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.PRENOTIFICATION, false, "question-circle.png");
+    buttons2.addButton(control.getDruckMailMitgliederButton(
+        this.getCurrentObject(), TYP.CENT1.toString()));
     buttons2.addButton(
         control.getStart1ctUeberweisungButton(this.getCurrentObject()));
     addButtonArea(buttons2, grtab2.getComposite());

--- a/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungMailView.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.gui.action.MailTextVorschauAction;
 import de.jost_net.JVerein.gui.action.MailVorlageUebernehmenAction;
 import de.jost_net.JVerein.gui.action.MailVorlageZuweisenAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
+import de.jost_net.JVerein.gui.control.RechnungControl.TYP;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Button;
@@ -103,6 +104,8 @@ public class RechnungMailView extends AbstractView
     buttons.addButton(
         new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
             control, false, "document-new.png"));
+    buttons.addButton(control.getDruckMailMitgliederButton(
+        this.getCurrentObject(), TYP.RECHNUNG.toString()));
     buttons.addButton(control.getStartRechnungButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungMailView.java
@@ -105,6 +105,8 @@ public class SpendenbescheinigungMailView extends AbstractView
     buttons.addButton(
         new Button("Als Vorlage übernehmen", new MailVorlageUebernehmenAction(),
             control, false, "document-new.png"));
+    buttons.addButton(
+        control.getDruckMailMitgliederButton(this.getCurrentObject(), null));
     buttons.addButton(control.getStartButton(this.getCurrentObject()));
     buttons.paint(this.getParent());
   }

--- a/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
+++ b/src/de/jost_net/JVerein/io/FreiesFormularAusgabe.java
@@ -13,15 +13,12 @@ import java.util.zip.ZipOutputStream;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
 
-import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.MitgliedMap;
-import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.FreieFormulareControl;
 import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.keys.FormularArt;
-import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.StringTool;
@@ -39,8 +36,8 @@ public class FreiesFormularAusgabe
 
   ZipOutputStream zos = null;
 
-  public FreiesFormularAusgabe(FreieFormulareControl control)
-      throws IOException, ApplicationException
+  public FreiesFormularAusgabe(ArrayList<Mitglied> mitglieder,
+      FreieFormulareControl control) throws IOException, ApplicationException
   {
     this.control = control;
     Formular formular = (Formular) control
@@ -70,19 +67,7 @@ public class FreiesFormularAusgabe
         zos = new ZipOutputStream(new FileOutputStream(file));
         break;
     }
-    Mitgliedstyp mitgliedstyp = (Mitgliedstyp) control
-        .getSuchMitgliedstyp(Mitgliedstypen.ALLE).getValue();
-    int type = -1;
-    if (mitgliedstyp != null)
-      type = Integer.parseInt(mitgliedstyp.getID());
-    ArrayList<Mitglied> mitglieder = new MitgliedQuery(control).get(type, null);
 
-    if (mitglieder.size() == 0)
-    {
-      GUI.getStatusBar().setErrorText("Keine passenden Mitglieder gefunden.");
-      file.delete();
-      return;
-    }
     aufbereitung(formular, mitglieder);
   }
 

--- a/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
+++ b/src/de/jost_net/JVerein/io/Rechnungsausgabe.java
@@ -43,7 +43,6 @@ import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.util.StringTool;
 import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.GenericIterator;
-import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.util.ApplicationException;
 
@@ -62,9 +61,8 @@ public class Rechnungsausgabe
 
   RechnungControl.TYP typ;
 
-  @SuppressWarnings("unchecked")
-  public Rechnungsausgabe(RechnungControl control, RechnungControl.TYP typ)
-      throws IOException, ApplicationException
+  public Rechnungsausgabe(Rechnung[] rechnungen, RechnungControl control,
+      RechnungControl.TYP typ) throws IOException, ApplicationException
   {
     this.control = control;
     this.typ = typ;
@@ -103,36 +101,14 @@ public class Rechnungsausgabe
           .createObject(Formular.class, form.getID());
     }
 
-    Object context = control.getCurrentObject();
-    if (context != null && context instanceof Rechnung[])
-    {
-      rechnungen = PseudoIterator.fromArray((Rechnung[]) context);
-    }
-    else if (context != null && context instanceof Rechnung)
-    {
-      rechnungen = PseudoIterator
-          .fromArray(new Rechnung[] { (Rechnung) context });
-    }
-    else
-    {
-      rechnungen = control.getRechnungIterator();
-    }
-
-    if (rechnungen.size() == 0)
-    {
-      GUI.getStatusBar().setErrorText("Keine passende Rechnung gefunden.");
-      file.delete();
-      return;
-    }
-    aufbereitung(formular);
+    aufbereitung(formular, rechnungen);
   }
 
-  public void aufbereitung(Formular formular)
+  public void aufbereitung(Formular formular, Rechnung[] rechnungen)
       throws IOException, ApplicationException
   {
-    while (rechnungen.hasNext())
+    for (Rechnung re : rechnungen)
     {
-      Rechnung re = rechnungen.next();
       switch ((Ausgabeart) control.getAusgabeart().getValue())
       {
         case DRUCK:
@@ -161,11 +137,9 @@ public class Rechnungsausgabe
     {
       case DRUCK:
         formularaufbereitung.showFormular();
-        if (rechnungen.size() == 1)
+        if (rechnungen.length == 1)
         {
-          rechnungen.begin();
-          formularaufbereitung.addZUGFeRD(rechnungen.next(),
-              typ == TYP.MAHNUNG);
+          formularaufbereitung.addZUGFeRD(rechnungen[0], typ == TYP.MAHNUNG);
         }
         break;
       case MAIL:

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.SollbuchungControl.DIFFERENZ;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.keys.Datentyp;
@@ -1455,6 +1457,24 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
             Buchung.T_SOLLBUCHUNG + " = " + Sollbuchung.TABLE_NAME_ID);
         it.addFilter(Sollbuchung.T_MITGLIED + " = " + this.getID());
         it.addGroupBy(Sollbuchung.T_MITGLIED);
+
+        MitgliedControl control = MitgliedControl.control;
+        if (control.isDifferenzAktiv()
+            && control.getDifferenz().getValue() != DIFFERENZ.EGAL)
+        {
+          if (control.isDatumvonAktiv()
+              && control.getDatumvon().getValue() != null)
+          {
+            it.addFilter(Sollbuchung.T_DATUM + " >= ?",
+                (Date) control.getDatumvon().getValue());
+          }
+          if (control.isDatumbisAktiv()
+              && control.getDatumbis().getValue() != null)
+          {
+            it.addFilter(Sollbuchung.T_DATUM + " <= ?",
+                (Date) control.getDatumbis().getValue());
+          }
+        }
 
         if (it.hasNext())
         {


### PR DESCRIPTION
 Wie in #458 gewünscht und auch von mir dir vorgeschlagen, habe ich in den DruckMailViews einen Vorschau Dialog der Empfänger Liste eingebaut.
<img width="221" height="47" alt="Bildschirmfoto_20250806_092206" src="https://github.com/user-attachments/assets/90e6bac4-45e6-4fe4-9c67-59db58fa5beb" />
Es wird eine Liste der Empfänger angezeigt. Zusätzlich werden gegebenenfalls Infos/Warnungen ausgegeben. Z.B. wenn Mail ausgewählt ist, aber einige ausgewählte Mitglieder keine Mail Adresse haben oder wenn bei Spendenbescheinigungen kein Mitglied eingetragen ist.

Um die Vorschau generieren zu können habe ich die Generierung der Mitglieder Liste aus den Exportern bzw. der Ausgabe Generierung herausgenommen und in den Control verlegt. Die gefundenen Mitglieder werden für die Vorschau verwendet und so auch als Liste an die Ausgabe übergeben.

Bei Pre-Notification  habe ich die drei Queries auf eine reduziert.

Für die Kontoauszüge musste ich den Differenzfilter aus der Reportgenerierung herausnehmen und in das MitgliedQuery verlegen. @lenilsas , ich wollte dabei den Code aus der Rechnung verwenden. Der funktioniert aber nicht mehr. Er ging davon aus, dass eine Rechnung nur eine Sollbuchung hat. Das haben wir aber geändert und erlauben jetzt auch mehr Sollbuchungen. Für die 3.1 müsste der Code für die Rechnung korrigiert werden, analog zu der neuen Implementierung im MitgliedQuery.

Dadurch, dass jetzt im MitgliedQuery die Differenz unterstützt wird habe ich sie dann auch gleich in den MitgliedListeView eingebaut. Das kostet ja jetzt nichts mehr. Die Spalte Kontostand benutzt auch den Datumsbereich wenn Differenz ausgewählt ist.

Das ist der neue Filter Bereich im MitgliedListeView.
<img width="806" height="235" alt="Bildschirmfoto_20250806_092138" src="https://github.com/user-attachments/assets/2cf060c2-d3cf-409f-bac2-264611dc8398" />


