### PR TITLE
Delete Check auf Buchungen bei Sollbuchung entfernt

### DIFF
--- a/src/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -73,14 +73,6 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
             "Sollbuchung kann nicht gelöscht werden weil sie zu einer "
                 + "Rechnung gehört!");
       }
-      DBIterator<Buchung> it;
-      it = Einstellungen.getDBService().createList(Buchung.class);
-      it.addFilter(Buchung.SOLLBUCHUNG + " = ?", new Object[] { this.getID() });
-      if (it.size() > 0)
-      {
-        throw new ApplicationException(
-            "Sollbuchung kann nicht gelöscht werden weil ihr Buchungen zugeordnet sind!");
-      }
     }
     catch (ObjectNotFoundException e)
     {


### PR DESCRIPTION
Wie in #1070 besprochen habe ich den Delete Check auf vorhandene Buchungen bei der Sollbuchung entfernt.
Damit funktioniert das DbBereinigen wieder.