### PR TITLE
Fix pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.test.skip>true</maven.test.skip>
-    <jameica.version>V_2_10_5_BUILD_488</jameica.version>
-    <hibiscus.version>V_2_10_24_BUILD_388</hibiscus.version>
+    <jameica.version>2.12.0</jameica.version>
+    <hibiscus.version>2.12.0</hibiscus.version>
     <!-- See https://github.com/willuhn/jameica/commit/1a8a8005e04c6201972a63bd403b161f9e3802e7 -->
     <swt.version>4.33</swt.version>
   </properties>
@@ -128,7 +128,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.xmlgraphics</groupId>
-          <artifactId>fop</artifactId>
+          <artifactId>fop-core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.eclipse.angus</groupId>


### PR DESCRIPTION
Es waren jetzt viele unnötige libraries dabei, da der exclude für fop jetzt fop-core lauten muss.