### PR TITLE
MitgliedZahltSelbst bei Zusatzbetrag Import unterstützen

### DIFF
--- a/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
+++ b/src/de/jost_net/JVerein/io/DefaultZusatzbetraegeImport.java
@@ -335,6 +335,15 @@ public class DefaultZusatzbetraegeImport implements Importer
           {
             zus.setZahlungsweg(new Zahlungsweg(Zahlungsweg.STANDARD));
           }
+          try
+          {
+            Integer selbstzahler = results.getInt("MitgliedZahltSelbst");
+            zus.setMitgliedzahltSelbst(selbstzahler == 0 ? false : true);
+          }
+          catch (Exception e)
+          {
+            zus.setMitgliedzahltSelbst(false);
+          }
           monitor.setStatusText(String.format(
               "Zusatzbeitrag für Mitglied %s erfolgreich importiert.",
               Adressaufbereitung.getNameVorname(zus.getMitglied())));

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0494.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0494.java
@@ -53,9 +53,9 @@ public class Update0494 extends AbstractDDLUpdate
         "UPDATE mitglied SET kontoinhaber = SUBSTR(CONCAT(ktoiname,' ',ktoivorname),1,70) WHERE ktoiname <> '' OR ktoivorname <> ''");
 
     execute(addColumn("zusatzabbuchung", new Column("mitgliedzahltselbst",
-        COLTYPE.BOOLEAN, 1, "0", true, false)));
+        COLTYPE.BOOLEAN, 1, "0", false, false)));
 
     execute(addColumn("zusatzbetragvorlage", new Column("mitgliedzahltselbst",
-        COLTYPE.BOOLEAN, 1, "0", true, false)));
+        COLTYPE.BOOLEAN, 1, "0", false, false)));
   }
 }


### PR DESCRIPTION
Beim Import von Zusatzbeträgen hat das Attribut für Mitglied zahlt selbst gefehlt.

PS: Ich habe festgestellt, dass der Import mit ISO 8859-1 nicht funktioniert hat. Da war "Fälligkeit" nicht erlaubt. Nur bei UTF-8 Import und auch UTF-8 Codierung der Datei hat es funktiuoniert.
Das liegt vermutlich daran, dass unser Code jetzt in UTF-8 codiert ist.