### PR TITLE
Automerg Fehler anzeigen

### DIFF
--- a/.github/workflows/merge-master-into-feature.yml
+++ b/.github/workflows/merge-master-into-feature.yml
@@ -27,14 +27,15 @@ jobs:
           git checkout feature-3.2.0
           git pull
           git merge master --no-ff --no-commit
-        continue-on-error: true
 
       - name: Abort previous merge check
+        if: always()
         run: |
           git merge --abort
           git reset --hard HEAD
       
       - name: Merge master into feature-3.2.0
+        if: always()
         run: |
           # Merge master branch into feature with feature as king (ours)
           git merge -X ours master -m "Auto-merge master into feature-3.2.0" --stat


### PR DESCRIPTION
Wenn der Automerg fehlschlägt wird er trotzdem als erfolgreich angezeigt. Durch diese Änderung läuft es weiterhin durch und es wird der merge mit `-X ours` gemacht, er wird aber als Fehlgeschlagen markiert wenn der Mergetest fehlgeschlagen ist. So bekommt man es mit und kann prüfen ob der Automerg geklappt hat oder nicht.

Hier ein Testrun in meinem Repro: https://github.com/lenilsas/jverein/actions/runs/17497291134/job/49701299632