### PR TITLE
Formularfelder mit Velocity

### DIFF
--- a/src/de/jost_net/JVerein/Variable/LastschriftMap.java
+++ b/src/de/jost_net/JVerein/Variable/LastschriftMap.java
@@ -47,39 +47,13 @@ public class LastschriftMap extends AbstractMap
     {
       map = inma;
     }
-    Abrechnungslauf abrl = null;
+
     if (ls.getID() == null)
     {
-      abrl = (Abrechnungslauf) Einstellungen.getDBService()
-          .createObject(Abrechnungslauf.class, null);
-      abrl.setDatum(new Date());
-      abrl.setFaelligkeit(new Date());
-      abrl.setID("123");
-      ls.setAdressierungszusatz("Hinterhaus bei Lieschen Müller");
-      ls.setAnrede("Herrn");
-      ls.setBetrag(123.45d);
-      ls.setBIC("XXXXXXXXXXX");
-      ls.setEmail("willi.wichtig@mail.de");
-      ls.setIBAN("DE89370400440532013000");
-      ls.setIBAN("DE89370400440532013000");
-      ls.setGeschlecht(GeschlechtInput.MAENNLICH);
-      ls.setMandatDatum(new Date());
-      ls.setMandatSequence("FRST");
-      ls.setMandatID("1234");
-      ls.setName("Wichtig");
-      ls.setOrt("Testenhausen");
-      ls.setPersonenart("n");
-      ls.setPlz("12345");
-      ls.setStaat("Deutschland");
-      ls.setStrasse("Bahnhofstr. 1");
-      ls.setTitel("Dr.");
-      ls.setVerwendungszweck("Beitrag 2013 Willi Wichtig");
-      ls.setVorname("Willi");
+      return getDummyMap(map);
     }
-    else
-    {
-      abrl = ls.getAbrechnungslauf();
-    }
+
+    Abrechnungslauf abrl = ls.getAbrechnungslauf();
 
     map.put(LastschriftVar.ABRECHNUNGSLAUF_NR.getName(), abrl.getID());
     map.put(LastschriftVar.ABRECHNUNGSLAUF_DATUM.getName(), abrl.getDatum());

--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -241,7 +241,6 @@ public class MitgliedMap extends AbstractMap
     }
     map.put(MitgliedVar.ZAHLUNGSWEGTEXT.getName(), zahlungsweg);
 
-    HashMap<String, String> format = new HashMap<>();
     DBIterator<Felddefinition> itfd = Einstellungen.getDBService()
         .createList(Felddefinition.class);
     while (itfd.hasNext())
@@ -266,7 +265,6 @@ public class MitgliedMap extends AbstractMap
         case Datentyp.DATUM:
           map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(),
               Datum.formatDate(z.getFeldDatum()));
-          format.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(), "DATE");
           break;
         case Datentyp.JANEIN:
           map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(),
@@ -275,14 +273,12 @@ public class MitgliedMap extends AbstractMap
         case Datentyp.GANZZAHL:
           map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(),
               z.getFeldGanzzahl() + "");
-          format.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(), "INTEGER");
           break;
         case Datentyp.WAEHRUNG:
           if (z.getFeldWaehrung() != null)
           {
             map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(),
                 Einstellungen.DECIMALFORMAT.format(z.getFeldWaehrung()));
-            format.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(), "DOUBLE");
           }
           else
           {
@@ -382,7 +378,7 @@ public class MitgliedMap extends AbstractMap
     map.put(MitgliedVar.ANREDE_DU.getName(), "Hallo Willi,");
     map.put(MitgliedVar.ANREDE_FOERMLICH.getName(),
         "Sehr geehrter Herr Dr. Dr. Wichtig,");
-    map.put(MitgliedVar.AUSTRITT.getName(), toDate("01.01.2025"));
+    map.put(MitgliedVar.AUSTRITT.getName(), "01.01.2025");
     map.put(MitgliedVar.BEITRAGSGRUPPE_ARBEITSEINSATZ_BETRAG.getName(), "50");
     map.put(MitgliedVar.BEITRAGSGRUPPE_ARBEITSEINSATZ_STUNDEN.getName(), "10");
     map.put(MitgliedVar.BEITRAGSGRUPPE_BEZEICHNUNG.getName(), "Beitrag");
@@ -392,13 +388,13 @@ public class MitgliedMap extends AbstractMap
     map.put(MitgliedVar.MANDATID.getName(), "12345");
     map.put(MitgliedVar.BIC.getName(), "BICXXXXXXXX");
     map.put(MitgliedVar.BLZ.getName(), "");
-    map.put(MitgliedVar.EINTRITT.getName(), toDate("01.01.2010"));
-    map.put(MitgliedVar.EINGABEDATUM.getName(), toDate("01.02.2010"));
+    map.put(MitgliedVar.EINTRITT.getName(), "01.01.2010");
+    map.put(MitgliedVar.EINGABEDATUM.getName(), "01.02.2010");
     map.put(MitgliedVar.EMPFAENGER.getName(),
         "Herr\nDr. Dr. Willi Wichtig\nHinterhof bei Müller\nBahnhofstr. 22\n12345 Testenhausen\nDeutschland");
     map.put(MitgliedVar.EMAIL.getName(), "willi.wichtig@jverein.de");
     map.put(MitgliedVar.EXTERNE_MITGLIEDSNUMMER.getName(), "123456");
-    map.put(MitgliedVar.GEBURTSDATUM.getName(), toDate("02.03.1980"));
+    map.put(MitgliedVar.GEBURTSDATUM.getName(), "02.03.1980");
     map.put(MitgliedVar.GESCHLECHT.getName(), GeschlechtInput.MAENNLICH);
     map.put(MitgliedVar.HANDY.getName(), "0152778899");
     map.put(MitgliedVar.IBAN.getName(), "DE89370400440532013000");
@@ -426,15 +422,15 @@ public class MitgliedMap extends AbstractMap
         "werner.maier@jverein.de");
     map.put(MitgliedVar.KONTOINHABER_GESCHLECHT.getName(),
         GeschlechtInput.MAENNLICH);
