### PR TITLE
Renovate an neue jameica/hibiscus Tags angepasst

### DIFF
--- a/build/build.properties
+++ b/build/build.properties
@@ -24,7 +24,7 @@ project.zipfilename.nightly     = ${plugin.name}.${plugin.version}-nightly.zip
 
 jameica.url                     = https://github.com/willuhn/jameica/archive/refs/tags
 # renovate: depName=willuhn/jameica
-jameica.version                 = V_2_10_5_BUILD_488
+jameica.version                 = 2.12.0
 hibiscus.url                    = https://github.com/willuhn/hibiscus/archive/refs/tags
 # renovate: depName=willuhn/hibiscus
-hibiscus.version                = V_2_10_27_BUILD_391
+hibiscus.version                = 2.12.0

--- a/renovate.json
+++ b/renovate.json
@@ -11,10 +11,10 @@
         "^build/build\\.properties$"
       ],
       "matchStrings": [
-        "# renovate: depName=(?<depName>.*?)\\s*\\S+\\.version\\s*=\\s*(?<currentValue>V_\\d+_\\d+_\\d+_BUILD_\\d+)"
+        "# renovate: depName=(?<depName>.*?)\\s*\\S+\\.version\\s*=\\s*(?<currentValue>\\d+.\\d+.\\d+)"
       ],
       "datasourceTemplate": "github-tags",
-      "versioningTemplate": "regex:^V_(?<major>\\d+)_(?<minor>\\d+)_(?<patch>\\d+)_BUILD_(?<build>\\d+)$"
+      "versioningTemplate": "regex:^(?<major>\\d+).(?<minor>\\d+).(?<patch>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
Bei jameica und hibiscus hat sich der Name des Tags geändert, er ist jetzt in der Form 2.12.0, daher hatte auch renovate die neuen Versionen nicht gefunden. Ich hab es angepasst und auch die Version auf die aktuelle hochgesetzt.