### PR TITLE
Einstellungen Eintrag für Kontonummer in Buchungsliste verschoben

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2757,8 +2757,6 @@ public class EinstellungControl extends AbstractControl
           (Boolean) getAutomatischeBuchungskorrekturHibiscus().getValue());
       Einstellungen.setEinstellung(Property.AFARESTWERT,
           (Double) afarestwert.getValue());
-      Einstellungen.setEinstellung(Property.KONTONUMMERINBUCHUNGSLISTE,
-          (Boolean) kontonummer_in_buchungsliste.getValue());
       Einstellungen.setEinstellung(Property.OPTIERT,
           (Boolean) getOptiert().getValue());
       Einstellungen.setEinstellung(Property.OPTIERTPFLICHT,
@@ -3006,6 +3004,9 @@ public class EinstellungControl extends AbstractControl
     try
     {
       DBTransaction.starten();
+
+      Einstellungen.setEinstellung(Property.KONTONUMMERINBUCHUNGSLISTE,
+          (Boolean) kontonummer_in_buchungsliste.getValue());
       Einstellungen.setEinstellung(
           Property.WIRTSCHFTSPLAN_IST_NICHT_ABGESCHLOSSEN,
           (Boolean) getWirtschaftsplanIstAbgeschlossen().getValue());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -47,9 +47,6 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     cont.addLabelPair("Geprüft Markierung mit Hibiscus synchronisieren",
         control.getGeprueftSynchronisieren());
     cont.addLabelPair(
-        "Zeige Kontonummer in Buchungsliste (PDF Einzelbuchungen)",
-        control.getKontonummerInBuchungsliste());
-    cont.addLabelPair(
         "Umsatzsteuer Support (Neustart erforderlich bei jameica < 2.12.0)",
         control.getOptiert());
     cont.addLabelPair("Umsatzsteuer Pflicht", control.getOptiertPflicht());

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenReportsView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenReportsView.java
@@ -36,6 +36,9 @@ public class EinstellungenReportsView extends AbstractView
     ScrolledContainer cont = new ScrolledContainer(getParent());
 
     cont.addLabelPair(
+        "Zeige Kontonummer in Buchungsliste (PDF Einzelbuchungen)",
+        control.getKontonummerInBuchungsliste());
+    cont.addLabelPair(
         "Wirtschaftsplan Ist-Beträge von laufendem Zeitraum ausgeben",
         control.getWirtschaftsplanIstAbgeschlossen());
     cont.addLabelPair("Hintergrund bei Reports",


### PR DESCRIPTION
Ich habe die Option "Zeige Kontonummer in Buchungsliste (PDF Einzelbuchungen)" aus den Einstellungen bei Buchführung in den neuen Teil reports verschoben. Da gehört es ja jetzt auch hin.
<img width="448" height="285" alt="Bildschirmfoto_20251128_094427" src="https://github.com/user-attachments/assets/f5782b84-0405-4f74-8829-dc3422356e89" />