-    map.put(MitgliedVar.KUENDIGUNG.getName(), toDate("01.11.2024"));
-    map.put(MitgliedVar.LETZTEAENDERUNG.getName(), toDate("01.11.2024"));
+    map.put(MitgliedVar.KUENDIGUNG.getName(), "01.11.2024");
+    map.put(MitgliedVar.LETZTEAENDERUNG.getName(), "01.11.2024");
     map.put(MitgliedVar.NAME.getName(), "Wichtig");
     map.put(MitgliedVar.NAMEVORNAME.getName(), "Wichtig, Dr. Dr. Willi");
     map.put(MitgliedVar.ORT.getName(), "Testenhausen");
     map.put(MitgliedVar.PERSONENART.getName(), "n");
     map.put(MitgliedVar.PLZ.getName(), "12345");
     map.put(MitgliedVar.STAAT.getName(), "Deutschland");
-    map.put(MitgliedVar.STERBETAG.getName(), toDate(("31.12.2024")));
+    map.put(MitgliedVar.STERBETAG.getName(), ("31.12.2024"));
     map.put(MitgliedVar.STRASSE.getName(), "Bahnhofstr. 22");
     map.put(MitgliedVar.TELEFONDIENSTLICH.getName(), "011/123456789");
     map.put(MitgliedVar.TELEFONPRIVAT.getName(), "011/123456");
@@ -463,8 +459,7 @@ public class MitgliedMap extends AbstractMap
       switch (fd.getDatentyp())
       {
         case Datentyp.DATUM:
-          map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(),
-              toDate(("31.12.2024")));
+          map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(), "31.12.2024");
           break;
         case Datentyp.JANEIN:
           map.put(Einstellungen.ZUSATZFELD_PRE + fd.getName(), "X");

--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -32,6 +32,7 @@ import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.JVerein.util.StringTool;
 
 public class RechnungMap extends AbstractMap
@@ -56,12 +57,12 @@ public class RechnungMap extends AbstractMap
       map = inMap;
     }
 
-    ArrayList<Date> buchungDatum = new ArrayList<>();
+    ArrayList<String> buchungDatum = new ArrayList<>();
     ArrayList<String> zweck = new ArrayList<>();
-    ArrayList<Double> nettobetrag = new ArrayList<>();
+    ArrayList<String> nettobetrag = new ArrayList<>();
     ArrayList<String> steuersatz = new ArrayList<>();
-    ArrayList<Double> steuerbetrag = new ArrayList<>();
-    ArrayList<Double> betrag = new ArrayList<>();
+    ArrayList<String> steuerbetrag = new ArrayList<>();
+    ArrayList<String> betrag = new ArrayList<>();
     HashMap<Double, Double> steuerMap = new HashMap<>();
     HashMap<Double, Double> steuerBetragMap = new HashMap<>();
 
