### PR TITLE
Fix Rechnung erzeugen geht nicht mehr

### DIFF
--- a/src/de/jost_net/JVerein/Messaging/HibscusUmsatzMessageConsumer.java
+++ b/src/de/jost_net/JVerein/Messaging/HibscusUmsatzMessageConsumer.java
@@ -80,7 +80,7 @@ public class HibscusUmsatzMessageConsumer implements MessageConsumer
 
     Buchung b = list.next();
     b.setGeprueft(state);
-    b.store(false);
+    b.updateForced();
   }
 
   /**

--- a/src/de/jost_net/JVerein/gui/action/BuchungGeprueftAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGeprueftAction.java
@@ -64,7 +64,7 @@ public class BuchungGeprueftAction implements Action
       for (Buchung b : buchungen)
       {
         b.setGeprueft(geprueft);
-        b.store(false);
+        b.updateForced();
 
         // ggfs. mit Hibiscus syncronisieren
         // wir verwenden hier die SynTAX-MessageQueue, da diese bereits

--- a/src/de/jost_net/JVerein/gui/action/GesamtrechnungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/GesamtrechnungNeuAction.java
@@ -151,7 +151,7 @@ public class GesamtrechnungNeuAction implements Action
       {
         summe += sollb.getBetrag();
         sollb.setRechnung(rechnung);
-        sollb.store();
+        sollb.updateForced();
       }
       rechnung.setBetrag(summe);
       rechnung.store();

--- a/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/RechnungNeuAction.java
@@ -113,7 +113,7 @@ public class RechnungNeuAction implements Action
         rechnung.store();
 
         sollb.setRechnung(rechnung);
-        sollb.store();
+        sollb.updateForced();
         erstellt++;
       }
       if (erstellt == 0)

--- a/src/de/jost_net/JVerein/gui/util/AfaUtil.java
+++ b/src/de/jost_net/JVerein/gui/util/AfaUtil.java
@@ -216,9 +216,9 @@ public class AfaUtil
     buchung.setBuchungsartId(konto.getAfaartId());
     buchung.setAbschluss(abschluss);
     if (abschluss == null)
-      buchung.store(true);
+      buchung.store();
     else
-      buchung.store(false);
+      buchung.updateForced();
     monitor
         .setStatusText("Konto " + konto.getNummer() + ": AfA Buchung erzeugt");
     return 1;
@@ -327,9 +327,9 @@ public class AfaUtil
     buchung.setBetrag(-betrag);
     buchung.setAbschluss(abschluss);
     if (abschluss == null)
-      buchung.store(true);
+      buchung.store();
     else
-      buchung.store(false);
+      buchung.updateForced();
     monitor
         .setStatusText("Konto " + konto.getNummer() + ": AfA Buchung erzeugt");
     return 1;

--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -1251,7 +1251,7 @@ public class AbrechnungSEPA
         }
         sollb.setZweck1(zweck);
       }
-      sollb.store();
+      sollb.updateForced();
     }
     if (spArray != null && adress != null && adress instanceof Kursteilnehmer)
     {

--- a/src/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/de/jost_net/JVerein/rmi/Buchung.java
@@ -169,8 +169,6 @@ public interface Buchung extends JVereinDBObject
 
   public void plausi() throws RemoteException, ApplicationException;
 
-  public void store(boolean check) throws RemoteException, ApplicationException;
-
   public Boolean getGeprueft() throws RemoteException;
 
   public void setGeprueft(Boolean geprueft) throws RemoteException;

--- a/src/de/jost_net/JVerein/rmi/JVereinDBObject.java
+++ b/src/de/jost_net/JVerein/rmi/JVereinDBObject.java
@@ -20,6 +20,7 @@ package de.jost_net.JVerein.rmi;
 import java.rmi.RemoteException;
 
 import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.util.ApplicationException;
 
 /**
  * Basis-Interface fuer alle DB-Klassen in JVerein.
@@ -34,4 +35,7 @@ public interface JVereinDBObject extends DBObject
    * @throws RemoteException
    */
   public boolean isChanged() throws RemoteException;
+
+  // Update ohne Update Check oder eingeschränktem Check
+  public void updateForced() throws RemoteException, ApplicationException;
 }

--- a/src/de/jost_net/JVerein/server/AbstractJVereinDBObject.java
+++ b/src/de/jost_net/JVerein/server/AbstractJVereinDBObject.java
@@ -32,6 +32,9 @@ public abstract class AbstractJVereinDBObject extends AbstractDBObject
 
   private static final long serialVersionUID = 1L;
 
