### PR TITLE
Speichern Checks nach Impl verschieben

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -144,7 +144,7 @@ public class ArbeitseinsatzControl extends FilterControl implements Savable
       }
       else
       {
-        throw new ApplicationException("Bitte Mitglied eingeben");
+        ae.setMitglied(null);
       }
     }
     ae.setDatum((Date) part.getDatum().getValue());

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -19,8 +19,6 @@ package de.jost_net.JVerein.gui.control;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.rmi.RemoteException;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.FileDialog;
@@ -331,18 +329,6 @@ public class BuchungsartControl extends FilterControl implements Savable
     b.setStatus(st.getKey());
     b.setSuchbegriff((String) getSuchbegriff().getValue());
     b.setRegexp((Boolean) getRegexp().getValue());
-    if ((Boolean) getRegexp().getValue())
-    {
-      try
-      {
-        Pattern.compile((String) getSuchbegriff().getValue());
-      }
-      catch (PatternSyntaxException pse)
-      {
-        throw new ApplicationException(
-            "Regulärer Ausdruck ungültig: " + pse.getDescription());
-      }
-    }
     if (steuer != null)
     {
       b.setSteuer((Steuer) steuer.getValue());

--- a/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
@@ -193,6 +193,18 @@ public class LehrgangControl extends FilterControl implements Savable
     l.setBis((Date) getBis().getValue());
     l.setVeranstalter((String) getVeranstalter().getValue());
     l.setErgebnis((String) getErgebnis().getValue());
+    if (l.isNewObject())
+    {
+      if (getMitglied().getValue() != null)
+      {
+        l.setMitglied(
+            Integer.valueOf(((Mitglied) getMitglied().getValue()).getID()));
+      }
+      else
+      {
+        l.setMitglied(null);
+      }
+    }
     return l;
   }
 