@@ -69,12 +70,13 @@ public class RechnungMap extends AbstractMap
     double summe = 0;
     for (SollbuchungPosition sp : re.getSollbuchungPositionList())
     {
-      buchungDatum.add(sp.getDatum());
+      buchungDatum.add(new JVDateFormatTTMMJJJJ().format(sp.getDatum()));
       zweck.add(sp.getZweck());
-      nettobetrag.add(sp.getNettobetrag());
+      nettobetrag.add(Einstellungen.DECIMALFORMAT.format(sp.getNettobetrag()));
       steuersatz.add("(" + format.format(sp.getSteuersatz()) + "%)");
-      steuerbetrag.add(sp.getSteuerbetrag());
-      betrag.add(sp.getBetrag());
+      steuerbetrag
+          .add(Einstellungen.DECIMALFORMAT.format(sp.getSteuerbetrag()));
+      betrag.add(Einstellungen.DECIMALFORMAT.format(sp.getBetrag()));
       summe += sp.getBetrag();
       if (sp.getSteuersatz() > 0)
       {
@@ -87,36 +89,41 @@ public class RechnungMap extends AbstractMap
     if (buchungDatum.size() > 1 || steuerMap.size() > 0)
     {
       zweck.add("");
-      betrag.add(null);
+      betrag.add("");
     }
     if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT))
     {
       for (Double satz : steuerMap.keySet())
       {
-        zweck.add("inkl. " + satz + "% USt.  von "
+        zweck.add("inkl. " + satz + "% USt. von "
             + Einstellungen.DECIMALFORMAT.format(steuerBetragMap.get(satz)));
-        betrag.add(+steuerMap.get(satz));
+        betrag.add(Einstellungen.DECIMALFORMAT.format(steuerMap.get(satz)));
       }
     }
     if (buchungDatum.size() > 1)
     {
       zweck.add("Summe");
-      betrag.add(summe);
+      betrag.add(Einstellungen.DECIMALFORMAT.format(summe));
     }
-    map.put(RechnungVar.BUCHUNGSDATUM.getName(), buchungDatum.toArray());
-    map.put(RechnungVar.MK_BUCHUNGSDATUM.getName(), buchungDatum.toArray());
-    map.put(RechnungVar.ZAHLUNGSGRUND.getName(), zweck.toArray());
-    map.put(RechnungVar.MK_ZAHLUNGSGRUND.getName(), zweck.toArray());
-    map.put(RechnungVar.ZAHLUNGSGRUND1.getName(), zweck.toArray());
+    map.put(RechnungVar.BUCHUNGSDATUM.getName(),
+        String.join("\n", buchungDatum));
+    map.put(RechnungVar.MK_BUCHUNGSDATUM.getName(),
+        String.join("\n", buchungDatum));
+    map.put(RechnungVar.ZAHLUNGSGRUND.getName(), String.join("\n", zweck));
+    map.put(RechnungVar.MK_ZAHLUNGSGRUND.getName(), String.join("\n", zweck));
+    map.put(RechnungVar.ZAHLUNGSGRUND1.getName(), String.join("\n", zweck));
     map.put(RechnungVar.ZAHLUNGSGRUND2.getName(), "");
-    map.put(RechnungVar.NETTOBETRAG.getName(), nettobetrag.toArray());
-    map.put(RechnungVar.MK_NETTOBETRAG.getName(), nettobetrag.toArray());
-    map.put(RechnungVar.STEUERSATZ.getName(), steuersatz.toArray());
-    map.put(RechnungVar.MK_STEUERSATZ.getName(), steuersatz.toArray());
-    map.put(RechnungVar.STEUERBETRAG.getName(), steuerbetrag.toArray());
-    map.put(RechnungVar.MK_STEUERBETRAG.getName(), steuerbetrag.toArray());
-    map.put(RechnungVar.BETRAG.getName(), betrag.toArray());
-    map.put(RechnungVar.MK_BETRAG.getName(), betrag.toArray());
+    map.put(RechnungVar.NETTOBETRAG.getName(), String.join("\n", nettobetrag));
+    map.put(RechnungVar.MK_NETTOBETRAG.getName(),
+        String.join("\n", nettobetrag));
+    map.put(RechnungVar.STEUERSATZ.getName(), String.join("\n", steuersatz));
+    map.put(RechnungVar.MK_STEUERSATZ.getName(), String.join("\n", steuersatz));
+    map.put(RechnungVar.STEUERBETRAG.getName(),
+        String.join("\n", steuerbetrag));
+    map.put(RechnungVar.MK_STEUERBETRAG.getName(),
+        String.join("\n", steuerbetrag));
+    map.put(RechnungVar.BETRAG.getName(), String.join("\n", betrag));
+    map.put(RechnungVar.MK_BETRAG.getName(), String.join("\n", betrag));
 
     Double ist = 0d;
     if (re.getSollbuchung() != null)
@@ -222,29 +229,25 @@ public class RechnungMap extends AbstractMap
     }
 
     map.put(RechnungVar.BUCHUNGSDATUM.getName(),
-        new Date[] { new Date(), new Date() });
+        new JVDateFormatTTMMJJJJ().format(new Date()) + "\n"
+            + new JVDateFormatTTMMJJJJ().format(new Date()));
     if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERTPFLICHT))
     {
       map.put(RechnungVar.ZAHLUNGSGRUND.getName(),
-          new String[] { "Mitgliedsbeitrag", "Zusatzbetrag", "",
-              "inkl. 19% USt. von 10.00", "Summe" });
-      map.put(RechnungVar.NETTOBETRAG.getName(), new Double[] { 8.4d, 13.8d });
-      map.put(RechnungVar.STEUERSATZ.getName(),
-          new String[] { "(19%)", "(0%)" });
-      map.put(RechnungVar.STEUERBETRAG.getName(), new Double[] { 1.6d, 0d });
-      map.put(RechnungVar.BETRAG.getName(),
-          new Double[] { 10d, 13.8d, null, 1.6d, 23.8d });
+          "Mitgliedsbeitrag\nZusatzbetrag\n\ninkl. 19% USt. von 10,00\nSumme");
+      map.put(RechnungVar.NETTOBETRAG.getName(), "8,40\n13,80");
+      map.put(RechnungVar.STEUERSATZ.getName(), "(19%)\n(0%)");
+      map.put(RechnungVar.STEUERBETRAG.getName(), "1,60\n0,00");
+      map.put(RechnungVar.BETRAG.getName(), "10,00\n13,80\n\n1,60\n23,80");
     }
     else
     {
       map.put(RechnungVar.ZAHLUNGSGRUND.getName(),
-          new String[] { "Mitgliedsbeitrag", "Zusatzbetrag", "", "Summe" });
-      map.put(RechnungVar.NETTOBETRAG.getName(), new Double[] { 10d, 13.8d });
-      map.put(RechnungVar.STEUERSATZ.getName(),
-          new String[] { "(0%)", "(0%)" });
-      map.put(RechnungVar.STEUERBETRAG.getName(), new Double[] { 0d, 0d });
-      map.put(RechnungVar.BETRAG.getName(),
-          new Double[] { 10d, 13.8d, null, 23.8d });
+          "Mitgliedsbeitrag\nZusatzbetrag\n\nSumme");
+      map.put(RechnungVar.NETTOBETRAG.getName(), "10,00\n13,80");
+      map.put(RechnungVar.STEUERSATZ.getName(), "(0%)\n(0%)");
+      map.put(RechnungVar.STEUERBETRAG.getName(), "0,00\n0,00");
+      map.put(RechnungVar.BETRAG.getName(), "10,00\n13,80\n\n23,80");
     }
 
     map.put(RechnungVar.SUMME.getName(), Double.valueOf("23.80"));

--- a/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
+++ b/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
@@ -475,6 +475,7 @@ public class SpendenbescheinigungMap extends AbstractMap
     map.put(SpendenbescheinigungVar.VERANLAGUNGSZEITRAUM.getName(),
         "2022 bis 2024");
     map.put(SpendenbescheinigungVar.ZWECK.getName(), "Spende");
+
     map.put(SpendenbescheinigungVar.UNTERSCHRIFT.getName(), "Unterschrift");
     map.put(SpendenbescheinigungVar.ZEILE1.getName(), "Herr");
     map.put(SpendenbescheinigungVar.ZEILE2.getName(), "Willi Wichtig");

--- a/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
@@ -53,12 +53,23 @@ public abstract class FormularPartControl extends VorZurueckControl
 
     formularfelderList = new TablePart(formularfelder,
         new EditAction(FormularfeldDetailView.class));
