### PR TITLE
Fix Filename bei Auswertung Mitglieder und Nicht-Mitglieder

### DIFF
--- a/src/de/jost_net/JVerein/Variable/AuswertungMitgliedFilterMap.java
+++ b/src/de/jost_net/JVerein/Variable/AuswertungMitgliedFilterMap.java
@@ -112,8 +112,12 @@ public class AuswertungMitgliedFilterMap extends AbstractMap
         control.getSortierung().getText());
     map.put(AuswertungMitgliedFilterVar.UEBERSCHRIFT.getName(),
         control.getAuswertungUeberschrift().getValue().toString());
-    map.put(AuswertungMitgliedFilterVar.AUSGABE.getName(),
-        control.getAusgabe().getText());
+    String ausgabe = control.getAusgabe().getText();
+    if (ausgabe.startsWith("Vorlage CSV:"))
+    {
+      ausgabe = ausgabe.substring(13);
+    }
+    map.put(AuswertungMitgliedFilterVar.AUSGABE.getName(), ausgabe);
 
     return map;
   }

--- a/src/de/jost_net/JVerein/Variable/AuswertungNichtMitgliedFilterMap.java
+++ b/src/de/jost_net/JVerein/Variable/AuswertungNichtMitgliedFilterMap.java
@@ -77,8 +77,12 @@ public class AuswertungNichtMitgliedFilterMap extends AbstractMap
         control.getSortierung().getText());
     map.put(AuswertungNichtMitgliedFilterVar.UEBERSCHRIFT.getName(),
         control.getAuswertungUeberschrift().getValue().toString());
-    map.put(AuswertungNichtMitgliedFilterVar.AUSGABE.getName(),
-        control.getAusgabe().getText());
+    String ausgabe = control.getAusgabe().getText();
+    if (ausgabe.startsWith("Vorlage CSV:"))
+    {
+      ausgabe = ausgabe.substring(13);
+    }
+    map.put(AuswertungNichtMitgliedFilterVar.AUSGABE.getName(), ausgabe);
 
     return map;
   }


### PR DESCRIPTION
Das ist ein Fix für #1186.

Bei selbst definierten csv Vorlagen wird der Vorlage Prefix aus dem Dateinamen entfernt. Damit wird nur der echte Dateiname verwendet.