### PR TITLE
Fix disabled Inputs im Sollbuchung Neu Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungNeuDialog.java
@@ -71,6 +71,7 @@ public class SollbuchungNeuDialog extends AbstractDialog<Boolean>
         .createObject(SollbuchungPosition.class, null);
 
     sollbControl = new SollbuchungControl(null, sollbuchung);
+    sollbControl.isSollbuchungEditable();
     sollbPosControl = new SollbuchungPositionControl(null, sollbuchungPosition);
 
     LabelGroup group = new LabelGroup(parent, null);


### PR DESCRIPTION
Das Disable der Inputs bei Sollbuchungen aus #1027 hatte den SollbuchungNeuDialog kaputt gemacht.