-    formularfelderList.addColumn("Name", "name");
+    formularfelderList.addColumn("Name", "name", o -> {
+      String s = (String) o;
+      if (s.contains("\n"))
+      {
+        return s.substring(0, s.indexOf("\n"));
+      }
+      else
+      {
+        return s;
+      }
+    });
     formularfelderList.addColumn("Seite", "seite");
     formularfelderList.addColumn("Von links", "x");
     formularfelderList.addColumn("Von unten", "y");
     formularfelderList.addColumn("Schriftart", "font");
     formularfelderList.addColumn("Schriftgröße", "fontsize");
+    formularfelderList.addColumn("Ausrichtung", "ausrichtung");
 
     formularfelderList.setRememberColWidths(true);
     formularfelderList.setContextMenu(new FormularfeldMenu());

--- a/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
@@ -18,27 +18,26 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Variable.AllgemeineVar;
-import de.jost_net.JVerein.Variable.LastschriftVar;
-import de.jost_net.JVerein.Variable.MitgliedVar;
+import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.LastschriftMap;
+import de.jost_net.JVerein.Variable.MitgliedMap;
+import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.Variable.RechnungVar;
+import de.jost_net.JVerein.Variable.SpendenbescheinigungMap;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.keys.Ausrichtung;
 import de.jost_net.JVerein.keys.FormularArt;
-import de.jost_net.JVerein.rmi.Felddefinition;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
-import de.jost_net.JVerein.rmi.Lesefeld;
-import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.input.DecimalInput;
-import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
-import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -47,7 +46,7 @@ public class FormularfeldControl extends FormularPartControl implements Savable
 
   private de.willuhn.jameica.system.Settings settings;
 
-  private SelectInput name;
+  private TextAreaInput name;
 
   private IntegerInput seite;
 
@@ -61,35 +60,13 @@ public class FormularfeldControl extends FormularPartControl implements Savable
 
   private Formularfeld formularfeld;
 
-  private TextInput formularTyp;
-
-  private TextInput formularName;
+  private SelectInput ausrichtung;
 
   public FormularfeldControl(AbstractView view, Formular formular)
   {
     super(view, formular);
     settings = new de.willuhn.jameica.system.Settings(this.getClass());
     settings.setStoreWhenRead(true);
-  }
-
-  public Input getFormularTyp() throws RemoteException
-  {
-    if (null == formularTyp)
-    {
-      formularTyp = new TextInput(getFormularArtName());
-      formularTyp.disable();
-    }
-    return formularTyp;
-  }
-
-  public Input getFormularName() throws RemoteException
-  {
-    if (null == formularName)
-    {
-      formularName = new TextInput(formular.getBezeichnung());
-      formularName.disable();
-    }
-    return formularName;
   }
 
   public Formularfeld getFormularfeld()
@@ -107,111 +84,16 @@ public class FormularfeldControl extends FormularPartControl implements Savable
     return formular;
   }
 
-  public SelectInput getName()
+  public TextAreaInput getName()
       throws RemoteException, NoSuchFieldException, SecurityException
   {
     if (name != null)
     {
       return name;
     }
-    ArrayList<String> namen = new ArrayList<>();
-    if (formular.getArt() == FormularArt.SPENDENBESCHEINIGUNG)
-    {
-      for (AllgemeineVar av : AllgemeineVar.values())
-      {
-        namen.add(av.getName());
-      }
-      for (SpendenbescheinigungVar spv : SpendenbescheinigungVar.values())
-      {
-        namen.add(spv.getName());
-      }
-      for (MitgliedVar mv : MitgliedVar.values())
-      {
-        namen.add(mv.getName());
-      }
-    }
-    if (formular.getArt() == FormularArt.SAMMELSPENDENBESCHEINIGUNG)
-    {
-      for (AllgemeineVar av : AllgemeineVar.values())
-      {
-        namen.add(av.getName());
-      }
-      for (SpendenbescheinigungVar spv : SpendenbescheinigungVar.values())
-      {
-        namen.add(spv.getName());
-      }
-      for (MitgliedVar mv : MitgliedVar.values())
-      {
-        namen.add(mv.getName());
-      }
-    }
-    if (formular.getArt() == FormularArt.FREIESFORMULAR)
-    {
-      for (AllgemeineVar av : AllgemeineVar.values())
-      {
-        namen.add(av.getName());
-      }
-      for (MitgliedVar mv : MitgliedVar.values())
-      {
-        namen.add(mv.getName());
-      }
-    }
-    if (formular.getArt() == FormularArt.SEPA_PRENOTIFICATION)
-    {
-      for (AllgemeineVar av : AllgemeineVar.values())
-      {
-        namen.add(av.getName());
-      }
-      for (LastschriftVar lsv : LastschriftVar.values())
-      {
-        namen.add(lsv.getName());
-      }
-    }
-    if (formular.getArt() == FormularArt.RECHNUNG
-        || formular.getArt() == FormularArt.MAHNUNG)
-    {
-      for (AllgemeineVar av : AllgemeineVar.values())
-      {
-        namen.add(av.getName());
-      }
-      for (MitgliedVar mv : MitgliedVar.values())
-      {
-        namen.add(mv.getName());
-      }
-      for (RechnungVar mkv : RechnungVar.values())
-      {
-        if (!RechnungVar.class.getField(mkv.name())
-            .isAnnotationPresent(Deprecated.class))
-        {
-          namen.add(mkv.getName());
-        }
-      }
 
-    }
-    if (formular.getArt() == FormularArt.FREIESFORMULAR
-        || formular.getArt() == FormularArt.RECHNUNG
-        || formular.getArt() == FormularArt.MAHNUNG
-        || formular.getArt() == FormularArt.SPENDENBESCHEINIGUNG
-        || formular.getArt() == FormularArt.SAMMELSPENDENBESCHEINIGUNG)
-    {
-      DBIterator<Lesefeld> itlesefelder = Einstellungen.getDBService()
-          .createList(Lesefeld.class);
-      while (itlesefelder.hasNext())
-      {
-        Lesefeld lesefeld = itlesefelder.next();
-        namen.add(Einstellungen.LESEFELD_PRE + lesefeld.getBezeichnung());
-      }
-
-      DBIterator<Felddefinition> zusatzfelder = Einstellungen.getDBService()
-          .createList(Felddefinition.class);
-      while (zusatzfelder.hasNext())
-      {
-        Felddefinition zusatzfeld = (Felddefinition) zusatzfelder.next();
-        namen.add(Einstellungen.ZUSATZFELD_PRE + zusatzfeld.getName());
-      }
-    }
-    Collections.sort(namen);
-    name = new SelectInput(namen, getFormularfeld().getName());
+    name = new TextAreaInput(getFormularfeld().getName(), 1000);
+    name.setHeight(200);
     return name;
   }
 
