### PR TITLE
Fix Unregister Document Consumer

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -143,7 +143,7 @@ public class BuchungPart implements Part
   {
     try
     {
-      if (JVereinPlugin.isArchiveServiceActive() && !bu.isNewObject())
+      if (JVereinPlugin.isArchiveServiceActive() && dcontrol != null)
       {
         dcontrol.deregisterDocumentConsumer();
       }

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -828,8 +828,7 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
     controlSollb.deregisterMitgliedskontoConsumer();
     try
     {
-      if (JVereinPlugin.isArchiveServiceActive()
-          && !control.getMitglied().isNewObject())
+      if (JVereinPlugin.isArchiveServiceActive() && dcontrol != null)
       {
         dcontrol.deregisterDocumentConsumer();
       }


### PR DESCRIPTION
Die Abfrage nach isNewObject war falsch, da das Mitgled oder die Buchung vor Verlassen des View gespeichert wurde und damit ist es kein newObject mehr beim Verlassen.

Es kam darum zu einer Exception die sich aber nicht weiter ausgewirkt hat, aber so ist es besser.