+  // Speichert ob Update ohne Update Check gemacht wird
+  protected boolean forcedUpdate = false;
+
   public AbstractJVereinDBObject() throws RemoteException
   {
     super();
@@ -75,5 +78,13 @@ public abstract class AbstractJVereinDBObject extends AbstractDBObject
     {
       super.store();
     }
+  }
+
+  // Update ohne Update Check oder eingeschränktem Check
+  @Override
+  public void updateForced() throws RemoteException, ApplicationException
+  {
+    this.forcedUpdate = true;
+    super.store();
   }
 }

--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -229,6 +229,31 @@ public class BuchungImpl extends AbstractJVereinDBObject implements Buchung
   @Override
   protected void updateCheck() throws ApplicationException
   {
+    // Wird eine Abschreibung während des Jahresabschlusses generiert muss
+    // zuerst der
+    // Jahresabschluss gespeichert werden damit die Referenz in der Buchung
+    // gespeichert
+    // werden kann. Dann muss man die Buchung auch bei bestehendem
+    // Jahresabschluss speichern
+    // können. In diesem Fall wird mit updateForced() gespeichert.
+    if (!forcedUpdate)
+    {
+      try
+      {
+        Jahresabschluss ja = getJahresabschluss();
+        if (ja != null)
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht gespeichert werden. Zeitraum ist bereits abgeschlossen!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Buchung kann nicht gespeichert werden. Siehe system log.";
+        Logger.error(fehler, e);
+        throw new ApplicationException(fehler);
+      }
+    }
     insertCheck();
   }
 
@@ -969,33 +994,4 @@ public class BuchungImpl extends AbstractJVereinDBObject implements Buchung
     }
     super.delete();
   }
-
-  @Override
-  public void store() throws RemoteException, ApplicationException
-  {
-    store(true);
-  }
-
-  @Override
-  public void store(boolean check) throws RemoteException, ApplicationException
-  {
-    if (check)
-    {
-      Jahresabschluss ja = getJahresabschluss();
-      if (ja != null)
-      {
-        throw new ApplicationException(
-            "Buchung kann nicht gespeichert werden. Zeitraum ist bereits abgeschlossen!");
-      }
-    }
-    // Wird eine Abschreibung während des Jahresabschlusses generiert muss
-    // zuerst der
-    // Jahresabschluss gespeichert werden damit die Referenz in der Buchung
-    // gespeichert
-    // werden kann. Dann muss man die Buchung auch bei bestehendem
-    // Jahresabschluss speichern
-    // können. In diesem Fall wird mit check false gespeichert.
-    super.store();
-  }
-
 }

--- a/src/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -128,27 +128,30 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
   @Override
   protected void updateCheck() throws ApplicationException
   {
-    insertCheck();
-    try
+    if (!forcedUpdate)
     {
-      if (getRechnung() != null)
+      try
       {
-        throw new ApplicationException(
-            "Sollbuchung kann nicht geändert werden weil sie zu einer Rechnung gehört");
+        if (getRechnung() != null)
+        {
+          throw new ApplicationException(
+              "Sollbuchung kann nicht geändert werden weil sie zu einer Rechnung gehört");
+        }
+      }
+      catch (ObjectNotFoundException e)
+      {
+        // Alles ok, es gibt keine Rechnung
+        // Das passiert wenn sie kurz vorher gelöscht wurde aber
+        // die ID noch im Cache gespeichert ist
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Sollbuchung kann nicht gespeichert werden. Siehe system log.";
+        Logger.error(fehler, e);
+        throw new ApplicationException(fehler);
       }
     }
-    catch (ObjectNotFoundException e)
-    {
-      // Alles ok, es gibt keine Rechnung
-      // Das passiert wenn sie kurz vorher gelöscht wurde aber
-      // die ID noch im Cache gespeichert ist
-    }
-    catch (RemoteException e)
-    {
-      String fehler = "Sollbuchung kann nicht gespeichert werden. Siehe system log.";
-      Logger.error(fehler, e);
-      throw new ApplicationException(fehler);
-    }
+    insertCheck();
   }
 
   @Override

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -368,7 +368,7 @@ public class SpendenbescheinigungImpl extends AbstractJVereinDBObject
       for (Buchung b : buchungen)
       {
         b.setSpendenbescheinigungId(id);
-        b.store(false);
+        b.updateForced();
       }
     }
   }


### PR DESCRIPTION
Mit #1039 wurde der Rechnung Check in den updateCheck der SollbuchungImpl verschoben. Dies führte aber dazu, dass man keine Rechnung mehr setzen kann, da die Rechnung vor dem store() zugewiesen wird. Dadurch schlägt der insertCheck fehl.
Ich habe jetzt analog zu #1038 eine Methode updateForced() in AbstractJVereinDBObject eingebaut. Damit kann man beim Speichern den Check ob eine Rechnung existiert überspringen.

Ich habe dann auch die alte spezifische Lösung bei der Buchung mit dem store(false) durch die neue generische Methode ersetzt damit es einheitlich wird.