### PR TITLE
Release automatisiert

### DIFF
--- a/.github/workflows/merge-bugfix-into-master.yml
+++ b/.github/workflows/merge-bugfix-into-master.yml
@@ -1,9 +1,9 @@
-name: Merge master branch bugfixes into feature branches
+name: Merge bugfix branch into master branche
 
 on:
   push:
     branches:
-      - 'master'
+      - '[0-9]+.[0-9]+'
     paths-ignore:
       - plugin.xml
 jobs:
@@ -22,11 +22,11 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "Github Actions"
 
-      - name: Check for merge conflicts for master into feature-3.2.0
+      - name: Check for merge conflicts for ${{ github.ref_name }} into master
         run: |
-          git checkout feature-3.2.0
+          git checkout master
           git pull
-          git merge master --no-ff --no-commit
+          git merge ${{ github.ref_name }} --no-ff --no-commit
 
       - name: Abort previous merge check
         if: always()
@@ -34,9 +34,9 @@ jobs:
           git merge --abort
           git reset --hard HEAD
       
-      - name: Merge master into feature-3.2.0
+      - name: Merge ${{ github.ref_name }} into master
         if: always()
         run: |
-          # Merge master branch into feature with feature as king (ours)
-          git merge -X ours master -m "Auto-merge master into feature-3.2.0" --stat
+          # Merge bugfix branch into master with master as king (ours)
+          git merge -X ours ${{ github.ref_name }} -m "Auto-merge ${{ github.ref_name }} into master" --stat
           git push origin

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -6,7 +6,7 @@ name: OpenJVerein nightly release
 on:
   push:
     branches:
-      - feature-3.2.0
+      - master
     tags-ignore:
       - '**'
 
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout openjverein
       uses: actions/checkout@v5
       with:
-        ref: 'feature-3.2.0'
+        ref: 'master'
         path: jverein
 
     - name: Setup
@@ -30,19 +30,15 @@ jobs:
         echo ${ant_output}
 
         ssa="SELECTED_VERSION="
-        ssb=".zip"
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
         ssa="SELECTED_FILENAME="
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
         ssa="SELECTED_PATH="
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
         echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         ref: ${{ github.ref_name }}
         path: jverein
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Setup
       uses: ./jverein/.github/actions/build-dependencies
@@ -25,25 +26,29 @@ jobs:
         echo ${ant_output}
 
         ssa="SELECTED_VERSION="
-        ssb=".zip"
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_version=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
-        tmp_version=$tmp_version
 
         ssa="SELECTED_FILENAME="
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_filename=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
         ssa="SELECTED_PATH="
         text="${ant_output#*${ssa}}"
-        text="${text%${ssb}*}.zip"
         tmp_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
+        
+        ssa="SELECTED_PLUGIN_PATH="
+        text="${ant_output#*${ssa}}"
+        tmp_plugin_path=$(echo $text | sed -rn 's/^([^[:blank:]]*).*$/\1/p')
 
         echo "selected_version=${tmp_version}" >> $GITHUB_OUTPUT
         echo "selected_filename=${tmp_filename}" >> $GITHUB_OUTPUT
         echo "selected_path=${tmp_path}" >> $GITHUB_OUTPUT
+        echo "selected_plugin_path=${tmp_plugin_path}" >> $GITHUB_OUTPUT
+        
+        echo "major=$(echo ${tmp_version} | sed -rn 's/^([0-9]+)\.[0-9]+\.[0-9]+$/\1/p')" >> $GITHUB_OUTPUT
+        echo "minor=$(echo ${tmp_version} | sed -rn 's/^[0-9]+\.([0-9]+)\.[0-9]+$/\1/p')" >> $GITHUB_OUTPUT
+        echo "bugfix=$(echo ${tmp_version} | sed -rn 's/^[0-9]+\.[0-9]+\.([0-9]+)$/\1/p')" >> $GITHUB_OUTPUT
 
         builddatetime=$(date +'%Y-%m-%d %H:%M')
         echo "### Version: ${tmp_version} | filename: ${tmp_filename} | build datetime: ${builddatetime}" >> $GITHUB_STEP_SUMMARY
@@ -56,3 +61,69 @@ jobs:
         name: Release ${{ steps.openjverein.outputs.selected_version }}
         files: ./jverein/${{ steps.openjverein.outputs.selected_path }}
         generate_release_notes: true
