### PR TITLE
Buchungsliste laden beschleunigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1565,15 +1565,19 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     else
     {
       buchungsList.updateSaldo((Konto) getSuchKonto().getValue());
+
       buchungsList.removeAll();
 
       for (Buchung bu : buchungen)
       {
         buchungsList.addItem(bu);
       }
+
+      // Summenzeile neu laden
+      buchungsList.featureEvent(
+          de.willuhn.jameica.gui.parts.table.Feature.Event.REFRESH, null);
       buchungsList.sort();
     }
-
     informKontoChangeListener();
 
     return buchungsList;
@@ -1784,7 +1788,6 @@ public class BuchungsControl extends VorZurueckControl implements Savable
       BackgroundTask t = new BackgroundTask()
       {
 
-        @SuppressWarnings("unused")
         @Override
         public void run(ProgressMonitor monitor) throws ApplicationException
         {

--- a/src/de/jost_net/JVerein/gui/parts/BuchungListTablePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungListTablePart.java
@@ -47,14 +47,8 @@ public class BuchungListTablePart extends AutoUpdateTablePart
     super(list, action);
 
     // ChangeListener für die Summe der ausgewählten Buchungen anhängen.
-    addSelectionListener(e -> {
-      createFeatureEventContext(Event.REFRESH, ctx);
-      Feature feature = this.getFeature(FeatureSummary.class);
-      if (feature != null)
-      {
-        feature.handleEvent(Event.REFRESH, ctx);
-      }
-    });
+    addSelectionListener(e -> featureEvent(
+        de.willuhn.jameica.gui.parts.table.Feature.Event.REFRESH, null));
   }
 
   /**
@@ -66,7 +60,8 @@ public class BuchungListTablePart extends AutoUpdateTablePart
   protected Context createFeatureEventContext(Feature.Event e, Object data)
   {
     ctx = super.createFeatureEventContext(e, data);
-    if (this.hasEvent(FeatureSummary.class, e))
+    if (this.hasEvent(FeatureSummary.class, e)
+        && (e == Event.REFRESH || e == Event.REMOVED || e == Event.REMOVED_ALL))
     {
       double sumBetrag = 0.0;
       double sumNetto = 0d;

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -235,11 +235,7 @@ public class BuchungImpl extends AbstractJVereinDBObject implements Buchung
   @Override
   protected Class<?> getForeignObject(String field)
   {
-    if ("abrechnungslauf".equals(field))
-    {
-      return Abrechnungslauf.class;
-    }
-    else if ("spendenbescheinigung".equals(field))
+    if ("spendenbescheinigung".equals(field))
     {
       return Spendenbescheinigung.class;
     }
@@ -476,7 +472,14 @@ public class BuchungImpl extends AbstractJVereinDBObject implements Buchung
   @Override
   public Abrechnungslauf getAbrechnungslauf() throws RemoteException
   {
-    return (Abrechnungslauf) getAttribute("abrechnungslauf");
+    Object l = (Object) super.getAttribute("abrechnungslauf");
+    if (l == null)
+    {
+      return null;
+    }
+
+    Cache cache = Cache.get(Abrechnungslauf.class, true);
+    return (Abrechnungslauf) cache.get(l);
   }
 
   @Override


### PR DESCRIPTION
Beim laden der Buchungsliste wurde beim laden jeder Buchung dies Summe neu berechnet. Jetzt mache ich es nur noch am ende, dadurch konnte ich bei mir mit MySQL und 4500 Buchungen das laden von 60s auf 15s beschleunigen.
Außerdem habe ich einen Cache für den Abrechnungslauf erstellt, dann ist nicht für jede Buchung ein Query nötig.