@@ -201,21 +213,7 @@ public class LehrgangControl extends FilterControl implements Savable
   {
     try
     {
-      Lehrgang l = (Lehrgang) prepareStore();
-      if (l.isNewObject())
-      {
-        if (getMitglied().getValue() != null)
-        {
-          l.setMitglied(
-              Integer.valueOf(((Mitglied) getMitglied().getValue()).getID()));
-        }
-        else
-        {
-          throw new ApplicationException("Bitte Mitglied eingeben");
-        }
-      }
-
-      l.store();
+      prepareStore().store();
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -107,21 +107,7 @@ public class MailVorlageControl extends VorZurueckControl
       throws RemoteException, ApplicationException
   {
     MailVorlage mv = getMailVorlage();
-    String betreff = (String) getBetreff(false).getValue();
-    if (betreff == null || betreff.isEmpty())
-    {
-      throw new ApplicationException("Bitte Betreff eingeben!");
-    }
-    DBIterator<MailVorlage> vorlagen = Einstellungen.getDBService()
-        .createList(MailVorlage.class);
-    vorlagen.addFilter("betreff = ?", betreff);
-    if (vorlagen.hasNext() && mv.isNewObject())
-    {
-      throw new ApplicationException(
-          "Es existiert bereits eine Vorlage mit diesem Betreff!");
-    }
-
-    mv.setBetreff(betreff);
+    mv.setBetreff((String) getBetreff(false).getValue());
     mv.setTxt((String) getTxt().getValue());
     return mv;
   }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -344,6 +344,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     Zahlungsweg zw = (Zahlungsweg) getZahlungsweg().getValue();
     sollb.setZahlungsweg(zw.getKey());
     sollb.setZweck1((String) getZweck1().getValue());
+    sollb.setMitglied((Mitglied) getMitglied().getValue());
     return sollb;
   }
 
@@ -352,17 +353,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
   {
     try
     {
-      Sollbuchung sollb = (Sollbuchung) prepareStore();
-
-      if (getZahler().getValue() == null)
-      {
-        throw new ApplicationException("Bitte Zahler eingeben");
-      }
-      sollb.setMitglied((Mitglied) getMitglied().getValue());
-      if (sollb.getRechnung() != null)
-        throw new ApplicationException(
-            "Sollbuchung kann nicht geändert werden, es existiert eine Rechnung darüber.");
-      sollb.store();
+      prepareStore().store();
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/control/WiedervorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WiedervorlageControl.java
@@ -177,6 +177,18 @@ public class WiedervorlageControl extends FilterControl implements Savable
     w.setDatum((Date) getDatum(false).getValue());
     w.setVermerk((String) getVermerk().getValue());
     w.setErledigung((Date) getErledigung().getValue());
+    if (w.isNewObject())
+    {
+      if (getMitglied().getValue() != null)
+      {
+        Mitglied m = (Mitglied) getMitglied().getValue();
+        w.setMitglied(Integer.parseInt(m.getID()));
+      }
+      else
+      {
+        w.setMitglied(null);
+      }
+    }
     return w;
   }
 
@@ -185,20 +197,7 @@ public class WiedervorlageControl extends FilterControl implements Savable
   {
     try
     {
-      Wiedervorlage w = (Wiedervorlage) prepareStore();
-      if (w.isNewObject())
-      {
-        if (getMitglied().getValue() != null)
-        {
-          Mitglied m = (Mitglied) getMitglied().getValue();
-          w.setMitglied(Integer.parseInt(m.getID()));
-        }
-        else
-        {
-          throw new ApplicationException("Bitte Mitglied eingeben");
-        }
-      }
-      w.store();
+      prepareStore().store();
     }
     catch (RemoteException e)
     {

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -212,6 +212,18 @@ public class ZusatzbetragControl extends VorZurueckControl implements Savable
     {
       z.setSteuer((Steuer) getZusatzbetragPart().getSteuer().getValue());
     }
+    if (z.isNewObject())
+    {
+      if (getZusatzbetragPart().getMitglied().getValue() != null)
+      {
+        Mitglied m = (Mitglied) getZusatzbetragPart().getMitglied().getValue();
+        z.setMitglied(Integer.parseInt(m.getID()));
+      }
+      else
+      {
+        z.setMitglied(null);
+      }
+    }
     return z;
   }
 
@@ -221,19 +233,6 @@ public class ZusatzbetragControl extends VorZurueckControl implements Savable
     try
     {
       Zusatzbetrag z = (Zusatzbetrag) prepareStore();
-      if (z.isNewObject())
-      {
-        if (getZusatzbetragPart().getMitglied().getValue() != null)
-        {
-          Mitglied m = (Mitglied) getZusatzbetragPart().getMitglied()
-              .getValue();
-          z.setMitglied(Integer.parseInt(m.getID()));
-        }
-        else
-        {
-          throw new ApplicationException("Bitte Mitglied eingeben");
-        }
-      }
       z.store();
       if (getVorlage().getValue().equals(MITDATUM)
           || getVorlage().getValue().equals(OHNEDATUM))

--- a/src/de/jost_net/JVerein/rmi/Arbeitseinsatz.java
+++ b/src/de/jost_net/JVerein/rmi/Arbeitseinsatz.java
@@ -23,7 +23,7 @@ public interface Arbeitseinsatz extends JVereinDBObject
 {
   public Mitglied getMitglied() throws RemoteException;
 
-  public void setMitglied(int mitglied) throws RemoteException;
+  public void setMitglied(Integer mitglied) throws RemoteException;
 
   public Date getDatum() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Lehrgang.java
+++ b/src/de/jost_net/JVerein/rmi/Lehrgang.java
@@ -23,7 +23,7 @@ public interface Lehrgang extends JVereinDBObject
 {
   public Mitglied getMitglied() throws RemoteException;
 
-  public void setMitglied(int mitglied) throws RemoteException;
+  public void setMitglied(Integer mitglied) throws RemoteException;
 
   public Lehrgangsart getLehrgangsart() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Wiedervorlage.java
+++ b/src/de/jost_net/JVerein/rmi/Wiedervorlage.java
@@ -23,7 +23,7 @@ public interface Wiedervorlage extends JVereinDBObject
 {
   public Mitglied getMitglied() throws RemoteException;
 
-  public void setMitglied(int mitglied) throws RemoteException;
+  public void setMitglied(Integer mitglied) throws RemoteException;
 
   public Date getDatum() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
+++ b/src/de/jost_net/JVerein/rmi/Zusatzbetrag.java
@@ -25,7 +25,7 @@ public interface Zusatzbetrag extends JVereinDBObject
 {
   public Mitglied getMitglied() throws RemoteException;
 
-  public void setMitglied(int mitglied) throws RemoteException;
+  public void setMitglied(Integer mitglied) throws RemoteException;
 
   public Date getFaelligkeit() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/ArbeitseinsatzImpl.java
+++ b/src/de/jost_net/JVerein/server/ArbeitseinsatzImpl.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.keys.ArbeitsstundenModel;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class ArbeitseinsatzImpl extends AbstractJVereinDBObject
@@ -66,9 +67,13 @@ public class ArbeitseinsatzImpl extends AbstractJVereinDBObject
   {
     try
     {
+      if (getMitglied() == null)
+      {
+        throw new ApplicationException("Bitte Mitglied eingeben!");
+      }
       if (getStunden() == null)
       {
-        throw new ApplicationException("Bitte Stunden eingeben");
+        throw new ApplicationException("Bitte Stunden eingeben!");
       }
       if (getStunden() <= 0d)
       {
@@ -76,17 +81,19 @@ public class ArbeitseinsatzImpl extends AbstractJVereinDBObject
             Property.ARBEITSSTUNDENMODEL) == ArbeitsstundenModel.STANDARD)
         {
           throw new ApplicationException(
-              "Bitte mehr als 0 Stunden eingeben oder Arbeitsstundenmodel in Einstellung ändern");
+              "Bitte mehr als 0 Stunden eingeben oder Arbeitsstundenmodel in Einstellung ändern!");
         }
       }
       if (getDatum() == null)
       {
-        throw new ApplicationException("Bitte Datum eingeben");
+        throw new ApplicationException("Bitte Datum eingeben!");
       }
     }
     catch (RemoteException e)
     {
-      throw new ApplicationException(e);
+      String fehler = "Arbeitseinsatz kann nicht gespeichert werden. Siehe system log.";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
     }
   }
 
@@ -107,9 +114,9 @@ public class ArbeitseinsatzImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  public void setMitglied(int mitglied) throws RemoteException
+  public void setMitglied(Integer mitglied) throws RemoteException
   {
-    setAttribute("mitglied", Integer.valueOf(mitglied));
+    setAttribute("mitglied", mitglied);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -17,6 +17,8 @@
 package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
@@ -63,6 +65,18 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
   {
     try
     {
+      if ((Boolean) getRegexp())
+      {
+        try
+        {
+          Pattern.compile((String) getSuchbegriff());
+        }
+        catch (PatternSyntaxException pse)
+        {
+          throw new ApplicationException(
+              "Regulärer Ausdruck ungültig: " + pse.getDescription());
+        }
+      }
       if (getBezeichnung() == null || getBezeichnung().isEmpty())
       {
         throw new ApplicationException("Bitte Bezeichnung eingeben!");
@@ -107,7 +121,7 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
     }
     catch (RemoteException e)
     {
-      String fehler = "Buchungsart kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Buchungsart kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }

--- a/src/de/jost_net/JVerein/server/EigenschaftImpl.java
+++ b/src/de/jost_net/JVerein/server/EigenschaftImpl.java
@@ -51,7 +51,7 @@ public class EigenschaftImpl extends AbstractJVereinDBObject
   @Override
   protected void deleteCheck() throws ApplicationException
   {
-    insertCheck();
+    //
   }
 
   @Override
@@ -65,7 +65,7 @@ public class EigenschaftImpl extends AbstractJVereinDBObject
     {
       Logger.error("insert check of eigenschaft failed", e);
       throw new ApplicationException(
-          "Eigenschaft kann nicht gespeichert werden. Siehe system log");
+          "Eigenschaft kann nicht gespeichert werden. Siehe system log.");
     }
   }
 
@@ -77,7 +77,7 @@ public class EigenschaftImpl extends AbstractJVereinDBObject
     }
     if (getEigenschaftGruppe() == null)
     {
-      throw new ApplicationException("Bitte Eigenschaftengruppe auswählen");
+      throw new ApplicationException("Bitte Eigenschaftengruppe auswählen!");
     }
     DBIterator<Eigenschaft> eigIt = Einstellungen.getDBService()
         .createList(Eigenschaft.class);

--- a/src/de/jost_net/JVerein/server/LehrgangImpl.java
+++ b/src/de/jost_net/JVerein/server/LehrgangImpl.java
@@ -62,7 +62,7 @@ public class LehrgangImpl extends AbstractJVereinDBObject implements Lehrgang
     }
     catch (RemoteException e)
     {
-      String fehler = "Lehrgang kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Lehrgang kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
@@ -77,7 +77,7 @@ public class LehrgangImpl extends AbstractJVereinDBObject implements Lehrgang
     }
     catch (RemoteException e)
     {
-      String fehler = "Lehrgang kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Lehrgang kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
@@ -85,13 +85,17 @@ public class LehrgangImpl extends AbstractJVereinDBObject implements Lehrgang
 
   private void plausi() throws RemoteException, ApplicationException
   {
+    if (getMitglied() == null)
+    {
+      throw new ApplicationException("Bitte Mitglied eingeben!");
+    }
     if (getLehrgangsart() == null)
     {
-      throw new ApplicationException("Bitte Lehrgangsart auswählen");
+      throw new ApplicationException("Bitte Lehrgangsart auswählen!");
     }
     if (getVon() == null)
     {
-      throw new ApplicationException("Bitte Datum eingeben");
+      throw new ApplicationException("Bitte Datum eingeben!");
     }
   }
 
@@ -117,9 +121,9 @@ public class LehrgangImpl extends AbstractJVereinDBObject implements Lehrgang
   }
 
   @Override
-  public void setMitglied(int mitglied) throws RemoteException
+  public void setMitglied(Integer mitglied) throws RemoteException
   {
-    setAttribute("mitglied", Integer.valueOf(mitglied));
+    setAttribute("mitglied", mitglied);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/MailVorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/MailVorlageImpl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.server;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.MailVorlage;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -60,22 +62,33 @@ public class MailVorlageImpl extends AbstractJVereinDBObject
       {
         throw new ApplicationException("Bitte Betreff eingeben");
       }
+      DBIterator<MailVorlage> vorlagen = Einstellungen.getDBService()
+          .createList(MailVorlage.class);
+      if (!this.isNewObject())
+      {
+        vorlagen.addFilter("id != ?", getID());
+      }
+      vorlagen.addFilter("betreff = ?", getBetreff());
+      if (vorlagen.hasNext())
+      {
+        throw new ApplicationException(
+            "Es existiert bereits eine Vorlage mit diesem Betreff!");
+      }
       if (getTxt() == null || getTxt().length() == 0)
       {
-        throw new ApplicationException("Bitte Text eingeben");
+        throw new ApplicationException("Bitte Text eingeben!");
       }
       if (getTxt().length() > 10000)
       {
         throw new ApplicationException(
-            "Maximale Länge des Textes 10.000 Zeichen");
+            "Maximale Länge des Textes 10.000 Zeichen!");
       }
-
     }
     catch (RemoteException e)
     {
       Logger.error("insert check of mailvorlage failed", e);
       throw new ApplicationException(
-          "MailVorlage kann nicht gespeichert werden. Siehe system log");
+          "MailVorlage kann nicht gespeichert werden. Siehe system log.");
     }
   }
 

--- a/src/de/jost_net/JVerein/server/ProjektImpl.java
+++ b/src/de/jost_net/JVerein/server/ProjektImpl.java
@@ -54,7 +54,7 @@ public class ProjektImpl extends AbstractJVereinDBObject implements Projekt
   @Override
   protected void deleteCheck() throws ApplicationException
   {
-    insertCheck();
+    //
   }
 
   @Override
@@ -68,7 +68,7 @@ public class ProjektImpl extends AbstractJVereinDBObject implements Projekt
     {
       Logger.error("insert check of projekt failed", e);
       throw new ApplicationException(
-          "Projekt kann nicht gespeichert werden. Siehe system log");
+          "Projekt kann nicht gespeichert werden. Siehe system log.");
     }
   }
 
