### PR TITLE
Fix Sollbuchung Zurück Meldung

### DIFF
--- a/src/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -223,7 +223,7 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
   @Override
   public void setMitglied(Mitglied mitglied) throws RemoteException
   {
-    setAttribute(MITGLIED, Integer.valueOf(mitglied.getID()));
+    setAttribute(MITGLIED, Long.valueOf(mitglied.getID()));
   }
 
   @Override


### PR DESCRIPTION
Mit #1039 habe ich das setzen des Mitglied von store() nach prepareStore() verschoben. Dies führt jetzt dazu, dass immer bei Zurück eine Meldung über Änderung erscheint.
Dies liegt daran, dass das Mitglied in der DB ein Long ist aber in der Impl Klasse Integer benutzt wurde. Ich habe das auf Long geändert. Jetzt ist es keine Änderung mehr.