@@ -289,6 +171,17 @@ public class FormularfeldControl extends FormularPartControl implements Savable
     return fontsize;
   }
 
+  public SelectInput getAusrichtung() throws RemoteException
+  {
+    if (ausrichtung != null)
+    {
+      return ausrichtung;
+    }
+    ausrichtung = new SelectInput(Ausrichtung.values(),
+        getFormularfeld().getAusrichtung());
+    return ausrichtung;
+  }
+
   @Override
   public JVereinDBObject prepareStore()
       throws RemoteException, ApplicationException
@@ -303,6 +196,7 @@ public class FormularfeldControl extends FormularPartControl implements Savable
       f.setY((Double) getY().getValue());
       f.setFont((String) getFont().getValue());
       f.setFontsize((Integer) getFontsize().getValue());
+      f.setAusrichtung((Ausrichtung) getAusrichtung().getValue());
     }
     catch (RemoteException e)
     {
@@ -333,9 +227,37 @@ public class FormularfeldControl extends FormularPartControl implements Savable
     }
   }
 
-  private String getFormularArtName() throws RemoteException
+  public Map<String, Object> getMap() throws RemoteException
   {
-    return formular.getArt().getText();
+    Map<String, Object> map = new AllgemeineMap().getMap(null);
+    if (formular.getArt() == FormularArt.SPENDENBESCHEINIGUNG
+        || formular.getArt() == FormularArt.SAMMELSPENDENBESCHEINIGUNG)
+    {
+      map = SpendenbescheinigungMap.getDummyMap(map);
+      map = MitgliedMap.getDummyMap(map);
+      // Dieser Eintrag ist nur in Formularen möglich, daher wird er hier extra
+      // hinzugefügt und ist nicht in der DummyMap.
+      map.put(SpendenbescheinigungVar.UNTERSCHRIFT.getName(),
+          "$" + SpendenbescheinigungVar.UNTERSCHRIFT.getName());
+    }
+    if (formular.getArt() == FormularArt.FREIESFORMULAR)
+    {
+      map = MitgliedMap.getDummyMap(map);
+    }
+    if (formular.getArt() == FormularArt.SEPA_PRENOTIFICATION)
+    {
+      map = LastschriftMap.getDummyMap(map);
+    }
+    if (formular.getArt() == FormularArt.RECHNUNG
+        || formular.getArt() == FormularArt.MAHNUNG)
+    {
+      map = MitgliedMap.getDummyMap(map);
+      map = RechnungMap.getDummyMap(map);
+      // Dieser Eintrag ist nur in Formularen möglich, daher wird er hier extra
+      // hinzugefügt und ist nicht in der DummyMap.
+      map.put(RechnungVar.QRCODE_SUMME.getName(),
+          "$" + RechnungVar.QRCODE_SUMME.getName());
+    }
+    return map;
   }
-
 }

--- a/src/de/jost_net/JVerein/gui/view/FormularfeldDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularfeldDetailView.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.FormularfeldNeuAction;
+import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.control.Savable;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
@@ -52,10 +53,14 @@ public class FormularfeldDetailView extends AbstractDetailView
     group.addLabelPair("Von unten", control.getY());
     group.addLabelPair("Schriftart", control.getFont());
     group.addLabelPair("Schriftgröße", control.getFontsize());
