### PR TITLE
Wirtschaftsplan Trees Collaps und Expand

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -56,6 +56,7 @@ import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.Settings;
@@ -83,6 +84,8 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
 
   private boolean tableChanged = false;
 
+  protected Settings settings = null;
+
   /**
    * Erzeugt einen neuen WirtschaftsplanControl fuer die angegebene View.
    *
@@ -92,8 +95,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
   public WirtschaftsplanControl(AbstractView view)
   {
     super(view);
-    de.willuhn.jameica.system.Settings settings = new de.willuhn.jameica.system.Settings(
-        this.getClass());
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
     settings.setStoreWhenRead(true);
   }
 
@@ -158,6 +160,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     if (einnahmen == null)
     {
       einnahmen = generateTree(WirtschaftsplanImpl.EINNAHME);
+      einnahmen.setRememberColWidths(true);
     }
     else
     {
@@ -174,6 +177,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     if (ausgaben == null)
     {
       ausgaben = generateTree(WirtschaftsplanImpl.AUSGABE);
+      ausgaben.setRememberColWidths(true);
     }
     else
     {
@@ -632,5 +636,87 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
   public void setToChanged()
   {
     tableChanged = true;
+  }
+
+  public Button getCollapsEinnahmenButton()
+  {
+    return new Button("", context -> {
+      handleEinnahmen(false);
+      settings.setAttribute("einnahmen_expand", "false");
+    }, null, false, "folder.png");
+  }
+
+  public Button getExpandEinnahmenButton()
+  {
+    return new Button("", context -> {
+      handleEinnahmen(true);
+      settings.setAttribute("einnahmen_expand", "true");
+    }, null, false, "folder-open.png");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void handleEinnahmen(boolean expand)
+  {
+    List<WirtschaftsplanNode> nodes;
+    try
+    {
+      nodes = (List<WirtschaftsplanNode>) einnahmen.getItems();
+      for (WirtschaftsplanNode node : nodes)
+      {
+        GenericIterator<WirtschaftsplanNode> it = node.getChildren();
+        while (it.hasNext())
+        {
+          einnahmen.setExpanded(it.next(), expand);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
+  }
+
+  public Button getCollapsAusgabenButton()
+  {
+    return new Button("", context -> {
+      handleAusgaben(false);
+      settings.setAttribute("ausgaben_expand", "false");
+    }, null, false, "folder.png");
+  }
+
+  public Button getExpandAusgabenButton()
+  {
+    return new Button("", context -> {
+      handleAusgaben(true);
+      settings.setAttribute("eausgaben_expand", "true");
+    }, null, false, "folder-open.png");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void handleAusgaben(boolean expand)
+  {
+    List<WirtschaftsplanNode> nodes;
+    try
+    {
+      nodes = (List<WirtschaftsplanNode>) ausgaben.getItems();
+      for (WirtschaftsplanNode node : nodes)
+      {
+        GenericIterator<WirtschaftsplanNode> it = node.getChildren();
+        while (it.hasNext())
+        {
+          ausgaben.setExpanded(it.next(), expand);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      //
+    }
+  }
+
+  public void initTrees()
+  {
+    handleEinnahmen(settings.getBoolean("einnahmen_expand", true));
+    handleAusgaben(settings.getBoolean("ausgaben_expand", true));
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/WirtschaftsplanDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/WirtschaftsplanDetailView.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.gui.parts.WirtschaftsplanUebersichtPart;
 import de.jost_net.JVerein.rmi.Wirtschaftsplan;
 import de.jost_net.JVerein.server.WirtschaftsplanImpl;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.util.ApplicationException;
@@ -61,13 +62,24 @@ public class WirtschaftsplanDetailView extends AbstractDetailView
     EditTreePart treeEinnahmen = control.getEinnahmen();
     treeEinnahmen.setContextMenu(
         new WirtschaftsplanMenu(WirtschaftsplanImpl.EINNAHME, control));
+    ButtonArea einnahmenButtons = new ButtonArea();
+    einnahmenButtons.addButton(control.getCollapsEinnahmenButton());
+    einnahmenButtons.addButton(control.getExpandEinnahmenButton());
+    einnahmen.addButtonArea(einnahmenButtons);
     einnahmen.addPart(treeEinnahmen);
+
     LabelGroup ausgaben = new LabelGroup(group.getComposite(), "Ausgaben",
         true);
     EditTreePart treeAusgaben = control.getAusgaben();
     treeAusgaben.setContextMenu(
         new WirtschaftsplanMenu(WirtschaftsplanImpl.AUSGABE, control));
+    ButtonArea ausgabenButtons = new ButtonArea();
+    ausgabenButtons.addButton(control.getCollapsAusgabenButton());
+    ausgabenButtons.addButton(control.getExpandAusgabenButton());
+    ausgaben.addButtonArea(ausgabenButtons);
     ausgaben.addPart(treeAusgaben);
+
+    control.initTrees();
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();
 


### PR DESCRIPTION
Im Wirtschaftsplan View habe ich bei den Trees je zwei Buttons eingebaut um die Buchungsarten Einträge zu und auf zu klappen. 
<img width="519" height="93" alt="Bildschirmfoto_20250926_131354" src="https://github.com/user-attachments/assets/14c20295-aab6-4313-b492-0cfb1751a49f" />


Ich habe dabei gesehen, dass im Feature Branch die Buchungsarten nicht die Summe der Items anzeigen. Im Steuer PR ist das aber korrigiert.