### PR TITLE
Fix Gegenbuchung Erstellen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungGegenbuchungAction.java
@@ -116,7 +116,7 @@ public class BuchungGegenbuchungAction implements Action
           }
           else
           {
-            GUI.startView(new BuchungDetailView(), buchungen[0]);
+            GUI.startView(new BuchungDetailView(), bu);
           }
         }
       }


### PR DESCRIPTION
Gegenbuchung erstellen wenn eine Buchung selektiert ist ging nicht mehr.

Ich habe es für den Master gemacht, da es ein gravierender Fehler ist.