### PR TITLE
Fix VorlagenUtil Dateiname

### DIFF
--- a/src/de/jost_net/JVerein/util/VorlageUtil.java
+++ b/src/de/jost_net/JVerein/util/VorlageUtil.java
@@ -395,6 +395,7 @@ public class VorlageUtil
       Velocity.evaluate(context, wdateiname, "LOG", in);
       String str = wdateiname.toString();
       str = str.replaceAll("\\'\\#\\'", "-");
+      str = str.replaceAll("/", "_");
       return str;
     }
     catch (Exception e)


### PR DESCRIPTION
Im Dateinamen dürfen keine / vorkommen, diese werden jetzt ersetzt.