### PR TITLE
Mitglied Id beim Speichern anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -269,6 +269,9 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
         {
           control.handleStore();
           GUI.getStatusBar().setSuccessText("Gespeichert");
+          funktion = 'B';
+          control.getMitgliedsnummer()
+              .setValue(((Mitglied) getCurrentObject()).getID());
           zeichneUeberschrift();
           lesefeldControl.updateLesefeldMitgliedList(control.getMitglied(),
               true);


### PR DESCRIPTION
Beim Speichern eines neuen Mitglieds wird hierdurch direkt die Mitglied ID angezeigt, im Inputfeld und im Titel.