### PR TITLE
Buchung Verlassenmeldung geprueft

### DIFF
--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0486.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0486.java
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0486 extends AbstractDDLUpdate
+{
+  public Update0486(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute("update buchung set geprueft = false where geprueft is null");
+  }
+}


### PR DESCRIPTION
Da durch #1022 in der DetailView eine Geprüft Checkbox ist, kommt es zu falschen Speichern-bei-Verlassenmeldungen. Daher setze ich hier alle geprüft null auf false.