### PR TITLE
Buchungsart Sortierung und Anzeige separat konfigurierbar

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -246,6 +246,7 @@ public class Einstellungen
     BUCHUNGBUCHUNGSARTAUSWAHL("buchungbuchungsartauswahl", Integer.class,
         ((Integer) AbstractInputAuswahl.SearchInput).toString()),
     BUCHUNGSARTSORT("buchungsartsort", Integer.class, "1"),
+    BUCHUNGSARTANZEIGE("buchungsartanzeige", Integer.class, "1"),
     MITGLIEDAUSWAHL("mitgliedauswahl", Integer.class,
         ((Integer) AbstractInputAuswahl.SearchInput).toString()),
     AFAINJAHRESABSCHLUSS("afainjahresabschluss", Boolean.class, "1"),

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.gui.formatter.SaldoFormatter;
 import de.jost_net.JVerein.io.AnlagenverzeichnisCSV;
 import de.jost_net.JVerein.io.AnlagenverzeichnisPDF;
 import de.jost_net.JVerein.io.ISaldoExport;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
@@ -136,9 +137,9 @@ public class AnlagenlisteControl extends AbstractSaldoControl
   {
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("konto");
 
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTANZEIGE))
     {
-      case BuchungsartSort.NACH_NUMMER:
+      case BuchungsartAnzeige.NACH_NUMMER:
         it.addColumn(
             "CONCAT(buchungsart.nummer,' - ',buchungsart.bezeichnung) as "
                 + BUCHUNGSART);
@@ -147,10 +148,8 @@ public class AnlagenlisteControl extends AbstractSaldoControl
                 + BUCHUNGSKLASSE);
         it.addColumn(
             "CONCAT(afaart.nummer,' - ',afaart.bezeichnung) as " + AFAART);
-        it.setOrder(
-            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC, konto.anschaffung");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
         it.addColumn(
             "CONCAT(buchungsart.bezeichnung,' (',buchungsart.nummer,')') as "
                 + BUCHUNGSART);
@@ -159,14 +158,21 @@ public class AnlagenlisteControl extends AbstractSaldoControl
                 + BUCHUNGSKLASSE);
         it.addColumn(
             "CONCAT(afaart.bezeichnung,' (',afaart.nummer,')') as " + AFAART);
