### PR TITLE
DB Update Fehler MySQL behoben

### DIFF
--- a/src/de/jost_net/JVerein/server/DBSupportH2Impl.java
+++ b/src/de/jost_net/JVerein/server/DBSupportH2Impl.java
@@ -178,7 +178,7 @@ public class DBSupportH2Impl extends AbstractDBSupportImpl
       catch (Exception e2)
       {
         Logger.error("Datenbankupdate kann nicht ausgeführt werden.", e2);
-        throw new ApplicationException(e2);
+        throw new ApplicationException(e2.getMessage(), e2);
       }
     }
   }

--- a/src/de/jost_net/JVerein/server/DBSupportMySqlImpl.java
+++ b/src/de/jost_net/JVerein/server/DBSupportMySqlImpl.java
@@ -130,7 +130,7 @@ public class DBSupportMySqlImpl extends AbstractDBSupportImpl
       catch (Exception e2)
       {
         Logger.error("Datenbankupdate kann nicht ausgeführt werden.", e2);
-        throw new ApplicationException(e2);
+        throw new ApplicationException(e2.getMessage(), e2);
       }
     }
   }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0459.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0459.java
@@ -42,9 +42,11 @@ public class Update0459 extends AbstractDDLUpdate
       if (getDriver() == DRIVER.MYSQL)
       {
         execute(
-            "SET @max_id = (SELECT if(MAX(zaehler),MAX(zaehler)+1,1) FROM formular WHERE art = 2);"
-                + "SET @sql = CONCAT('ALTER TABLE rechnung AUTO_INCREMENT = ', @max_id);"
-                + "PREPARE st FROM @sql; EXECUTE st;");
+            "SET @max_id = (SELECT if(MAX(zaehler),MAX(zaehler)+1,1) FROM formular WHERE art = 2);");
+        execute(
+            "SET @sql = CONCAT('ALTER TABLE rechnung AUTO_INCREMENT = ', @max_id);");
+        execute("PREPARE st FROM @sql;");
+        execute("EXECUTE st;");
       }
     }
   }


### PR DESCRIPTION
Wie in #1035 geschrieben, schlug das Update bei MySQL fehl. Ich hab es jetzt so umgesetzt, dass erst nach dem Spaltennamen gesucht wird, und nur wenn nicht vorhanden diese Spalte erstellt (bzw. geändert oder gelöscht) wird.

Dabei habe ich auch gemerkt, dass manche meiner Änderungen aus #993 nicht mit nach feature gemergt wurden, daher habe ich die hier nochmal mit rein genommen.