### PR TITLE
IBAN Formatter überall anwenden

### DIFF
--- a/src/de/jost_net/JVerein/Variable/AllgemeineMap.java
+++ b/src/de/jost_net/JVerein/Variable/AllgemeineMap.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.util.JVDateFormatJJJJ;
 import de.jost_net.JVerein.util.JVDateFormatMM;
@@ -109,8 +110,8 @@ public class AllgemeineMap
     map.put(AllgemeineVar.STAAT.getName(),
         Staat.getByKey((String) Einstellungen.getEinstellung(Property.STAAT))
             .getText());
-    map.put(AllgemeineVar.IBAN.getName(),
-        (String) Einstellungen.getEinstellung(Property.IBAN));
+    map.put(AllgemeineVar.IBAN.getName(), new IBANFormatter()
+        .format((String) Einstellungen.getEinstellung(Property.IBAN)));
     map.put(AllgemeineVar.BIC.getName(),
         (String) Einstellungen.getEinstellung(Property.BIC));
     map.put(AllgemeineVar.GLAEUBIGER_ID.getName(),

--- a/src/de/jost_net/JVerein/Variable/LastschriftMap.java
+++ b/src/de/jost_net/JVerein/Variable/LastschriftMap.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
@@ -60,8 +61,7 @@ public class LastschriftMap extends AbstractMap
       ls.setBetrag(123.45d);
       ls.setBIC("XXXXXXXXXXX");
       ls.setEmail("willi.wichtig@mail.de");
-      ls.setIBAN("DE89370400440532013000");
-      ls.setIBAN("DE89370400440532013000");
+      ls.setIBAN("DE89 3704 0044 0532 0130 00");
       ls.setGeschlecht(GeschlechtInput.MAENNLICH);
       ls.setMandatDatum(new Date());
       ls.setMandatSequence("FRST");
@@ -120,7 +120,8 @@ public class LastschriftMap extends AbstractMap
     map.put(LastschriftVar.MANDATID.getName(), ls.getMandatID());
     map.put(LastschriftVar.MANDATDATUM.getName(), ls.getMandatDatum());
     map.put(LastschriftVar.BIC.getName(), ls.getBIC());
-    map.put(LastschriftVar.IBAN.getName(), ls.getIBAN());
+    map.put(LastschriftVar.IBAN.getName(),
+        new IBANFormatter().format(ls.getIBAN()));
     map.put(LastschriftVar.IBANMASKIERT.getName(),
         VarTools.maskieren(ls.getIBAN()));
     map.put(LastschriftVar.VERWENDUNGSZWECK.getName(),
@@ -172,7 +173,7 @@ public class LastschriftMap extends AbstractMap
     map.put(LastschriftVar.MANDATID.getName(), "12345");
     map.put(LastschriftVar.MANDATDATUM.getName(), toDate("01.01.2024"));
     map.put(LastschriftVar.BIC.getName(), "XXXXXXXXXXX");
-    map.put(LastschriftVar.IBAN.getName(), "DE89370400440532013000");
+    map.put(LastschriftVar.IBAN.getName(), "DE89 3704 0044 0532 0130 00");
     map.put(LastschriftVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");
     map.put(LastschriftVar.VERWENDUNGSZWECK.getName(), "Zweck");
     map.put(LastschriftVar.BETRAG.getName(), "23,80");

--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.BeitragsUtil;
 import de.jost_net.JVerein.io.VelocityTool;
@@ -62,6 +63,7 @@ public class MitgliedMap extends AbstractMap
     return getMap(m, inma, false);
   }
 
+  @SuppressWarnings("deprecation")
   public Map<String, Object> getMap(Mitglied mitglied,
       Map<String, Object> initMap, boolean ohneLesefelder)
       throws RemoteException
@@ -139,7 +141,8 @@ public class MitgliedMap extends AbstractMap
     map.put(MitgliedVar.HANDY.getName(), mitglied.getHandy());
     map.put(MitgliedVar.IBANMASKIERT.getName(),
         VarTools.maskieren(mitglied.getIban()));
-    map.put(MitgliedVar.IBAN.getName(), mitglied.getIban());
+    map.put(MitgliedVar.IBAN.getName(),
+        new IBANFormatter().format(mitglied.getIban()));
     map.put(MitgliedVar.ID.getName(), mitglied.getID());
     if (mitglied.getIndividuellerBeitrag() != null)
     {
@@ -359,6 +362,7 @@ public class MitgliedMap extends AbstractMap
     return null;
   }
 
+  @SuppressWarnings("deprecation")
   public static Map<String, Object> getDummyMap(Map<String, Object> inMap)
       throws RemoteException
   {
@@ -397,7 +401,7 @@ public class MitgliedMap extends AbstractMap
     map.put(MitgliedVar.GEBURTSDATUM.getName(), "02.03.1980");
     map.put(MitgliedVar.GESCHLECHT.getName(), GeschlechtInput.MAENNLICH);
     map.put(MitgliedVar.HANDY.getName(), "0152778899");
-    map.put(MitgliedVar.IBAN.getName(), "DE89370400440532013000");
+    map.put(MitgliedVar.IBAN.getName(), "DE89 3704 0044 0532 0130 00");
     map.put(MitgliedVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");
     map.put(MitgliedVar.ID.getName(), "15");
     map.put(MitgliedVar.INDIVIDUELLERBEITRAG.getName(), "123,45");

--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.VelocityTool;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
@@ -162,7 +163,8 @@ public class RechnungMap extends AbstractMap
     map.put(RechnungVar.MANDATID.getName(), re.getMandatID());
     map.put(RechnungVar.MANDATDATUM.getName(), re.getMandatDatum());
     map.put(RechnungVar.BIC.getName(), re.getBIC());
-    map.put(RechnungVar.IBAN.getName(), re.getIBAN());
+    map.put(RechnungVar.IBAN.getName(),
+        new IBANFormatter().format(re.getIBAN()));
     map.put(RechnungVar.IBANMASKIERT.getName(),
         VarTools.maskieren(re.getIBAN()));
     map.put(RechnungVar.EMPFAENGER.getName(),
@@ -176,7 +178,8 @@ public class RechnungMap extends AbstractMap
         zahlungsweg = (String) Einstellungen
             .getEinstellung(Property.RECHNUNGTEXTABBUCHUNG);
         zahlungsweg = zahlungsweg.replaceAll("\\$\\{BIC\\}", re.getBIC());
-        zahlungsweg = zahlungsweg.replaceAll("\\$\\{IBAN\\}", re.getIBAN());
+        zahlungsweg = zahlungsweg.replaceAll("\\$\\{IBAN\\}",
+            new IBANFormatter().format(re.getIBAN()));
         zahlungsweg = zahlungsweg.replaceAll("\\$\\{MANDATID\\}",
             re.getMandatID());
         break;
@@ -196,7 +199,8 @@ public class RechnungMap extends AbstractMap
     }
     try
     {
-      zahlungsweg = VelocityTool.eval(map, zahlungsweg);
+      zahlungsweg = VelocityTool.eval(new AllgemeineMap().getMap(map),
+          zahlungsweg);
     }
     catch (IOException e)
     {
@@ -273,7 +277,7 @@ public class RechnungMap extends AbstractMap
     map.put(RechnungVar.MANDATID.getName(), "12345");
     map.put(RechnungVar.MANDATDATUM.getName(), toDate("01.01.2024"));
     map.put(RechnungVar.BIC.getName(), "XXXXXXXXXXX");
-    map.put(RechnungVar.IBAN.getName(), "DE89370400440532013000");
+    map.put(RechnungVar.IBAN.getName(), "DE89 3704 0044 0532 0130 00");
     map.put(RechnungVar.IBANMASKIERT.getName(), "XXXXXXXXXXXXXXX3000");
     map.put(RechnungVar.EMPFAENGER.getName(),
         "Herr\nDr. Dr. Willi Wichtig\nHinterhof bei Müller\nBahnhofstr. 22\n12345 Testenhausen\nDeutschland");

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -48,6 +48,7 @@ import de.jost_net.JVerein.gui.dialogs.BuchungsjournalSortDialog;
 import de.jost_net.JVerein.gui.dialogs.SammelueberweisungAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.formatter.SollbuchungFormatter;
 import de.jost_net.JVerein.gui.input.BuchungsartInput;
 import de.jost_net.JVerein.gui.input.BuchungsartInput.buchungsarttyp;
@@ -111,8 +112,6 @@ import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
-import de.willuhn.jameica.hbci.HBCIProperties;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.jameica.hbci.rmi.SepaSammelUeberweisung;
 import de.willuhn.jameica.hbci.rmi.SepaSammelUeberweisungBuchung;
 import de.willuhn.jameica.messaging.Message;
@@ -1525,7 +1524,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
       buchungsList.addColumn("Name", "name");
       if (geldkonto)
         buchungsList.addColumn("IBAN oder Kontonummer", "iban",
-            new IbanFormatter());
+            new IBANFormatter());
       buchungsList.addColumn("Verwendungszweck", "zweck", new Formatter()
       {
         @Override
@@ -1917,7 +1916,6 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     BackgroundTask t = new BackgroundTask()
     {
 
-      @SuppressWarnings("unused")
       @Override
       public void run(ProgressMonitor monitor) throws ApplicationException
       {
@@ -1961,7 +1959,6 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     BackgroundTask t = new BackgroundTask()
     {
 
-      @SuppressWarnings("unused")
       @Override
       public void run(ProgressMonitor monitor) throws ApplicationException
       {
@@ -2186,7 +2183,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     {
       return iban;
     }
-    iban = new IBANInput(HBCIProperties.formatIban(getBuchung().getIban()),
+    iban = new IBANInput(new IBANFormatter().format(getBuchung().getIban()),
         new TextInput(""));
     iban.setEnabled(editable);
     return iban;

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -31,6 +31,7 @@ import org.kapott.hbci.sepa.SepaVersion;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.IBANInput;
@@ -76,7 +77,6 @@ import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.TablePart;
-import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -578,8 +578,8 @@ public class EinstellungControl extends AbstractControl
     {
       return iban;
     }
-    iban = new IBANInput(HBCIProperties
-        .formatIban((String) Einstellungen.getEinstellung(Property.IBAN)), bic);
+    iban = new IBANInput(new IBANFormatter()
+        .format((String) Einstellungen.getEinstellung(Property.IBAN)), bic);
     return iban;
   }
 
@@ -897,7 +897,7 @@ public class EinstellungControl extends AbstractControl
     }
     rechnungtextabbuchung = new TextInput(
         (String) Einstellungen.getEinstellung(Property.RECHNUNGTEXTABBUCHUNG),
-        100);
+        500);
     return rechnungtextabbuchung;
   }
 
@@ -908,7 +908,7 @@ public class EinstellungControl extends AbstractControl
       return rechnungtextueberweisung;
     }
     rechnungtextueberweisung = new TextInput((String) Einstellungen
-        .getEinstellung(Property.RECHNUNGTEXTUEBERWEISUNG), 100);
+        .getEinstellung(Property.RECHNUNGTEXTUEBERWEISUNG), 500);
     return rechnungtextueberweisung;
   }
 
@@ -919,7 +919,7 @@ public class EinstellungControl extends AbstractControl
       return rechnungtextbar;
     }
     rechnungtextbar = new TextInput(
-        (String) Einstellungen.getEinstellung(Property.RECHNUNGTEXTBAR), 100);
+        (String) Einstellungen.getEinstellung(Property.RECHNUNGTEXTBAR), 500);
     return rechnungtextbar;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -32,6 +32,7 @@ import com.itextpdf.text.Element;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
@@ -60,8 +61,6 @@ import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
-import de.willuhn.jameica.hbci.HBCIProperties;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.Settings;
@@ -333,7 +332,7 @@ public class KursteilnehmerControl extends FilterControl implements Savable
       return iban;
     }
     iban = new IBANInput(
-        HBCIProperties.formatIban(getKursteilnehmer().getIban()), getBIC());
+        new IBANFormatter().format(getKursteilnehmer().getIban()), getBIC());
     iban.setName("IBAN");
     iban.setMandatory(true);
     return iban;
