### PR TITLE
CSV Import Dateinamen mit Leerzeichen

### DIFF
--- a/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
+++ b/src/de/jost_net/JVerein/io/CSVBuchungsImport.java
@@ -69,7 +69,8 @@ public class CSVBuchungsImport implements Importer
       // create a Statement object to execute the query with
       Statement stmt = conn.createStatement();
 
-      results = stmt.executeQuery("SELECT * FROM " + fil.substring(0, pos));
+      results = stmt
+          .executeQuery("SELECT * FROM \"" + fil.substring(0, pos) + "\"");
 
       while (results.next())
       {

--- a/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
+++ b/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
@@ -76,7 +76,8 @@ public class DefaultZusatzbetraegeImport implements Importer
       // create a Statement object to execute the query with
       stmt = conn.createStatement();
 
-      results = stmt.executeQuery("SELECT * FROM " + fil.substring(0, pos));
+      results = stmt
+          .executeQuery("SELECT * FROM \"" + fil.substring(0, pos) + "\"");
       String columnMitgliedsnummer = "Mitglieds_Nr";
       String colExtMitgliedsnummer = "Ext_Mitglieds_Nr";
       String colNachname = "Nachname";

--- a/src/de/jost_net/JVerein/io/FormularfelderImportCSV.java
+++ b/src/de/jost_net/JVerein/io/FormularfelderImportCSV.java
@@ -114,7 +114,8 @@ public class FormularfelderImportCSV implements Importer
           props);
       Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
           ResultSet.CONCUR_READ_ONLY);
-      results = stmt.executeQuery("SELECT * FROM " + fil.substring(0, pos));
+      results = stmt
+          .executeQuery("SELECT * FROM \"" + fil.substring(0, pos) + "\"");
 
       int anz = 0;
       while (results.next())

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -68,7 +68,8 @@ public class MitgliederImport implements Importer
           props);
       Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
           ResultSet.CONCUR_READ_ONLY);
-      results = stmt.executeQuery("SELECT * FROM " + fil.substring(0, pos));
+      results = stmt
+          .executeQuery("SELECT * FROM \"" + fil.substring(0, pos) + "\"");
 
       try
       {


### PR DESCRIPTION
Beim CSV Import von Dateien mit ` ` oder `(` etc im Dateinamen kam es zu Eceptions.