+
+    - name: Checkout website repository
+      uses: actions/checkout@v5
+      with:
+        repository: openjverein/openjverein.github.io
+        path: website
+        ref: 'main'
+        token: ${{ secrets.WEBSITE_DEPLOY_KEY }}
+
+    - name: Upload Files to Website repository
+      run: |
+        path=jameica-repository/${{ steps.openjverein.outputs.major }}.${{ steps.openjverein.outputs.minor }}
+        if [ ! -d website/$path ];then
+          mkdir -p website/$path
+          #Add new direcotry in repository.xml
+          sed -i "s#<plugins name=\"OpenJVerein 3\">#\0\n<plugin url=\"https://openjverein.github.io/$path\"/>#" website/jameica-repository/repository.xml
+        fi
+        
+        cp "jverein/${{ steps.openjverein.outputs.selected_path }}" "website/$path/${{ steps.openjverein.outputs.selected_filename }}"
+        cp "jverein/${{ steps.openjverein.outputs.selected_plugin_path }}" website/$path/plugin.xml
+        cd website
+        
+        git config --local user.email "actions@github.com"
+        git config --local user.name "Github Actions"
+        git add -A
+        git commit -m "Release ${{ steps.openjverein.outputs.selected_version }}"
+        git push
+
+    - name: "Minor/major release: Create new Branch and update version in plugin.xml for bugfix branch"
+      if: github.ref_name == 'master'
+      run: |
+        cd jverein
+        git config --local user.email "actions@github.com"
+        git config --local user.name "Github Actions"
+        git checkout -b ${{ steps.openjverein.outputs.major }}.${{ steps.openjverein.outputs.minor }}
+        
+        new_version=${{ steps.openjverein.outputs.major }}.${{ steps.openjverein.outputs.minor }}.1
+        sed -i "s/name=\"jverein\" version=\"${{ steps.openjverein.outputs.selected_version }}/name=\"jverein\" version=\"${new_version}/" plugin.xml
+        
+        git add plugin.xml
+        git commit -m "Update Version in plugin.xml to ${new_version}"
+        git push --set-upstream origin ${{ steps.openjverein.outputs.major }}.${{ steps.openjverein.outputs.minor }}
+        
+    - name: Update Version in plugin.xml
+      run: |
+        cd jverein
+        git config --local user.email "actions@github.com"
+        git config --local user.name "Github Actions"
+        git checkout ${{ github.ref_name }}
+        
+        minor=${{ steps.openjverein.outputs.minor }}
+        bugfix=${{ steps.openjverein.outputs.bugfix }}
+        if [ "${{ github.ref_name }}" == 'master' ];then
+          minor=$(($minor+1))
+          bugfix=0
+        else
+          bugfix=$(($bugfix+1))
+        fi
+
+        new_version=${{ steps.openjverein.outputs.major }}.$minor.$bugfix
+        
+        sed -i "s/name=\"jverein\" version=\"${{ steps.openjverein.outputs.selected_version }}/name=\"jverein\" version=\"${new_version}/" plugin.xml
+        
+        git add plugin.xml
+        git commit -m "Update Version in plugin.xml to ${new_version}"
+        git push

--- a/build/build.xml
+++ b/build/build.xml
@@ -137,9 +137,16 @@
       <fileset dir="${lib.dir}" />
     </copy>
 
+    <loadresource property="minor">
+           <propertyresource name="plugin.version" />
+           <filterchain>
+                   <replaceregex pattern="\.[0-9]+$" />
+           </filterchain>
+    </loadresource>
+
     <copy todir="${project.zipdir}" file="plugin.xml" />
     <replace file="${project.zipdir}/plugin.xml">
-      <replacefilter token="[PLUGIN_ZIP]" value="${project.zipfilename}" />
+      <replacefilter token="[PLUGIN_ZIP]" value="${minor}/${project.zipfilename}" />
     </replace>
 
     <!-- Jetzt muessen wir noch das ZIP-File erzeugen -->
@@ -206,6 +213,7 @@
     <echo message="SELECTED_VERSION=${plugin.version}" />
     <echo message="SELECTED_PATH=${project.release}/${project.zipfilename}" />
     <echo message="SELECTED_FILENAME=${project.zipfilename}" />
+    <echo message="SELECTED_PLUGIN_PATH=${project.release}/jverein/plugin.xml" />
   </target>
 
   <target name="fast" depends="jar,src" description="Build a development release">


### PR DESCRIPTION
Ich hab jetzt die automerge Action so geändert, dass sie immer den Bugfix-Branch (3.2, 3.3 etc.) in den master meged.
Nigthly-Build wird jetzt auch immer auf dem master erstellt.
Die releas Action hab ich erweitert, so dass sie folgendes macht:

- Wie bisher wird jverein gebaut und ein Release erstellt
- Anschießend wird das fertige Paket und die plugin.xml ins Website Repository hochgeladen (also für jameica veröffentlicht)
- Wenn die Action auf dem master Branche ausgeführt wird, ist es ein Minor (oder Major) Release, dann wird ein neuer Branche erstellt (zB. 2.3) und die Version in der plugin.xml erhöht.
- Für den Branche auf dem die Action ausgeführt wird, wird dann auch die plugin.xml Version erhöht

Somit ist beim Release keine Handarbeit mehr nötig, es muss lediglich die Action im richtigen Kontext ausgeführt werden. Nur bei einer Major Version muss die Version in plugin.xml angepasst werden.

Automatische bugfix Release finde ich nicht sinnvoll, da dann zT. nur unwesentliche Fixes gleich eine neue Version machen und die User genervt werden, wenn alle paar Tage eine neue Version mit update, neustart etc. da ist.
So kann man das bei bedarf schnell ohne großen Aufwand erledigen.