@@ -76,14 +76,14 @@ public class ProjektImpl extends AbstractJVereinDBObject implements Projekt
   {
     if (getBezeichnung() == null || getBezeichnung().isEmpty())
     {
-      throw new ApplicationException("Bitte Bezeichnung eingeben");
+      throw new ApplicationException("Bitte Bezeichnung eingeben!");
     }
 
     if (isStartDatumGesetzt() && isEndeDatumGesetzt()
         && getEndeDatum().before(getStartDatum()))
     {
       throw new ApplicationException(
-          "Endedatum muss nach dem Startdatum liegen");
+          "Endedatum muss nach dem Startdatum liegen!");
     }
   }
 

--- a/src/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -71,7 +71,7 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
       {
         throw new ApplicationException(
             "Sollbuchung kann nicht gelöscht werden weil sie zu einer "
-                + "Rechnung gehört");
+                + "Rechnung gehört!");
       }
     }
     catch (ObjectNotFoundException e)
@@ -84,7 +84,7 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
     {
       Logger.error("Fehler", e);
       throw new ApplicationException(
-          "Sollbuchung kann nicht gelöscht werden. Siehe system log");
+          "Sollbuchung kann nicht gelöscht werden. Siehe system log.");
     }
   }
 
@@ -95,19 +95,23 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
     {
       if (getMitglied() == null)
       {
-        throw new ApplicationException("Bitte Mitglied eingeben");
+        throw new ApplicationException("Bitte Mitglied eingeben!");
+      }
+      if (getZahler() == null)
+      {
+        throw new ApplicationException("Bitte Zahler eingeben!");
       }
       if (getDatum() == null)
       {
-        throw new ApplicationException("Datum fehlt");
+        throw new ApplicationException("Bitte Datum eingeben!");
       }
       if (getZweck1().length() == 0)
       {
-        throw new ApplicationException("Verwendungszweck fehlt");
+        throw new ApplicationException("Bitt Verwendungszweck eingeben!");
       }
       if (getBetrag() == null)
       {
-        String fehler = "Betrag fehlt";
+        String fehler = "Bitte Betrag eingeben!";
         Logger.error(fehler);
         throw new ApplicationException(fehler);
       }
@@ -115,7 +119,7 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
     }
     catch (RemoteException e)
     {
-      String fehler = "Sollbuchung kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Sollbuchung kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
@@ -125,6 +129,26 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
   protected void updateCheck() throws ApplicationException
   {
     insertCheck();
+    try
+    {
+      if (getRechnung() != null)
+      {
+        throw new ApplicationException(
+            "Sollbuchung kann nicht geändert werden weil sie zu einer Rechnung gehört");
+      }
+    }
+    catch (ObjectNotFoundException e)
+    {
+      // Alles ok, es gibt keine Rechnung
+      // Das passiert wenn sie kurz vorher gelöscht wurde aber
+      // die ID noch im Cache gespeichert ist
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Sollbuchung kann nicht gespeichert werden. Siehe system log.";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
+    }
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/WiedervorlageImpl.java
+++ b/src/de/jost_net/JVerein/server/WiedervorlageImpl.java
@@ -58,18 +58,22 @@ public class WiedervorlageImpl extends AbstractJVereinDBObject
   {
     try
     {
+      if (getMitglied() == null)
+      {
+        throw new ApplicationException("Bitte Mitglied eingeben!");
+      }
       if (getDatum() == null)
       {
-        throw new ApplicationException("Bitte Datum eingeben");
+        throw new ApplicationException("Bitte Datum eingeben!");
       }
       if (getVermerk() == null || getVermerk().isEmpty())
       {
-        throw new ApplicationException("Bitte Vermerk eingeben");
+        throw new ApplicationException("Bitte Vermerk eingeben!");
       }
     }
     catch (RemoteException e)
     {
-      String fehler = "Wiedervorlage kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Wiedervorlage kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
@@ -98,9 +102,9 @@ public class WiedervorlageImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  public void setMitglied(int mitglied) throws RemoteException
+  public void setMitglied(Integer mitglied) throws RemoteException
   {
-    setAttribute("mitglied", Integer.valueOf(mitglied));
+    setAttribute("mitglied", mitglied);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
+++ b/src/de/jost_net/JVerein/server/ZusatzbetragImpl.java
@@ -67,44 +67,48 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
   {
     try
     {
+      if (getMitglied() == null)
+      {
+        throw new ApplicationException("Bitte Mitglied eingeben!");
+      }
       if (getStartdatum() == null)
       {
-        throw new ApplicationException("Bitte erste Fälligkeit eingeben");
+        throw new ApplicationException("Bitte erste Fälligkeit eingeben!");
       }
       if (getFaelligkeit() == null)
       {
-        throw new ApplicationException("Bitte nächste Fälligkeit eingeben");
+        throw new ApplicationException("Bitte nächste Fälligkeit eingeben!");
       }
       if (getIntervall() == null)
       {
-        throw new ApplicationException("Bitte Intervall eingeben");
+        throw new ApplicationException("Bitte Intervall eingeben!");
       }
       if (getBuchungstext() == null || getBuchungstext().length() == 0)
       {
-        throw new ApplicationException("Bitte Buchungstext eingeben");
+        throw new ApplicationException("Bitte Buchungstext eingeben!");
       }
       if (getEndedatum() != null)
       {
         if (!Datum.isImInterval(getStartdatum(), getEndedatum(),
             getIntervall()))
         {
-          throw new ApplicationException("Endedatum liegt nicht im Intervall");
+          throw new ApplicationException("Endedatum liegt nicht im Intervall.");
         }
       }
       if (getFaelligkeit().getTime() < getStartdatum().getTime())
       {
         throw new ApplicationException(
-            "Das Fälligkeitsdatum darf nicht vor dem Startdatum liegen");
+            "Das Fälligkeitsdatum darf nicht vor dem Startdatum liegen.");
       }
       if (!Datum.isImInterval(getStartdatum(), getFaelligkeit(),
           getIntervall()))
       {
         throw new ApplicationException(
-            "Nächste Fälligkeit liegt nicht im Intervall");
+            "Nächste Fälligkeit liegt nicht im Intervall.");
       }
       if (getBetrag() == null)
       {
-        throw new ApplicationException("Bitte Betrag eingeben");
+        throw new ApplicationException("Bitte Betrag eingeben!");
       }
       if (getZahlungsweg().getKey() == Zahlungsweg.BASISLASTSCHRIFT)
       {
@@ -156,7 +160,7 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
     }
     catch (RemoteException e)
     {
-      String fehler = "Zusatzbetrag kann nicht gespeichert werden. Siehe system log";
+      String fehler = "Zusatzbetrag kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
@@ -193,9 +197,9 @@ public class ZusatzbetragImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  public void setMitglied(int mitglied) throws RemoteException
+  public void setMitglied(Integer mitglied) throws RemoteException
   {
-    setAttribute("mitglied", Integer.valueOf(mitglied));
+    setAttribute("mitglied", mitglied);
   }
 
   @Override


### PR DESCRIPTION
Ich habe bei Klassen in denen Speichern Checks in den prepareStore() gemacht wurden in die Impl Klasse verschoben.

Für Mitglied ist das umfangreicher, das mache ich separat.
Auch die Checks aus den delete Actions mache ich separat damit die PRs nicht zu groß werden.