-        it.setOrder(
-            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.anschaffung");
         break;
       default:
         it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
         it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
         it.addColumn("afaart.bezeichnung as " + AFAART);
+        break;
+    }
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    {
+      case BuchungsartSort.NACH_NUMMER:
+        it.setOrder(
+            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC, konto.anschaffung");
+        break;
+      case BuchungsartSort.NACH_BEZEICHNUNG:
+      default:
         it.setOrder(
             "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
                 + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung, konto.anschaffung");

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -37,6 +37,7 @@ import de.jost_net.JVerein.gui.view.BuchungsartDetailView;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.StatusBuchungsart;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -230,11 +231,12 @@ public class BuchungsartControl extends FilterControl implements Savable
   {
     try
     {
-      switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+      switch ((Integer) Einstellungen
+          .getEinstellung(Property.BUCHUNGSARTANZEIGE))
       {
-        case BuchungsartSort.NACH_NUMMER:
+        case BuchungsartAnzeige.NACH_NUMMER:
           return "nrbezeichnung";
-        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
           return "bezeichnungnr";
         default:
           return "bezeichnung";

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.io.BuchungsklassesaldoCSV;
 import de.jost_net.JVerein.io.BuchungsklassesaldoPDF;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.StatusBuchungsart;
@@ -361,32 +362,37 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
 
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
         "buchungsart");
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTANZEIGE))
     {
-      case BuchungsartSort.NACH_NUMMER:
+      case BuchungsartAnzeige.NACH_NUMMER:
         it.addColumn(
             "CONCAT(buchungsart.nummer,' - ',buchungsart.bezeichnung) as "
                 + BUCHUNGSART);
         it.addColumn(
             "CONCAT(buchungsklasse.nummer,' - ',buchungsklasse.bezeichnung) as "
                 + BUCHUNGSKLASSE);
-        it.setOrder(
-            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC ");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
         it.addColumn(
             "CONCAT(buchungsart.bezeichnung,' (',buchungsart.nummer,')') as "
                 + BUCHUNGSART);
         it.addColumn(
             "CONCAT(buchungsklasse.bezeichnung,' (',buchungsklasse.nummer,')') as "
                 + BUCHUNGSKLASSE);
-        it.setOrder(
-            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung ");
         break;
       default:
         it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
         it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
+        break;
+    }
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    {
+      case BuchungsartSort.NACH_NUMMER:
+        it.setOrder(
+            "Order by -buchungsklasse.nummer DESC, -buchungsart.nummer DESC ");
+        break;
+      case BuchungsartSort.NACH_BEZEICHNUNG:
+      default:
         it.setOrder(
             "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
                 + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung ");

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -45,6 +45,7 @@ import de.jost_net.JVerein.keys.AfaOrt;
 import de.jost_net.JVerein.keys.Altermodel;
 import de.jost_net.JVerein.keys.ArbeitsstundenModel;
 import de.jost_net.JVerein.keys.Beitragsmodel;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.SepaMandatIdSource;
 import de.jost_net.JVerein.keys.Staat;
@@ -318,6 +319,8 @@ public class EinstellungControl extends AbstractControl
   private SelectInput mitgliedAuswahl;
 
   private SelectInput buchungsartsort;
+
+  private SelectInput buchungsartanzeige;
 
   private CheckboxInput abrlabschliessen;
 
@@ -1924,6 +1927,18 @@ public class EinstellungControl extends AbstractControl
     return buchungsartsort;
   }
 
+  public SelectInput getBuchungsartAnzeige() throws RemoteException
+  {
+    if (buchungsartanzeige != null)
+    {
+      return buchungsartanzeige;
+    }
+    buchungsartanzeige = new SelectInput(BuchungsartAnzeige.getArray(),
+        new BuchungsartAnzeige((Integer) Einstellungen
+            .getEinstellung(Property.BUCHUNGSARTANZEIGE)));
+    return buchungsartanzeige;
+  }
+
   public IntegerInput getQRCodeSizeInMm() throws RemoteException
   {
     if (null == qrcodesize)
@@ -2599,6 +2614,8 @@ public class EinstellungControl extends AbstractControl
       Einstellungen.setEinstellung(Property.MITGLIEDAUSWAHL, mAuswahl.getKey());
       Einstellungen.setEinstellung(Property.BUCHUNGSARTSORT,
           ((BuchungsartSort) buchungsartsort.getValue()).getKey());
+      Einstellungen.setEinstellung(Property.BUCHUNGSARTANZEIGE,
+          ((BuchungsartAnzeige) buchungsartanzeige.getValue()).getKey());
       if (((AfaOrt) afaort.getValue()).getKey() == 0)
         Einstellungen.setEinstellung(Property.AFAINJAHRESABSCHLUSS, false);
       else

--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -43,6 +43,7 @@ import de.jost_net.JVerein.keys.AbstractInputAuswahl;
 import de.jost_net.JVerein.keys.AfaMode;
 import de.jost_net.JVerein.keys.Anlagenzweck;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.keys.StatusBuchungsart;
@@ -552,12 +553,12 @@ public class KontoControl extends FilterControl implements Savable
     buchungsart = new SelectInput(liste, b);
     buchungsart.setPleaseChoose("Bitte auswählen");
 
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTANZEIGE))
     {
-      case BuchungsartSort.NACH_NUMMER:
+      case BuchungsartAnzeige.NACH_NUMMER:
         buchungsart.setAttribute("nrbezeichnung");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
         buchungsart.setAttribute("bezeichnungnr");
         break;
       default:
@@ -1032,11 +1033,12 @@ public class KontoControl extends FilterControl implements Savable
   {
     try
     {
-      switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+      switch ((Integer) Einstellungen
+          .getEinstellung(Property.BUCHUNGSARTANZEIGE))
       {
-        case BuchungsartSort.NACH_NUMMER:
+        case BuchungsartAnzeige.NACH_NUMMER:
           return "nrbezeichnung";
-        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
           return "bezeichnungnr";
         default:
           return "bezeichnung";
@@ -1044,7 +1046,7 @@ public class KontoControl extends FilterControl implements Savable
     }
     catch (RemoteException e)
     {
-      String fehler = "Keine Buchungssortierung hinterlegt.";
+      String fehler = "Keine Buchungsartanzeige hinterlegt.";
       Logger.error(fehler, e);
       GUI.getStatusBar().setErrorText(fehler);
     }

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -58,7 +58,7 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
       case BuchungsartSort.NACH_NUMMER:
         it.setOrder("ORDER BY projekt.bezeichnung, -buchungsart.nummer DESC ");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartSort.NACH_BEZEICHNUNG:
       default:
         it.setOrder(
             "ORDER BY projekt.bezeichnung, buchungsart.bezeichnung is NUll,"

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -199,7 +199,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
       case BuchungsartSort.NACH_NUMMER:
         buchungsklasseIterator.setOrder("Order by -nummer DESC");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartSort.NACH_BEZEICHNUNG:
       default:
         buchungsklasseIterator
             .setOrder("Order by bezeichnung is NULL, bezeichnung");

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
@@ -402,7 +402,7 @@ public class WirtschaftsplanNode
                 - o.getBuchungsart().getNummer();
           }
           break;
-        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        case BuchungsartSort.NACH_BEZEICHNUNG:
         default:
           if (type == Type.BUCHUNGSART)
           {

--- a/src/de/jost_net/JVerein/gui/formatter/BuchungsartFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/BuchungsartFormatter.java
@@ -20,7 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.keys.BuchungsartSort;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.logging.Logger;
@@ -38,12 +38,13 @@ public class BuchungsartFormatter implements Formatter
     String bez = null;
     try
     {
-      switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+      switch ((Integer) Einstellungen
+          .getEinstellung(Property.BUCHUNGSARTANZEIGE))
       {
-        case BuchungsartSort.NACH_NUMMER:
+        case BuchungsartAnzeige.NACH_NUMMER:
           bez = ba.getNummer() + " - " + ba.getBezeichnung();
           break;
-        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
           bez = ba.getBezeichnung() + " (" + ba.getNummer() + ")";
           break;
         default:

--- a/src/de/jost_net/JVerein/gui/formatter/BuchungsklasseFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/BuchungsklasseFormatter.java
@@ -20,7 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.keys.BuchungsartSort;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.logging.Logger;
@@ -38,12 +38,13 @@ public class BuchungsklasseFormatter implements Formatter
     String bez = null;
     try
     {
-      switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+      switch ((Integer) Einstellungen
+          .getEinstellung(Property.BUCHUNGSARTANZEIGE))
       {
-        case BuchungsartSort.NACH_NUMMER:
+        case BuchungsartAnzeige.NACH_NUMMER:
           bez = bk.getNummer() + " - " + bk.getBezeichnung();
           break;
-        case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+        case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
           bez = bk.getBezeichnung() + " (" + bk.getNummer() + ")";
           break;
         default:

--- a/src/de/jost_net/JVerein/gui/input/BuchungsartInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsartInput.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.keys.AbstractInputAuswahl;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.StatusBuchungsart;
 import de.jost_net.JVerein.rmi.Buchungsart;
@@ -153,12 +154,12 @@ public class BuchungsartInput
         }
 
         switch ((Integer) Einstellungen
-            .getEinstellung(Property.BUCHUNGSARTSORT))
+            .getEinstellung(Property.BUCHUNGSARTANZEIGE))
         {
-          case BuchungsartSort.NACH_NUMMER:
+          case BuchungsartAnzeige.NACH_NUMMER:
             ((SelectInput) buchungsart).setAttribute("nrbezeichnung");
             break;
-          case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+          case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
             ((SelectInput) buchungsart).setAttribute("bezeichnungnr");
             break;
           default:
@@ -172,13 +173,13 @@ public class BuchungsartInput
         // Settings immer gesetzt sein, aber man weiss ja nie.
         buchungsart = new BuchungsartSearchInput(art);
         switch ((Integer) Einstellungen
-            .getEinstellung(Property.BUCHUNGSARTSORT))
+            .getEinstellung(Property.BUCHUNGSARTANZEIGE))
         {
-          case BuchungsartSort.NACH_NUMMER:
+          case BuchungsartAnzeige.NACH_NUMMER:
             ((BuchungsartSearchInput) buchungsart)
                 .setAttribute("nrbezeichnung");
             break;
-          case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+          case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
             ((BuchungsartSearchInput) buchungsart)
                 .setAttribute("bezeichnungnr");
             break;

--- a/src/de/jost_net/JVerein/gui/input/BuchungsklasseInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsklasseInput.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.keys.BuchungsartAnzeige;
 import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -45,12 +46,12 @@ public class BuchungsklasseInput
     buchungsklasse = new SelectInput(
         it != null ? PseudoIterator.asList(it) : null, klasse);
 
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
+    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTANZEIGE))
     {
-      case BuchungsartSort.NACH_NUMMER:
+      case BuchungsartAnzeige.NACH_NUMMER:
         buchungsklasse.setAttribute("nrbezeichnung");
         break;
-      case BuchungsartSort.NACH_BEZEICHNUNG_NR:
+      case BuchungsartAnzeige.NACH_BEZEICHNUNG_NR:
         buchungsklasse.setAttribute("bezeichnungnr");
         break;
       default:

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -103,14 +103,17 @@ public class EinstellungenAnzeigeView extends AbstractView
     links.addLabelPair("Basis für Berechnung des Alters",
         control.getAltersModel());
     links.addLabelPair("Ort der Abschreibung", control.getAfaOrt());
+    links.addLabelPair("Mitglied Auswahl", control.getMitgliedAuswahl());
 
     SimpleContainer rechts = new SimpleContainer(cols2.getComposite());
     rechts.addLabelPair("Ungenutzte Auto Buchungsarten unterdrücken (Monate)",
         control.getUnterdrueckungLaenge());
     rechts.addLabelPair("Buchungsart Auswahl",
         control.getBuchungBuchungsartAuswahl());
-    rechts.addLabelPair("Buchungsart Sortierung", control.getBuchungsartSort());
-    rechts.addLabelPair("Mitglied Auswahl", control.getMitgliedAuswahl());
+    rechts.addLabelPair("Buchungsart/-klasse Sortierung",
+        control.getBuchungsartSort());
+    rechts.addLabelPair("Buchungsart/-klasse Anzeige",
+        control.getBuchungsartAnzeige());
 
     cont.addSeparator();
     cont.addHeadline("* " + "Änderung erfordert Neustart");

--- a/src/de/jost_net/JVerein/keys/BuchungsartAnzeige.java
+++ b/src/de/jost_net/JVerein/keys/BuchungsartAnzeige.java
@@ -26,38 +26,32 @@ package de.jost_net.JVerein.keys;
 import java.util.ArrayList;
 
 /**
- * Schlüssel Sortierung der Buchungsart; Form der Anzeige
+ * Schlüssel Anzeige der Buchungsart; Form der Anzeige
  */
-public class BuchungsartSort
+public class BuchungsartAnzeige
 {
 
   public static final int NACH_BEZEICHNUNG = 1;
 
   public static final int NACH_NUMMER = 2;
 
-  private int buchungsartsort;
+  public static final int NACH_BEZEICHNUNG_NR = 3;
 
-  public BuchungsartSort(int key)
+  private int buchungsartanzeige;
+
+  public BuchungsartAnzeige(int key)
   {
-    // Wegen Migration alter Settings
-    if (key == 3)
-    {
-      this.buchungsartsort = 1;
-    }
-    else
-    {
-      this.buchungsartsort = key;
-    }
+    this.buchungsartanzeige = key;
   }
 
   public int getKey()
   {
-    return buchungsartsort;
+    return buchungsartanzeige;
   }
 
   public String getText()
   {
-    return get(buchungsartsort);
+    return get(buchungsartanzeige);
   }
 
   public static String get(int key)
@@ -65,28 +59,31 @@ public class BuchungsartSort
     switch (key)
     {
       case NACH_BEZEICHNUNG:
-        return "Nach Bezeichnung";
+        return "Bezeichnung";
       case NACH_NUMMER:
-        return "Nach Nummer";
+        return "Nummer-Bezeichnung";
+      case NACH_BEZEICHNUNG_NR:
+        return "Bezeichnung (Nummer)";
       default:
         return null;
     }
   }
 
-  public static ArrayList<BuchungsartSort> getArray()
+  public static ArrayList<BuchungsartAnzeige> getArray()
   {
-    ArrayList<BuchungsartSort> ret = new ArrayList<>();
-    ret.add(new BuchungsartSort(NACH_BEZEICHNUNG));
-    ret.add(new BuchungsartSort(NACH_NUMMER));
+    ArrayList<BuchungsartAnzeige> ret = new ArrayList<>();
+    ret.add(new BuchungsartAnzeige(NACH_BEZEICHNUNG));
+    ret.add(new BuchungsartAnzeige(NACH_NUMMER));
+    ret.add(new BuchungsartAnzeige(NACH_BEZEICHNUNG_NR));
     return ret;
   }
 
   @Override
   public boolean equals(Object obj)
   {
-    if (obj instanceof BuchungsartSort)
+    if (obj instanceof BuchungsartAnzeige)
     {
-      BuchungsartSort v = (BuchungsartSort) obj;
+      BuchungsartAnzeige v = (BuchungsartAnzeige) obj;
       return (getKey() == v.getKey());
     }
     return false;
@@ -95,12 +92,12 @@ public class BuchungsartSort
   @Override
   public int hashCode()
   {
-    return buchungsartsort;
+    return buchungsartanzeige;
   }
 
   @Override
   public String toString()
   {
-    return get(buchungsartsort);
+    return get(buchungsartanzeige);
   }
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0490.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0490.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0490 extends AbstractDDLUpdate
+{
+  public Update0490(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute("INSERT INTO einstellungneu (name,wert)"
+        + " SELECT 'buchungsartanzeige',wert FROM einstellungneu WHERE name = 'buchungsartsort' "
+        + "AND not exists(select * from einstellungneu where name = 'buchungsartanzeige')");
+  }
+}


### PR DESCRIPTION
In Einstellungen-Anzeige kann man jetzt die Sortierung bei Buchungsart/Buchungsklasse getrennt von der Anzeigeart konfigurieren. Anzeige hat die drei bisherigen Optionen. Bei Sortierung gibt es nur Nummer oder Bezeichnung.
<img width="352" height="93" alt="Bildschirmfoto_20250927_132414" src="https://github.com/user-attachments/assets/3f515ec6-2515-4dc4-9932-e8359a16b8c0" />

Bei der Migration werden die Werte kopiert. Bei Sortierung wird im Key ein gespeicherter Wert 3 nach 1 konvertiert.

Die Migration ist bei 490 und damit nach den anderen PRs. Darum kann er momentan nicht übernommen aber getestet werden.