### PR TITLE
Button in Buchung Part verschieben

### DIFF
--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.parts;
 import java.rmi.RemoteException;
 
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
@@ -134,17 +135,18 @@ public class BuchungPart implements Part
         budo.setReferenz(Long.valueOf(bu.getID()));
         dcontrol = new DokumentControl(view, "buchungen",
             !buchungabgeschlossen);
-        grDokument.addPart(dcontrol.getDokumenteList(budo));
 
+        grDokument.getComposite().setLayout(new GridLayout(1, false));
+        ButtonArea butts = new ButtonArea();
+        butts.addButton(dcontrol.getNeuButton(budo));
+        butts.paint(grDokument.getComposite());
+
+        grDokument.addPart(dcontrol.getDokumenteList(budo));
         dcontrol.setDragDrop(grDokument.getComposite(), BuchungDokument.class);
 
         GridData gridData = new GridData(GridData.FILL_BOTH);
-        gridData.heightHint = 120;
+        gridData.heightHint = 150;
         grDokument.getComposite().setLayoutData(gridData);
-
-        ButtonArea butts = new ButtonArea();
-        butts.addButton(dcontrol.getNeuButton(budo));
-        butts.paint(scrolled.getComposite());
       }
     }
   }


### PR DESCRIPTION
Beim BuchungDetailView war der Button für neues Dokument nach dem Dokumente Rahmen.
Ich habe den Button jetzt in den Rahmen für Dokumente verschoben und über der Tabelle angeordnet so wie das auch sonst z.B. im Mitglied ist. So ist es einheitlicher.
<img width="704" height="189" alt="Bildschirmfoto_20251120_150029" src="https://github.com/user-attachments/assets/0a1f247d-be7d-4b2d-ac4b-20e48f3633fb" />

Das alte Layout war so:
<img width="710" height="191" alt="Bildschirmfoto_20251120_150609" src="https://github.com/user-attachments/assets/aa1bbe4c-76d6-4a72-a005-a8362b63a384" />
