### PR TITLE
Bei Anlagenbuchungen hat der Menüpunkt Spendenbescheinigung gefehlt

### DIFF
--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -90,19 +90,19 @@ public class BuchungMenu extends ContextMenu
           new MitgliedDetailAction(), "user-friends.png"));
       addItem(new SingleGegenBuchungItem("Neues Anlagenkonto",
           new AnlagenkontoNeuAction(), "document-new.png"));
-      try
+    }
+    try
+    {
+      if ((Boolean) Einstellungen
+          .getEinstellung(Property.SPENDENBESCHEINIGUNGENANZEIGEN))
       {
-        if ((Boolean) Einstellungen
-            .getEinstellung(Property.SPENDENBESCHEINIGUNGENANZEIGEN))
-        {
-          addItem(new SpendenbescheinigungMenuItem("Spendenbescheinigung",
-              new SpendenbescheinigungNeuAction(), "file-invoice.png"));
-        }
+        addItem(new SpendenbescheinigungMenuItem("Spendenbescheinigung",
+            new SpendenbescheinigungNeuAction(), "file-invoice.png"));
       }
-      catch (RemoteException e)
-      {
-        // Dann nicht anzeigen
-      }
+    }
+    catch (RemoteException e)
+    {
+      // Dann nicht anzeigen
     }
     addItem(new CheckedContextMenuItem("Buchungsart zuordnen",
         new BuchungBuchungsartZuordnungAction(), "view-refresh.png"));


### PR DESCRIPTION
Bei Anlagenbuchungen hat der Menüpunkt Spendenbescheinigung gefehlt. Bei Sachspenden wird das aber jetzt gebraucht.