+    group.addLabelPair("Ausrichtung", control.getAusrichtung());
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FORMULARE, false, "question-circle.png");
+    buttons.addButton("Variablen anzeigen",
+        new InsertVariableDialogAction(control.getMap()), control, false,
+        "bookmark.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -98,10 +98,7 @@ public class FormularAufbereitung
 
   private File f;
 
-  private static final int links = 1;
-
-  private static final int rechts = 2;
-
+  // Constanten für QR-Code
   private static final String EPC_STRING = "BCD";
 
   private static final String EPC_VERSION = "002";
@@ -113,8 +110,6 @@ public class FormularAufbereitung
   private static final String EPC_ID = "SCT";
 
   private static final String EPC_EUR = "EUR";
-
-  private int buendig = links;
 
   /**
    * Öffnet die Datei und startet die PDF-Generierung
@@ -199,8 +194,7 @@ public class FormularAufbereitung
 
         DBIterator<Formularfeld> it = Einstellungen.getDBService()
             .createList(Formularfeld.class);
-        it.addFilter("formular = ? and seite = ?",
-            new Object[] { formular.getID(), i });
+        it.addFilter("formular = ? and seite = ?", formular.getID(), i);
 
         Boolean increased = false;
 
@@ -210,9 +204,10 @@ public class FormularAufbereitung
 
           // Increase counter if form field is zaehler or qrcode (counter is
           // needed in QR code, so it needs to be incremented)
-          if ((f.getName().equals(AllgemeineVar.ZAEHLER.getName())
-              || f.getName().equals(RechnungVar.QRCODE_SUMME.getName()))
-              && !increased)
+          if (!increased && (f.getName().toLowerCase()
+              .contains(AllgemeineVar.ZAEHLER.getName().toLowerCase())
+              || f.getName().toLowerCase()
+                  .contains(RechnungVar.QRCODE_SUMME.getName().toLowerCase())))
           {
             zaehler++;
             // Prevent multiple increases by next page
@@ -223,14 +218,7 @@ public class FormularAufbereitung
                 StringTool.lpad(zaehler.toString(), zaehlerLaenge, "0"));
           }
 
-          // create QR code for invoice sum if form field is QRCODE_SUM
-          if (f.getName().equals(RechnungVar.QRCODE_SUMME.getName()))
-          {
-            map.put(RechnungVar.QRCODE_SUMME.getName(), getPaymentQRCode(map));
-            // Update QR code
-          }
-
-          goFormularfeld(contentByte, f, map.get(f.getName()));
+          goFormularfeld(contentByte, f, map);
         }
       }
 
@@ -247,8 +235,8 @@ public class FormularAufbereitung
     }
   }
 
-  @SuppressWarnings({ "unchecked", "rawtypes" })
-  private Image getPaymentQRCode(Map fieldsMap) throws RemoteException
+  private Image getPaymentQRCode(Map<String, Object> fieldsMap)
+      throws RemoteException
   {
     boolean festerText = (Boolean) Einstellungen
         .getEinstellung(Property.QRCODEFESTERTEXT);
@@ -265,13 +253,11 @@ public class FormularAufbereitung
 
     StringBuilder sb = new StringBuilder();
     String verwendungszweck;
-    String infoToMitglied;
 
     if (festerText)
     {
-      String zahlungsgruende_raw = getString(
-          fieldsMap.get(RechnungVar.ZAHLUNGSGRUND.getName()));
-      String[] zahlungsgruende = zahlungsgruende_raw.split("\n");
+      String[] zahlungsgruende = ((String) fieldsMap
+          .get(RechnungVar.ZAHLUNGSGRUND.getName())).split("\n");
       if (zahlungsgruende.length == 1
           && (Boolean) Einstellungen.getEinstellung(Property.QRCODESNGLLINE))
       {
@@ -348,7 +334,7 @@ public class FormularAufbereitung
 
     verwendungszweck = sb.toString();
 
-    infoToMitglied = (String) Einstellungen
+    String infoToMitglied = (String) Einstellungen
         .getEinstellung(Property.QRCODEINFOM);
     if (null == infoToMitglied)
     {
@@ -382,17 +368,14 @@ public class FormularAufbereitung
         infoToMitglied.substring(0, Math.min(infoToMitglied.length(), 70)));
     // trim to 70 chars max.
     String charset = EPC_CHARSET;
-    Map hintMap = new HashMap();
+    Map<EncodeHintType, ErrorCorrectionLevel> hintMap = new HashMap<>();
     hintMap.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.M);
     try
     {
-
       BitMatrix matrix = new MultiFormatWriter().encode(
           new String(sbEpc.toString().getBytes(charset), charset),
           BarcodeFormat.QR_CODE, (int) sz, (int) sz, hintMap);
-
       return MatrixToImageWriter.toBufferedImage(matrix);
-
     }
     catch (UnsupportedEncodingException e1)
     {
@@ -445,53 +428,114 @@ public class FormularAufbereitung
   }
 
   private void goFormularfeld(PdfContentByte contentByte, Formularfeld feld,
-      Object val) throws DocumentException, IOException
+      Map<String, Object> map) throws DocumentException, IOException
   {
     String filename = String.format("/fonts/%s.ttf", feld.getFont());
-    BaseFont bf = BaseFont.createFont(filename, BaseFont.IDENTITY_H, true);
+    BaseFont baseFont = BaseFont.createFont(filename, BaseFont.IDENTITY_H,
+        true);
 
     float x = mm2point(feld.getX().floatValue());
     float y = mm2point(feld.getY().floatValue());
-    if (val == null)
+
+    Object val;
+    String inhalt = feld.getName();
+    // (Alte) Felder mit nur einer Variable direkt aus der Map holen
+    if (inhalt.matches("^\\$?[a-zA-Z0-9_]+$"))
     {
-      return;
-    }
-    else if (val instanceof Image)
-    {
-      com.itextpdf.text.Image i = com.itextpdf.text.Image
-          .getInstance((Image) val, Color.BLACK);
-      float sz = mm2point(
-          (Integer) Einstellungen.getEinstellung(Property.QRCODESIZEINMM));
-      contentByte.addImage(i, sz, 0, 0, sz, x, y);
-    }
-    else if (val instanceof com.itextpdf.text.Image)
-    {
-      com.itextpdf.text.Image i = (com.itextpdf.text.Image) val;
-      float sh = i.getScaledHeight();
-      float sw = i.getScaledWidth();
-      contentByte.addImage(i, sw, 0, 0, sh, x, y);
+      val = map.get(inhalt.replace("$", ""));
+      if (val == null)
+      {
+        val = inhalt;
+      }
     }
     else
     {
-      buendig = links;
-      String stringVal = getString(val);
-      stringVal = stringVal.replace("\\n", "\n");
-      stringVal = stringVal.replaceAll("\r\n", "\n");
-      String[] ss = stringVal.split("\n");
-      for (String s : ss)
+      // Felder mit Text und Variablen
+      VelocityContext context = new VelocityContext();
+      context.put("dateformat", new JVDateFormatTTMMJJJJ());
+      context.put("decimalformat", Einstellungen.DECIMALFORMAT);
+      VarTools.add(context, map);
+
+      StringWriter wtext = new StringWriter();
+      Velocity.evaluate(context, wtext, "LOG", inhalt);
+      val = wtext.toString();
+    }
+
+    String stringVal = getString(val).replace("\\n", "\n").replaceAll("\r\n",
+        "\n");
+    for (String s : stringVal.split("\n"))
+    {
+      Object o = null;
+      // Unterschrift und QR-Code durch Bild ersetzen
+      if (s.matches("^\\$?[a-zA-Z0-9_]+$"))
       {
-        contentByte.setFontAndSize(bf, feld.getFontsize().floatValue());
-        contentByte.beginText();
-        float offset = 0;
-        if (buendig == rechts)
+        if (s.replace("$", "")
+            .equalsIgnoreCase(RechnungVar.QRCODE_SUMME.getName()))
         {
-          offset = contentByte.getEffectiveStringWidth(s, true);
+          com.itextpdf.text.Image i = com.itextpdf.text.Image
+              .getInstance(getPaymentQRCode(map), Color.BLACK);
+          float sz = mm2point(
+              (Integer) Einstellungen.getEinstellung(Property.QRCODESIZEINMM));
+          float offset = 0;
+          switch (feld.getAusrichtung())
+          {
+            case RECHTS:
+              offset = sz;
+              break;
+            case MITTE:
+              offset = sz / 2;
+            default:
+              break;
+          }
+          contentByte.addImage(i, sz, 0, 0, sz, x - offset, y - sz);
+          y -= sz + 3;
+          continue;
         }
-        contentByte.moveText(x - offset, y);
-        contentByte.showText(s);
-        contentByte.endText();
-        y -= feld.getFontsize().floatValue() + 3;
+
+        // Unterschrift
+        o = map.get(s.replace("$", ""));
+        if (o instanceof com.itextpdf.text.Image)
+        {
+          com.itextpdf.text.Image i = (com.itextpdf.text.Image) val;
+          float sh = i.getScaledHeight();
+          float sw = i.getScaledWidth();
+          float offset = 0;
+          switch (feld.getAusrichtung())
+          {
+            case RECHTS:
+              offset = sw;
+              break;
+            case MITTE:
+              offset = sw / 2;
+            default:
+              break;
+          }
+          contentByte.addImage(i, sw, 0, 0, sh, x - offset, y);
+          y -= sh + 3;
+          continue;
+        }
+        else if (o instanceof String)
+        {
+          s = (String) o;
+        }
       }
+      contentByte.setFontAndSize(baseFont, feld.getFontsize().floatValue());
+      contentByte.beginText();
+      float offset = 0;
+      switch (feld.getAusrichtung())
+      {
+        case RECHTS:
+          offset = contentByte.getEffectiveStringWidth(s, true);
+          break;
+        case MITTE:
+          offset = contentByte.getEffectiveStringWidth(s, true) / 2;
+        default:
+          break;
+      }
+      contentByte.moveText(x - offset, y);
+      contentByte.showText(s);
+      contentByte.endText();
+      y -= feld.getFontsize().floatValue() + 3;
     }
   }
 
@@ -502,79 +546,15 @@ public class FormularAufbereitung
 
   private String getString(Object val)
   {
-    StringBuilder stringVal = new StringBuilder();
-    if (val instanceof Object[])
-    {
-      Object[] o = (Object[]) val;
-      if (o.length == 0)
-      {
-        return "";
-      }
-      if (o[0] instanceof String)
-      {
-        for (Object ostr : o)
-        {
-          stringVal.append((String) ostr);
-          stringVal.append("\n");
-        }
-
-        // Format Strings with percent numbers and closing bracket e.g. taxes
-        if (((String) o[0]).contains("%)"))
-        {
-          buendig = rechts;
-        }
-      }
-      if (o[0] instanceof Date)
-      {
-        for (Object od : o)
-        {
-          if (od != null)
-          {
-            stringVal.append(new JVDateFormatTTMMJJJJ().format((Date) od));
-          }
-          stringVal.append("\n");
-        }
-      }
-      if (o[0] instanceof Double)
-      {
-        for (Object od : o)
-        {
-          if (od != null)
-          {
-            stringVal.append(Einstellungen.DECIMALFORMAT.format(od));
-          }
-          stringVal.append("\n");
-        }
-        buendig = rechts;
-      }
-
-    }
-    if (val instanceof String)
-    {
-      stringVal = new StringBuilder((String) val);
-
-      // Format Strings with percent numbers and closing bracket e.g. taxes
-      if (((String) val).contains("%)"))
-      {
-        buendig = rechts;
-      }
-    }
     if (val instanceof Double)
     {
-      stringVal = new StringBuilder(Einstellungen.DECIMALFORMAT.format(val));
-      buendig = rechts;
-    }
-    if (val instanceof Integer)
-    {
-      stringVal = new StringBuilder(val.toString());
-      buendig = rechts;
+      return Einstellungen.DECIMALFORMAT.format(val);
     }
     if (val instanceof Date)
     {
-      stringVal = new StringBuilder(
-          new JVDateFormatTTMMJJJJ().format((Date) val));
+      return new JVDateFormatTTMMJJJJ().format((Date) val);
     }
-    return stringVal.toString();
+    return val.toString();
   }
 
   public void printNeueSeite()

--- a/src/de/jost_net/JVerein/keys/Ausrichtung.java
+++ b/src/de/jost_net/JVerein/keys/Ausrichtung.java
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.keys;
+
+/**
+ * Ausrichtung von Formularfeldern
+ */
+public enum Ausrichtung
+{
+
+  LINKS("Links", 0),
+  RECHTS("Rechts", 1),
+  MITTE("Mitte", 2);
+
+  private final int key;
+
+  private String text;
+
+  Ausrichtung(String text, int key)
+  {
+    this.text = text;
+    this.key = key;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public static Ausrichtung getByKey(int key)
+  {
+    for (Ausrichtung a : Ausrichtung.values())
+    {
+      if (a.getKey() == key)
+      {
+        return a;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return text;
+  }
+}

--- a/src/de/jost_net/JVerein/rmi/Formularfeld.java
+++ b/src/de/jost_net/JVerein/rmi/Formularfeld.java
@@ -18,6 +18,8 @@ package de.jost_net.JVerein.rmi;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.keys.Ausrichtung;
+
 public interface Formularfeld extends JVereinDBObject
 {
   public void setID(String id) throws RemoteException;
@@ -53,4 +55,8 @@ public interface Formularfeld extends JVereinDBObject
   public Integer getFontstyle() throws RemoteException;
 
   public void setFontstyle(Integer fontstyle) throws RemoteException;
+
+  public Ausrichtung getAusrichtung() throws RemoteException;
+
+  public void setAusrichtung(Ausrichtung ausrichtung) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0485.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0485.java
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.Variable.RechnungVar;
+import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0485 extends AbstractDDLUpdate
+{
+  public Update0485(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public void run() throws ApplicationException
+  {
+    Column col = new Column("name", COLTYPE.VARCHAR, 1000, "''", true, false);
+    execute(alterColumn("formularfeld", col));
+
+    col = new Column("ausrichtung", COLTYPE.INTEGER, 1, "0", true, false);
+    execute(addColumn("formularfeld", col));
+
+    // Bisher waren Double Felder und der Steuersatz rechts ausgerichtet
+    execute("UPDATE formularfeld SET ausrichtung = 1 WHERE name IN('"
+        + RechnungVar.SUMME.getName() + "','" + RechnungVar.IST.getName()
+        + "','" + RechnungVar.SUMME_OFFEN.getName() + "','"
+        + RechnungVar.STAND.getName() + "','" + RechnungVar.STEUERSATZ.getName()
+        + "','" + RechnungVar.MK_STEUERSATZ.getName() + "','"
+        + RechnungVar.MK_SUMME_OFFEN.getName() + "','"
+        + RechnungVar.MK_STAND.getName() + "','"
+        + SpendenbescheinigungVar.BETRAG.getName() + "','"
+        + RechnungVar.NETTOBETRAG.getName() + "','"
+        + RechnungVar.STEUERBETRAG.getName() + "','"
+        + RechnungVar.BETRAG.getName() + "','"
+        + RechnungVar.MK_NETTOBETRAG.getName() + "','"
+        + RechnungVar.MK_STEUERBETRAG.getName() + "','"
+        + RechnungVar.MK_BETRAG.getName() + "')");
+  }
+}

--- a/src/de/jost_net/JVerein/server/FormularfeldImpl.java
+++ b/src/de/jost_net/JVerein/server/FormularfeldImpl.java
@@ -20,6 +20,9 @@ import java.rmi.RemoteException;
 
 import org.eclipse.swt.SWT;
 
+import de.jost_net.JVerein.Variable.RechnungVar;
+import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.keys.Ausrichtung;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
 import de.willuhn.logging.Logger;
@@ -61,7 +64,25 @@ public class FormularfeldImpl extends AbstractJVereinDBObject
     {
       if (getName() == null || getName().length() == 0)
       {
-        throw new ApplicationException("Bitte Namen eingeben");
+        throw new ApplicationException("Bitte Inhalt eingeben");
+      }
+      for (String zeile : getName().split("\n"))
+      {
+        if (zeile.contains(RechnungVar.QRCODE_SUMME.getName())
+            && !zeile.replace("$", "")
+                .equalsIgnoreCase(RechnungVar.QRCODE_SUMME.getName()))
+        {
+          throw new ApplicationException(RechnungVar.QRCODE_SUMME.getName()
+              + " Muss alleine in der Zeile Stehen!");
+        }
+        if (zeile.contains(SpendenbescheinigungVar.UNTERSCHRIFT.getName())
+            && !zeile.replace("$", "").equalsIgnoreCase(
+                SpendenbescheinigungVar.UNTERSCHRIFT.getName()))
+        {
+          throw new ApplicationException(
+              SpendenbescheinigungVar.UNTERSCHRIFT.getName()
+                  + " Muss alleine in der Zeile Stehen!");
+        }
       }
     }
     catch (RemoteException e)
@@ -213,6 +234,10 @@ public class FormularfeldImpl extends AbstractJVereinDBObject
   @Override
   public Object getAttribute(String fieldName) throws RemoteException
   {
+    if ("ausrichtung".equals(fieldName))
+    {
+      return this.getAusrichtung();
+    }
     return super.getAttribute(fieldName);
   }
 
@@ -226,5 +251,22 @@ public class FormularfeldImpl extends AbstractJVereinDBObject
   public String getObjektNameMehrzahl()
   {
     return "Formularfelder";
+  }
+
+  @Override
+  public Ausrichtung getAusrichtung() throws RemoteException
+  {
+    Object o = super.getAttribute("ausrichtung");
+    if (o == null)
+    {
+      return Ausrichtung.LINKS;
+    }
+    return Ausrichtung.getByKey((int) o);
+  }
+
+  @Override
+  public void setAusrichtung(Ausrichtung ausrichtung) throws RemoteException
+  {
+    setAttribute("ausrichtung", ausrichtung.getKey());
   }
 }


### PR DESCRIPTION
Ich hab bei den Formularen die Möglichkeit geschaffen auch Text anzugeben der er Velocity geparst wird. Also so wie auch bei den Mails etc. Es gibt beim Formularfeld jetzt nicht mehr den Dropdown mit Feldern sondern eine TextArea.
Dafür habe ich die RechungsMap etwas geändert. Hier gibt es jetzt keine Arrays mehr sondern mehrzeilige Strings, das wurde bei der Aufbereitung bisher sowieso so weiterverarbeitet.
Bisher warnen alle Double felder rechts ausgerichtet, das wird per DB update auch wieder gemacht, dazu existiert eine neue Spalte "Ausrichtung", außerdem habe ich hier die Ausrichtung "Mitte" hinzugefügt.
Bei der Mitgliedmap im Dummy wurde einiges als Date ausgegeben was in der richtigen Map aber als String war. Das hab ich geändert.
In der neuen Form müssen die Felder mit einem führenden $ versehen werden. Wenn jedoch nur ein Feld da steht, akzeptiere ich auch weiterhin ohne $. Der Gedanke war, es dadurch auch abwärtskompatiebel zu machen. Ganz ist das aber nicht der Fall, da ja neu angelegte Formulare nicht mit einer älteren Version verarbeitet werden können. Wahrscheinlich sollte es daher eine 4.0.0 werden.
Was ich noch nicht gemacht habe, ist den FormularIm/Export und den FormularfeldIm/Export umzustellen.
