### PR TITLE
Sachspende ausblenden wenn Spendenbescheinigung deaktiviert ist

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -120,6 +120,10 @@ public class FormularControl extends FormularPartControl implements Savable
       {
         list.remove(FormularArt.SAMMELSPENDENBESCHEINIGUNG);
       }
+      if (aktuelleFormularArt != FormularArt.SACHSPENDENBESCHEINIGUNG)
+      {
+        list.remove(FormularArt.SACHSPENDENBESCHEINIGUNG);
+      }
     }
     if (!(Boolean) Einstellungen.getEinstellung(Property.RECHNUNGENANZEIGEN))
     {


### PR DESCRIPTION
Im FormularDetailView sollte Sachspende als Formular Art ausgeblendet werden wenn Spendenbescheinigung deaktiviert ist.