### PR TITLE
Filter Bereich bei Nicht-Mitglieder wie bei Mitglieder

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/NichtMitgliedListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/NichtMitgliedListeView.java
@@ -18,6 +18,10 @@ package de.jost_net.JVerein.gui.view;
 
 import java.rmi.RemoteException;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.TabFolder;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.NichtMitgliedDetailAction;
@@ -26,9 +30,10 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
-import de.willuhn.jameica.gui.util.ColumnLayout;
+import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
+import de.willuhn.jameica.gui.util.TabGroup;
 import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 
 public class NichtMitgliedListeView extends AbstractMitgliedListeView
@@ -49,28 +54,47 @@ public class NichtMitgliedListeView extends AbstractMitgliedListeView
   public void getFilter() throws RemoteException
   {
     LabelGroup group = new LabelGroup(getParent(), "Filter");
-    ColumnLayout cl = new ColumnLayout(group.getComposite(), 3);
+    TabFolder folder = new TabFolder(group.getComposite(),
+        SWT.V_SCROLL | SWT.BORDER);
+    folder.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+    folder.setBackground(Color.BACKGROUND.getSWTColor());
 
-    SimpleContainer left = new SimpleContainer(cl.getComposite());
+    // Erster Tab
+    TabGroup tab1 = new TabGroup(folder, "Allgemein", true, 3);
+    SimpleContainer left = new SimpleContainer(tab1.getComposite());
     left.addInput(control.getSuchMitgliedstyp(Mitgliedstypen.NICHTMITGLIED));
     left.addInput(control.getSuchname());
-    left.addInput(control.getMailauswahl());
 
-    SimpleContainer middle = new SimpleContainer(cl.getComposite());
+    SimpleContainer middle = new SimpleContainer(tab1.getComposite());
     middle.addInput(control.getSuchGeschlecht());
+    middle.addInput(control.getMailauswahl());
+
+    SimpleContainer right = new SimpleContainer(tab1.getComposite());
     DialogInput eigenschaftenInput = control.getEigenschaftenAuswahl();
-    middle.addInput(eigenschaftenInput);
+    right.addInput(eigenschaftenInput);
     control.updateEigenschaftenAuswahlTooltip();
     if ((Boolean) Einstellungen.getEinstellung(Property.USEZUSATZFELDER))
     {
       DialogInput zusatzfelderInput = control.getZusatzfelderAuswahl();
-      middle.addInput(zusatzfelderInput);
+      right.addInput(zusatzfelderInput);
       control.updateZusatzfelderAuswahlTooltip();
     }
 
-    SimpleContainer right = new SimpleContainer(cl.getComposite());
-    right.addInput(control.getGeburtsdatumvon());
-    right.addInput(control.getGeburtsdatumbis());
+    // Zeiter Tab
+    TabGroup tab2 = new TabGroup(folder, "Datum", true, 1);
+    SimpleContainer left2 = new SimpleContainer(tab2.getComposite());
+    left2.addInput(control.getGeburtsdatumvon());
+    left2.addInput(control.getGeburtsdatumbis());
+
+    // Dritter Tab
+    TabGroup tab3 = new TabGroup(folder, "Mitgliedskonto", true, 2);
+    SimpleContainer left3 = new SimpleContainer(tab3.getComposite());
+    left3.addInput(control.getDifferenz());
+    left3.addLabelPair("Differenz Limit", control.getDoubleAusw());
+
+    SimpleContainer right3 = new SimpleContainer(tab3.getComposite());
+    right3.addInput(control.getDatumvon());
+    right3.addInput(control.getDatumbis());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(control.getResetButton());


### PR DESCRIPTION
Ich habe den Filter Bereich in der Nicht-Mitglieder Liste in drei Tabs aufgeteilt so wie auch schon bei den Mitgliedern.
Damit kann man jetzt auch nach Diffrenz filtern, z.B. Fehlbetrag.
<img width="271" height="87" alt="Bildschirmfoto_20250924_135144" src="https://github.com/user-attachments/assets/56ba2929-f0d0-4da8-a402-19cedc88b99f" />
