### PR TITLE
Fix Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         path: website
         ref: 'main'
         token: ${{ secrets.WEBSITE_DEPLOY_KEY }}
+        target_commitish: ${{ github.ref_name }}
 
     - name: Upload Files to Website repository
       run: |


### PR DESCRIPTION
Beim Release wurden die ReleaseNotes, der Tag und der Source immer auf dem master branch erzeugt. Hierdurch wird der richtige Branch verwendet.