### PR TITLE
Weitere Attribute bei auto generierten Buchungen setzen

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -1270,6 +1270,11 @@ public class AbrechnungSEPA
       buchung.setName(adress != null ? Adressaufbereitung.getNameVorname(adress)
           : "JVerein");
       buchung.setZweck(adress == null ? "Gegenbuchung" : zweck);
+      buchung.setIban("");
+      buchung.setVerzicht(false);
+      buchung.setArt("Lastschrift");
+      buchung.setKommentar("Abrechnungslauf " + abrl.getNr() + " vom "
+          + Datum.formatDate(abrl.getDatum()));
       buchung.store();
 
       if (sollb != null)


### PR DESCRIPTION
Die bei der Abrechnung erzeugten Buchungen erzeugten immer eine Meldung, dass nicht gespeichert wurde wenn man sie verlässt. Das lag an einigen Attributen die nicht gesetzt wurden.