### PR TITLE
Filter auch bei Vor und Zurück speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -497,7 +497,7 @@ public abstract class FilterControl extends VorZurueckControl
         }
         catch (RemoteException e)
         {
-          
+
         }
       }
       else
@@ -1992,7 +1992,7 @@ public abstract class FilterControl extends VorZurueckControl
           calendar.add(Calendar.DAY_OF_MONTH, -1);
           bisDatum.setValue(calendar.getTime());
         }
-        TabRefresh();
+        refresh();
       }
     }, null, false, "go-previous.png");
   }
@@ -2033,7 +2033,7 @@ public abstract class FilterControl extends VorZurueckControl
           calendar.add(Calendar.DAY_OF_MONTH, -1);
           bisDatum.setValue(calendar.getTime());
         }
-        TabRefresh();
+        refresh();
       }
     }, null, false, "go-next.png");
   }


### PR DESCRIPTION
Bisher werde in allen FilterControls beim Vor und Zurück Button die Filtersettings nicht gespeichert. Das sollte meiner Meinung nach aber passieren.