### PR TITLE
Umlaute in Dateinamen erlauben

### DIFF
--- a/src/de/jost_net/JVerein/util/VorlageUtil.java
+++ b/src/de/jost_net/JVerein/util/VorlageUtil.java
@@ -395,7 +395,7 @@ public class VorlageUtil
       Velocity.evaluate(context, wdateiname, "LOG", in);
       String str = wdateiname.toString();
       str = str.replaceAll("\\'\\#\\'", "-");
-      str = str.replaceAll("[^a-zA-Z0-9_\\-\\. ]", "_");
+      str = str.replaceAll("[^a-zA-Z0-9äöüÄÖÜß_\\-\\. ]", "_");
       return str;
     }
     catch (Exception e)


### PR DESCRIPTION
Wir verwenden auch Mitgliedsnamen in Dateinamen. Diese können Umlaute enthalten. Diese sollten in den Dateinamen erlaubt sein.