### PR TITLE
Wirtschaftsplan Verbindlichkeiten/Forderungen ausblenden

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
@@ -142,6 +142,11 @@ public class WirtschaftsplanNode
     istIt.addColumn("buchungsart.id as " + ID);
     istIt.addColumn("COUNT(buchung.id) as anzahl");
     istIt.addFilter("buchungsart.art = ?", art);
+    if (!((Boolean) Einstellungen
+        .getEinstellung(Property.VERBINDLICHKEITEN_FORDERUNGEN)))
+    {
+      istIt.addFilter("konto.kontoart < " + Kontoart.LIMIT_RUECKLAGE.getKey());
+    }
 
     if (mitSteuer)
     {

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanNode.java
@@ -142,10 +142,15 @@ public class WirtschaftsplanNode
     istIt.addColumn("buchungsart.id as " + ID);
     istIt.addColumn("COUNT(buchung.id) as anzahl");
     istIt.addFilter("buchungsart.art = ?", art);
-    if (!((Boolean) Einstellungen
-        .getEinstellung(Property.VERBINDLICHKEITEN_FORDERUNGEN)))
+    if ((Boolean) Einstellungen
+        .getEinstellung(Property.VERBINDLICHKEITEN_FORDERUNGEN))
     {
-      istIt.addFilter("konto.kontoart < " + Kontoart.LIMIT_RUECKLAGE.getKey());
+      istIt.addFilter("konto.kontoart < " + Kontoart.LIMIT.getKey()
+          + " OR konto.kontoart > " + Kontoart.LIMIT_RUECKLAGE.getKey());
+    }
+    else
+    {
+      istIt.addFilter("konto.kontoart < " + Kontoart.LIMIT.getKey());
     }
 
     if (mitSteuer)


### PR DESCRIPTION
Momentan werden beim Wirtschaftsplan immer die Buchungen auf Verbindlichkeits- und Forderungskonten berücksichtigt. Das ist aber nicht Konform mit den Regeln der Einfachen Buchführung.

Mit der Einführung des Schalter für diese Konten in den Einstellungen wird bereits am GUI die Anzeige von Ist Buchungen auf Verbindlichkeits- und Forderungskonten ausgeblendet.

Ich habe jetzt beim Buchungs Query einen Filter Eingebaut, so dass wenn Verbindlichkeits- und Forderungskonten nicht ausgewählt sind, diese auch bei den Buchungen nicht berücksichtigt werden.

Wenn also jemand mit Verbindlichkeits- und Forderungskonten plant bekommt er den dazu passenden (nicht Steuer konformen) Wirtschaftsplan. Wenn er dann einen konformen Plan haben will kann er in den Einstellungen die Option Verbindlichkeits- und Forderungskonten abwählen und bekommt dann den Steuer konformen Plan.