@@ -403,7 +402,7 @@ public class KursteilnehmerControl extends FilterControl implements Savable
     part.addColumn("Ort", "ort");
     part.addColumn("Verwendungszweck", "vzweck1");
     part.addColumn("BIC", "bic");
-    part.addColumn("IBAN", "iban", new IbanFormatter());
+    part.addColumn("IBAN", "iban", new IBANFormatter());
     part.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     part.addColumn("Mandats-ID", "mandatid");

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -21,6 +21,7 @@ import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
@@ -44,8 +45,6 @@ import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
-import de.willuhn.jameica.hbci.HBCIProperties;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.logging.Logger;
 
 public class LastschriftControl extends FilterControl
@@ -115,7 +114,7 @@ public class LastschriftControl extends FilterControl
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     lastschriftList.addColumn("Fälligkeit", "faelligkeit",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
-    lastschriftList.addColumn("IBAN", "iban", new IbanFormatter());
+    lastschriftList.addColumn("IBAN", "iban", new IBANFormatter());
     lastschriftList.addColumn("Mandat", "mandatid");
     lastschriftList.addColumn("Mandatdatum", "mandatdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
@@ -442,7 +441,7 @@ public class LastschriftControl extends FilterControl
     {
       return iban;
     }
-    iban = new IBANInput(HBCIProperties.formatIban(getLastschrift().getIBAN()),
+    iban = new IBANInput(new IBANFormatter().format(getLastschrift().getIBAN()),
         getBIC());
     iban.setName("IBAN");
     iban.setEnabled(false);

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -44,6 +44,7 @@ import de.jost_net.JVerein.gui.action.NichtMitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.EmailInput;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
@@ -144,7 +145,6 @@ import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SWTUtil;
-import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.system.Application;
@@ -901,7 +901,7 @@ public class MitgliedControl extends FilterControl implements Savable
     {
       return iban;
     }
-    iban = new IBANInput(HBCIProperties.formatIban(getMitglied().getIban()),
+    iban = new IBANInput(new IBANFormatter().format(getMitglied().getIban()),
         getBic());
     if (((Zahlungsweg) getZahlungsweg().getValue())
         .getKey() != Zahlungsweg.BASISLASTSCHRIFT)

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -25,6 +25,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.control.SollbuchungControl.DIFFERENZ;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
 import de.jost_net.JVerein.gui.input.FormularInput;
@@ -72,7 +73,6 @@ import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
-import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -682,7 +682,7 @@ public class RechnungControl extends DruckMailControl implements Savable
       return iban;
     }
 
-    iban = new IBANInput(HBCIProperties.formatIban(getRechnung().getIBAN()),
+    iban = new IBANInput(new IBANFormatter().format(getRechnung().getIBAN()),
         getBic());
     iban.setName("IBAN");
     iban.disable();

--- a/src/de/jost_net/JVerein/gui/control/listener/IBANListener.java
+++ b/src/de/jost_net/JVerein/gui/control/listener/IBANListener.java
@@ -24,13 +24,13 @@ import org.eclipse.swt.widgets.Listener;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.IBANInput;
 import de.jost_net.OBanToo.SEPA.IBAN;
 import de.jost_net.OBanToo.SEPA.SEPAException;
 import de.jost_net.OBanToo.SEPA.BankenDaten.Bank;
 import de.jost_net.OBanToo.SEPA.BankenDaten.Banken;
 import de.willuhn.jameica.gui.input.TextInput;
-import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.logging.Logger;
 
 /**
@@ -70,7 +70,7 @@ public class IBANListener implements Listener
       return;
     }
     String ib2 = ib.trim().toUpperCase().replace(" ", "");
-    iban.setValue(HBCIProperties.formatIban(ib2));
+    iban.setValue(new IBANFormatter().format(ib2));
     if (ib2.length() == 0)
     {
       iban.setComment("");

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
@@ -24,6 +24,7 @@ import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.util.JVDateFormatDATETIME;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -36,7 +37,6 @@ import de.willuhn.jameica.gui.input.LabelInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.util.LabelGroup;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 
 /**
  * Ein Dialog, ueber den man ein Konto auswaehlen kann.
@@ -71,7 +71,7 @@ public class BuchungUebernahmeProtokollDialog extends AbstractDialog<Buchung>
     bu.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     bu.addColumn("Name", "name");
-    bu.addColumn("IBAN oder Kontonummer", "iban", new IbanFormatter());
+    bu.addColumn("IBAN oder Kontonummer", "iban", new IBANFormatter());
     bu.addColumn("Verwendungszweck", "zweck", new Formatter()
     {
 

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.StartViewAction;
 import de.jost_net.JVerein.gui.dialogs.BuchungenSollbuchungZuordnungDialog.BookingMemberAccountEntry;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.view.BuchungListeView;
 import de.jost_net.JVerein.io.SplitbuchungsContainer;
 import de.jost_net.JVerein.rmi.Buchung;
@@ -40,7 +41,6 @@ import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.TablePart;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -90,7 +90,7 @@ public class BuchungenSollbuchungZuordnungVorschauDialog
     bu.addColumn("Buchungsnummer",
         BookingMemberAccountEntry.PREFIX_BUCHUNG + "id");
     bu.addColumn("IBAN oder Kontonummer",
-        BookingMemberAccountEntry.PREFIX_BUCHUNG + "iban", new IbanFormatter());
+        BookingMemberAccountEntry.PREFIX_BUCHUNG + "iban", new IBANFormatter());
     bu.addColumn("Betrag", BookingMemberAccountEntry.PREFIX_BUCHUNG + "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     bu.addColumn("Verwendungszweck",

--- a/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ */
+package de.jost_net.JVerein.gui.formatter;
+
+import de.willuhn.jameica.gui.formatter.Formatter;
+
+public class IBANFormatter implements Formatter
+{
+  /**
+   * Gruppiert eine IBAN in Gruppen zu je 4 Zeichen und schreibt die ersten
+   * beiden Buchstaben (Laenderkennzeichen) gross.
+   * 
+   * @param s
+   *          die IBAN.
+   * @return die formatierte Darstellung.
+   */
+  public String format(Object o)
+  {
+    if (!(o instanceof String))
+    {
+      return "";
+    }
+    String s = (String) o;
+
+    // Wenn es falsche Zeien enthält, nicht formatieren
+    if (!s.trim().matches("^[a-zA-Z]{2}[0-9 ]+$"))
+    {
+      return s;
+    }
+    return s.replaceAll(" ", "").replaceAll("(.{4})", "$0 ").trim()
+        .toUpperCase();
+  }
+}

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungsrhythmusFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungsterminFormatter;
@@ -33,7 +34,6 @@ import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.formatter.Formatter;
 import de.willuhn.jameica.gui.parts.Column;
-import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
 import de.willuhn.logging.Logger;
 
 public class MitgliedSpaltenauswahl extends Spaltenauswahl
@@ -112,7 +112,7 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
         new ZahlungsterminFormatter(), Column.ALIGN_LEFT, true);
     add("Datum des Mandats", "mandatdatum", false, true);
     add("BIC", "bic", false, true);
-    add("IBAN", "iban", false, new IbanFormatter(), Column.ALIGN_LEFT, true);
+    add("IBAN", "iban", false, new IBANFormatter(), Column.ALIGN_LEFT, true);
     add("Kontoinhaber Anrede", "ktoianrede", false, true);
     add("Kontoinhaber Name", "ktoiname", false, true);
     add("Kontoinhaber Titel", "ktoititel", false, true);


### PR DESCRIPTION
Wie in https://jverein-forum.de/viewtopic.php?t=7343 gewünscht wende ich den IBAN Formatter überall an. Da in #1079 bemängelt wurde, das PayPal "IBANs" auch formatiert wurden, hab ich einen neuen IBAN Foramtter erstellt.
Außerdem hab ich im Verwendungszeck von Rechnungen die AllgemeineMap hinzugefügt und die Feldlänge verlängert, wie in https://jverein-forum.de/viewtopic.php?t=7514 gewünscht