### PR TITLE
Checks bei Mitglied von Control nach Impl verschoben

### DIFF
--- a/src/de/jost_net/JVerein/JVereinAdressbuch.java
+++ b/src/de/jost_net/JVerein/JVereinAdressbuch.java
@@ -51,8 +51,7 @@ public class JVereinAdressbuch implements Addressbook
     {
       Mitglied m = (Mitglied) it.next();
       String kategorie = m.getMitgliedstyp().getBezeichnung();
-      if (m.getMitgliedstyp().getID()
-          .equals(String.valueOf(Mitgliedstyp.MITGLIED)))
+      if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
       {
         kategorie = m.getBeitragsgruppe().getBezeichnung();
       }

--- a/src/de/jost_net/JVerein/gui/action/KursteilnehmerWirdMitgliedAction.java
+++ b/src/de/jost_net/JVerein/gui/action/KursteilnehmerWirdMitgliedAction.java
@@ -41,7 +41,7 @@ public class KursteilnehmerWirdMitgliedAction implements Action
     {
       Mitglied m = (Mitglied) Einstellungen.getDBService()
           .createObject(Mitglied.class, null);
-      m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+      m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
       m.setAnrede(k.getAnrede());
       m.setBic(k.getBic());
       m.setEmail(k.getEmail());

--- a/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDetailAction.java
@@ -143,8 +143,8 @@ public class MitgliedDetailAction implements Action
       {
         GUI.getCurrentView().setCurrentObject(mitglied);
       }
-      if (mitglied.getMitgliedstyp() == null || mitglied.getMitgliedstyp()
-          .getID().equals(String.valueOf(Mitgliedstyp.MITGLIED)))
+      if (mitglied.getMitgliedstyp() == null
+          || mitglied.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
       {
         GUI.startView(new MitgliedDetailView(), mitglied);
       }

--- a/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedDuplizierenAction.java
@@ -40,7 +40,7 @@ public class MitgliedDuplizierenAction implements Action
     {
       m = Einstellungen.getDBService().createObject(Mitglied.class, null);
       m.overwrite((Mitglied) context);
-      if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+      if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
       {
         GUI.startView(new MitgliedDetailView(), m);
       }

--- a/src/de/jost_net/JVerein/gui/action/MitgliedstypDefaultAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MitgliedstypDefaultAction.java
@@ -36,15 +36,14 @@ public class MitgliedstypDefaultAction implements Action
     try
     {
       Mitgliedstyp mt = (Mitgliedstyp) Einstellungen.getDBService()
-          .createObject(Mitgliedstyp.class,
-              String.valueOf(Mitgliedstyp.MITGLIED));
+          .createObject(Mitgliedstyp.class, Mitgliedstyp.MITGLIED);
       mt.setBezeichnung("Mitglied");
-      mt.setJVereinid(Mitgliedstyp.ID_MITGLIED);
+      mt.setJVereinid(Integer.valueOf(Mitgliedstyp.MITGLIED));
       mt.store();
       mt = (Mitgliedstyp) Einstellungen.getDBService().createObject(
           Mitgliedstyp.class, String.valueOf(Mitgliedstyp.SPENDER));
       mt.setBezeichnung("Spender/in");
-      mt.setJVereinid(Mitgliedstyp.ID_SPENDER);
+      mt.setJVereinid(Integer.valueOf(Mitgliedstyp.SPENDER));
       mt.store();
 
       GUI.getStatusBar().setSuccessText("Mitgliedstypen eingefügt.");

--- a/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/PersonalbogenAction.java
@@ -295,8 +295,7 @@ public class PersonalbogenAction implements Action
       kommunikation += "Email: " + m.getEmail();
     }
     rpt.addColumn(kommunikation, Element.ALIGN_LEFT);
-    if (m.getMitgliedstyp().getID()
-        .equals(String.valueOf(Mitgliedstyp.MITGLIED)))
+    if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
     {
       rpt.addColumn("Eintritt", Element.ALIGN_LEFT);
       rpt.addColumn(m.getEintritt(), Element.ALIGN_LEFT);

--- a/src/de/jost_net/JVerein/gui/control/FilterControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FilterControl.java
@@ -243,13 +243,11 @@ public abstract class FilterControl extends VorZurueckControl
     switch (typ)
     {
       case MITGLIED:
-        mtIt.addFilter(
-            Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.ID_MITGLIED);
+        mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
         break;
       case NICHTMITGLIED:
-        mtIt.addFilter(
-            Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.ID_MITGLIED + " OR "
-                + Mitgliedstyp.JVEREINID + " IS NULL");
+        mtIt.addFilter(Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.MITGLIED
+            + " OR " + Mitgliedstyp.JVEREINID + " IS NULL");
         break;
       case NOT_USED:
       case ALLE:
@@ -260,8 +258,7 @@ public abstract class FilterControl extends VorZurueckControl
     if (typ == Mitgliedstypen.MITGLIED)
     {
       Mitgliedstyp mt = (Mitgliedstyp) Einstellungen.getDBService()
-          .createObject(Mitgliedstyp.class,
-              String.valueOf(Mitgliedstyp.MITGLIED));
+          .createObject(Mitgliedstyp.class, Mitgliedstyp.MITGLIED);
       suchmitgliedstyp = new SelectInput(
           mtIt != null ? PseudoIterator.asList(mtIt) : null, mt);
     }

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -263,8 +263,8 @@ public class LastschriftControl extends FilterControl
     String text = "";
     if (getLastschrift().getKursteilnehmer() != null)
       text = "Kursteilnehmer";
-    else if (getLastschrift().getMitglied().getMitgliedstyp()
-        .getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+    else if (getLastschrift().getMitglied().getMitgliedstyp().getID()
+        .equals(Mitgliedstyp.MITGLIED))
       text = "Mitglied";
     else
       text = "Nicht-Mitglied";

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -362,7 +362,7 @@ public class MitgliedControl extends FilterControl implements Savable
     }
     DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
         .createList(Mitgliedstyp.class);
-    mtIt.addFilter(Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.ID_MITGLIED
+    mtIt.addFilter(Mitgliedstyp.JVEREINID + " != " + Mitgliedstyp.MITGLIED
         + " OR " + Mitgliedstyp.JVEREINID + " IS NULL");
     mtIt.setOrder("order by " + Mitgliedstyp.BEZEICHNUNG);
     mitgliedstyp = new SelectNoScrollInput(
@@ -2283,7 +2283,7 @@ public class MitgliedControl extends FilterControl implements Savable
     // Für Mitglieder
     if (isMitglied)
     {
-      m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+      m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
       Beitragsgruppe bg = (Beitragsgruppe) getBeitragsgruppe(true).getValue();
       m.setBeitragsgruppe(bg);
       if (bg != null
@@ -2432,8 +2432,8 @@ public class MitgliedControl extends FilterControl implements Savable
       m.setLetzteAenderung();
       m.store();
 
-      boolean ist_mitglied = m.getMitgliedstyp()
-          .getJVereinid() == Mitgliedstyp.ID_MITGLIED;
+      boolean ist_mitglied = m.getMitgliedstyp().getID()
+          .equals(Mitgliedstyp.MITGLIED);
       if ((Boolean) Einstellungen.getEinstellung(Property.MITGLIEDFOTO)
           && ist_mitglied)
       {
@@ -3078,7 +3078,7 @@ public class MitgliedControl extends FilterControl implements Savable
     Mitglied m = getMitglied();
     if ((Boolean) Einstellungen
         .getEinstellung(Property.SEKUNDAEREBEITRAGSGRUPPEN)
-        && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+        && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
     {
       // Schritt 1: Die selektierten sekundären Beitragsgruppe prüfen, ob sie
       // bereits gespeichert sind. Ggfls. speichern.

--- a/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
@@ -200,24 +200,21 @@ public class EigenschaftenAuswahlDialog
     {
       for (Mitglied mitglied : mitglieder)
       {
-        if (mitglied.getMitgliedstyp()
-            .getJVereinid() != Mitgliedstyp.ID_MITGLIED
+        if (!mitglied.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
             && mitglied.getPersonenart().equalsIgnoreCase("n")
             && !(Boolean) Einstellungen
                 .getEinstellung(Property.NICHTMITGLIEDPFLICHTEIGENSCHAFTEN))
         {
           continue;
         }
-        if (mitglied.getMitgliedstyp()
-            .getJVereinid() == Mitgliedstyp.ID_MITGLIED
+        if (mitglied.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
             && mitglied.getPersonenart().equalsIgnoreCase("j")
             && !(Boolean) Einstellungen
                 .getEinstellung(Property.JMITGLIEDPFLICHTEIGENSCHAFTEN))
         {
           continue;
         }
-        if (mitglied.getMitgliedstyp()
-            .getJVereinid() != Mitgliedstyp.ID_MITGLIED
+        if (!mitglied.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
             && mitglied.getPersonenart().equalsIgnoreCase("j")
             && !(Boolean) Einstellungen
                 .getEinstellung(Property.JNICHTMITGLIEDPFLICHTEIGENSCHAFTEN))

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -150,7 +150,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+            if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
                 && m.isAngemeldet(stichtag))
             {
               control.getMitgliedMitMail().setChecked(o, true);
@@ -175,7 +175,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+            if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
                 && !m.isAngemeldet(stichtag))
             {
               control.getMitgliedMitMail().setChecked(o, true);
@@ -199,7 +199,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getJVereinid() != Mitgliedstyp.ID_MITGLIED)
+            if (!m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
             {
               control.getMitgliedMitMail().setChecked(o, true);
             }
@@ -223,9 +223,8 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           for (Object o : control.getMitgliedMitMail().getItems(false))
           {
             Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getJVereinid() != Mitgliedstyp.ID_MITGLIED
-                || (m.getMitgliedstyp()
-                    .getJVereinid() == Mitgliedstyp.ID_MITGLIED
+            if (!m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
+                || (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
                     && m.isAngemeldet(stichtag)))
             {
               control.getMitgliedMitMail().setChecked(o, true);

--- a/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/MitgliedMenu.java
@@ -129,7 +129,7 @@ public class MitgliedMenu extends ContextMenu
                 {
                   Logger.error("Fehler", e);
                 }
-                m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+                m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
                 m.setEingabedatum();
                 GUI.startView(MitgliedDetailView.class.getName(), m);
               }
@@ -166,7 +166,7 @@ public class MitgliedMenu extends ContextMenu
                 {
                   Logger.error("Fehler", e);
                 }
-                m.setMitgliedstyp(Mitgliedstyp.SPENDER);
+                m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.SPENDER));
                 m.setEingabedatum();
                 m.setBeitragsgruppe(null);
                 m.setExterneMitgliedsnummer(null);

--- a/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
@@ -48,8 +48,8 @@ public class MitgliedstypListeView extends AbstractView
 
     DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
         .createList(Mitgliedstyp.class);
-    mtIt.addFilter(Mitgliedstyp.JVEREINID + " >= " + Mitgliedstyp.ID_MITGLIED
-        + " AND " + Mitgliedstyp.JVEREINID + " <= " + Mitgliedstyp.ID_SPENDER);
+    mtIt.addFilter(Mitgliedstyp.JVEREINID + " >= " + Mitgliedstyp.MITGLIED
+        + " AND " + Mitgliedstyp.JVEREINID + " <= " + Mitgliedstyp.SPENDER);
     if (mtIt.size() == 0)
     {
       buttons.addButton("Default-Mitgliedstypen einrichten",

--- a/src/de/jost_net/JVerein/io/Migration.java
+++ b/src/de/jost_net/JVerein/io/Migration.java
@@ -590,7 +590,7 @@ public class Migration
       final Map<String, Integer> beitragsGruppen)
       throws RemoteException, SQLException, ApplicationException, ParseException
   {
-    m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+    m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
 
     /*
      * necessary columns
@@ -906,12 +906,12 @@ public class Migration
         progMonitor.log(String.format(
             "Mitgliedstyp bei: %s ist entweder leer oder besteht nicht nur aus Zahlen, setze auf 1 (Mitglied)",
             Adressaufbereitung.getNameVorname(m)));
-        m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+        m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
       }
     }
     else
     { // Default value
-      m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+      m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
     }
 
     m.setVermerk1(getResultFrom(results, InternalColumns.VERMERKA));

--- a/src/de/jost_net/JVerein/io/MitgliedAbstractPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAbstractPDF.java
@@ -80,7 +80,7 @@ public abstract class MitgliedAbstractPDF implements IAuswertung
     {
       DBIterator<Mitgliedstyp> mtIt = Einstellungen.getDBService()
           .createList(Mitgliedstyp.class);
-      mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.ID_MITGLIED);
+      mtIt.addFilter(Mitgliedstyp.JVEREINID + " = " + Mitgliedstyp.MITGLIED);
       mitgliedstyp = (Mitgliedstyp) mtIt.next();
     }
     initParams();

--- a/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
+++ b/src/de/jost_net/JVerein/io/MitgliedAuswertungPDF.java
@@ -62,7 +62,7 @@ public class MitgliedAuswertungPDF extends MitgliedAbstractPDF
           130, BaseColor.LIGHT_GRAY);
       report.addHeaderColumn("Geburts- datum", Element.ALIGN_CENTER, 30,
           BaseColor.LIGHT_GRAY);
-      if (mitgliedstyp.getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+      if (mitgliedstyp.getID().equals(Mitgliedstyp.MITGLIED))
       {
         report
             .addHeaderColumn(
@@ -129,7 +129,7 @@ public class MitgliedAuswertungPDF extends MitgliedAbstractPDF
         {
           zelle += "\n" + new JVDateFormatTTMMJJJJ().format(m.getSterbetag());
         }
-        if (mitgliedstyp.getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+        if (mitgliedstyp.getID().equals(Mitgliedstyp.MITGLIED))
         {
           report.addColumn(zelle, Element.ALIGN_LEFT);
         }

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -193,14 +193,14 @@ public class MitgliederImport implements Importer
             }
           }
           else
-            m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+            m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
         }
         catch (SQLException e)
         {
           if (id == null)
           {
             // Wenn Adresstyp nicht vorhanden speichern wir es als Mitglied
-            m.setMitgliedstyp(Mitgliedstyp.MITGLIED);
+            m.setMitgliedstyp(Long.valueOf(Mitgliedstyp.MITGLIED));
           }
         }
 
@@ -238,7 +238,7 @@ public class MitgliederImport implements Importer
           }
         }
 
-        if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+        if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
         {
           try
           {
@@ -316,7 +316,7 @@ public class MitgliederImport implements Importer
         try
         {
           // Beitragsgruppe nur bei Mitgliedern möglich
-          if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+          if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
           {
             String beitragsgruppe = results.getString("beitragsgruppe");
             DBIterator<Beitragsgruppe> it = Einstellungen.getDBService()
@@ -489,7 +489,7 @@ public class MitgliederImport implements Importer
             m.setMandatDatum(Datum.toDate(mandatdatum));
           }
           else if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+              && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
           {
             throw new ApplicationException(
                 "Zeile " + anz + ": Mandatdatum fehlt");
@@ -499,7 +499,7 @@ public class MitgliederImport implements Importer
         {
           // Nur bei Zahlungsweg Lastschrift pflicht
           if (id == null && m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+              && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
           {
             throw new ApplicationException("Mandatdatum fehlt");
           }
@@ -545,7 +545,7 @@ public class MitgliederImport implements Importer
             }
           }
           else if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
-              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+              && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
           {
             throw new ApplicationException("Zeile " + anz + ": IBAN fehlt");
           }
@@ -555,8 +555,8 @@ public class MitgliederImport implements Importer
           if (id == null)
           {
             m.setIban("");
-            if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT && m
-                .getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+            if (m.getZahlungsweg() == Zahlungsweg.BASISLASTSCHRIFT
+                && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
             {
               throw new ApplicationException("IBAN fehlt");
             }
@@ -617,7 +617,7 @@ public class MitgliederImport implements Importer
 
         if ((Boolean) Einstellungen
             .getEinstellung(Property.EXTERNEMITGLIEDSNUMMER)
-            && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+            && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
         {
           try
           {
@@ -658,12 +658,11 @@ public class MitgliederImport implements Importer
           else if (((Boolean) Einstellungen
               .getEinstellung(Property.GEBURTSDATUMPFLICHT)
               && m.getPersonenart().equalsIgnoreCase("n")
-              && m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+              && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
               || ((Boolean) Einstellungen
                   .getEinstellung(Property.NICHTMITGLIEDGEBURTSDATUMPFLICHT)
-                  && m.getPersonenart().equalsIgnoreCase("n")
-                  && m.getMitgliedstyp()
-                      .getJVereinid() != Mitgliedstyp.ID_MITGLIED))
+                  && m.getPersonenart().equalsIgnoreCase("n") && !m
+                      .getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)))
             throw new ApplicationException(
                 "Zeile " + anz + ": Geburtsdatum fehlt");
         }
@@ -673,13 +672,11 @@ public class MitgliederImport implements Importer
               && ((Boolean) Einstellungen
                   .getEinstellung(Property.GEBURTSDATUMPFLICHT)
                   && m.getPersonenart().equalsIgnoreCase("n")
-                  && m.getMitgliedstyp()
-                      .getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+                  && m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
               || ((Boolean) Einstellungen
                   .getEinstellung(Property.NICHTMITGLIEDGEBURTSDATUMPFLICHT)
-                  && m.getPersonenart().equalsIgnoreCase("n")
-                  && m.getMitgliedstyp()
-                      .getJVereinid() != Mitgliedstyp.ID_MITGLIED))
+                  && m.getPersonenart().equalsIgnoreCase("n") && !m
+                      .getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)))
             throw new ApplicationException("Geburtsdatum fehlt");
         }
 
@@ -1326,7 +1323,7 @@ public class MitgliederImport implements Importer
           }
         }
         // Sekundaere-Beitragsgruppe nur bei Mitgliedern möglich
-        if (m.getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED)
+        if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
         {
           for (Beitragsgruppe bg : sekundaerList)
           {

--- a/src/de/jost_net/JVerein/rmi/Mitgliedstyp.java
+++ b/src/de/jost_net/JVerein/rmi/Mitgliedstyp.java
@@ -30,13 +30,9 @@ public interface Mitgliedstyp extends JVereinDBObject
 
   public static final String JVEREINID = "jvereinid";
 
-  public static final int ID_MITGLIED = 1;
+  public static final String MITGLIED = "1";
 
-  public static final int ID_SPENDER = 2;
-
-  public static final Long MITGLIED = Long.valueOf(1);
-
-  public static final Long SPENDER = Long.valueOf(2);
+  public static final String SPENDER = "2";
 
   public String getBezeichnung() throws RemoteException;
 

--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -158,12 +158,12 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte Vornamen eingeben!");
       }
-      if (getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+      if (getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
           && getBeitragsgruppe() == null)
       {
         throw new ApplicationException("Bitte Beitragsgruppe eingeben!");
       }
-      if (getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+      if (getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("n")
           && getGeburtsdatum().getTime() == Einstellungen.NODATE.getTime()
           && (Boolean) Einstellungen
@@ -171,7 +171,7 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
       {
         throw new ApplicationException("Bitte Geburtsdatum eingeben!");
       }
-      if (getMitgliedstyp().getJVereinid() != Mitgliedstyp.ID_MITGLIED
+      if (!getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("n")
           && getGeburtsdatum().getTime() == Einstellungen.NODATE.getTime()
           && (Boolean) Einstellungen
@@ -180,10 +180,10 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
         throw new ApplicationException("Bitte Geburtsdatum eingeben!");
       }
       if (getPersonenart().equalsIgnoreCase("n")
-          && ((getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+          && ((getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
               && (Boolean) Einstellungen
                   .getEinstellung(Property.GEBURTSDATUMPFLICHT))
-              || (getMitgliedstyp().getJVereinid() != Mitgliedstyp.ID_MITGLIED
+              || (!getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
                   && (Boolean) Einstellungen.getEinstellung(
                       Property.NICHTMITGLIEDGEBURTSDATUMPFLICHT))))
       {
@@ -217,7 +217,7 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
         }
       }
 
-      if (getMitgliedstyp().getJVereinid() == Mitgliedstyp.ID_MITGLIED
+      if (getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
           && getEintritt().getTime() == Einstellungen.NODATE.getTime()
           && (Boolean) Einstellungen
               .getEinstellung(Property.EINTRITTSDATUMPFLICHT))
@@ -377,7 +377,7 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
   private void checkExterneMitgliedsnummer()
       throws RemoteException, ApplicationException
   {
-    if (getMitgliedstyp().getJVereinid() != Mitgliedstyp.ID_MITGLIED)
+    if (!getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
       return;
     if (!((Boolean) Einstellungen
         .getEinstellung(Property.EXTERNEMITGLIEDSNUMMER)))
@@ -424,16 +424,16 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
       ArrayList<?> rootNodes = (ArrayList<?>) eigenschaftenTree.getItems();
       EigenschaftenNode root = (EigenschaftenNode) rootNodes.get(0);
       // Mitgliedstyp wird erst in handleStore() gesetzt!!
-      int typ = Integer.valueOf(getMitgliedstyp().getID());
-      boolean checkMitglied = typ == Mitgliedstyp.MITGLIED
+      String typ = getMitgliedstyp().getID();
+      boolean checkMitglied = typ.equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("n");
-      boolean checkNichtMitglied = typ != Mitgliedstyp.MITGLIED
+      boolean checkNichtMitglied = !typ.equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("n") && (Boolean) Einstellungen
               .getEinstellung(Property.NICHTMITGLIEDPFLICHTEIGENSCHAFTEN);
-      boolean checkJMitglied = typ == Mitgliedstyp.MITGLIED
+      boolean checkJMitglied = typ.equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("j") && (Boolean) Einstellungen
               .getEinstellung(Property.JMITGLIEDPFLICHTEIGENSCHAFTEN);
-      boolean checkJNichtMitglied = typ != Mitgliedstyp.MITGLIED
+      boolean checkJNichtMitglied = !typ.equals(Mitgliedstyp.MITGLIED)
           && getPersonenart().equalsIgnoreCase("j") && (Boolean) Einstellungen
               .getEinstellung(Property.JNICHTMITGLIEDPFLICHTEIGENSCHAFTEN);
       if (checkMitglied || checkNichtMitglied || checkJMitglied

--- a/src/de/jost_net/JVerein/util/Spaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/Spaltenauswahl.java
@@ -67,7 +67,7 @@ public abstract class Spaltenauswahl
     {
       if (spalte.isChecked())
       {
-        if (mitgliedstyp == Mitgliedstyp.MITGLIED
+        if (mitgliedstyp == Integer.valueOf(Mitgliedstyp.MITGLIED)
             || spalte.isAuchNichtMitglied())
         {
           part.addColumn(spalte.getSpaltenbezeichnung(),


### PR DESCRIPTION
Ich habe jetzt auch die Checks beim Mitglied verschoben.
Dann habe ich noch geändert:
* In Mitglied habe ich die MitgliedsID auf Long geändert. Damit kann man sie auch in prepareStore() setzen. Die JVereinID in Mitgliedstyp ist weiter wie in der DB ein Integer. Dazu habe ich auch die Defines geändert. Es gibt die Long werte und neu die entsprechenden int. Diese haben jetzt "ID_" davor, also ID_MITGLIED und ID_SPENDER. Letztere werden beim Vergleich mit der JVEREINID verwendet
* Die editierbare MandatID wird auch in prepareStore gesetzt und damit auf Änderungen überprüft
* Das Änderungsdatum wird erst nach dem store() gesetzt damit es nicht verändert wird wenn der insert oder update Check schief geht
* Den Check der Eigenschaften habe ich in die Impl Klasse verlagert
* Der Eigenschaften Check wird in handleStore() aufgerufen. Ich kann ihn nicht in insertCheck machen weil er die Daten aus dem GUI braucht
* Beim Mitglied Import wird jetzt auch ein Eigenschaften Check aufgerufen bevor das Mitglied gespeichert wird
* Beim Mitglied Import werden noch Default Werte gesetzt damit es keine Änderungsanzeige bei Zurück gibt
* Bei setKtoiPersonenart im else Zweig war auch noch ein Fehler im Import, es wurde setPersonenart gemacht