### PR TITLE
IBAN Formatter nach ISO Standard

### DIFF
--- a/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
@@ -37,7 +37,7 @@ public class IBANFormatter implements Formatter
     String s = (String) o;
 
     // Wenn es falsche Zeien enthält, nicht formatieren
-    if (!s.trim().matches("^[a-zA-Z]{2}[0-9 ]+$"))
+    if (!s.trim().matches("^[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{11,30}$"))
     {
       return s;
     }

--- a/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/IBANFormatter.java
@@ -37,7 +37,7 @@ public class IBANFormatter implements Formatter
     String s = (String) o;
 
     // Wenn es falsche Zeien enthält, nicht formatieren
-    if (!s.trim().matches("^[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{11,30}$"))
+    if (!s.trim().replaceAll(" ", "").matches("^[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{11,30}$"))
     {
       return s;
     }


### PR DESCRIPTION
Der alte IBAN Formatter hat zwar deutsche IBANs erkannt, aber nicht alle Internationalen. Bspw. Niederländische IBANs haben in der BBAN Buchstaben enthalten. Der korrekte Aufbau ist: 2 Buchstaben als Länder-Code
2 Prüfziffern
11-30 Stellen BBAN, kann Buchstaben enthalten