### PR TITLE
Feld Bezeichnung Sachspende vergrößert

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungPrintAction.java
@@ -321,7 +321,7 @@ public class SpendenbescheinigungPrintAction implements Action
     Map<String, Object> map = new SpendenbescheinigungMap().getMap(spb, null);
     map = new AllgemeineMap().getMap(map);
     boolean isSammelbestaetigung = spb.isSammelbestaetigung();
-    Reporter rpt = new Reporter(fos, 80, 50, 50, 50, true);
+    Reporter rpt = new Reporter(fos, 80, 50, 30, 20, true);
 
     // Aussteller, kein Header
     rpt.addHeaderColumn("", Element.ALIGN_CENTER, 100, BaseColor.LIGHT_GRAY);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -191,7 +191,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
 
   private CheckboxInput verzicht;
 
-  private TextInput bezeichnungsachzuwendung;
+  private TextAreaInput bezeichnungsachzuwendung;
 
   private SelectInput herkunftspende;
 
@@ -641,14 +641,15 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     return verzicht;
   }
 
-  public TextInput getBezeichnungSachzuwendung() throws RemoteException
+  public TextAreaInput getBezeichnungSachzuwendung() throws RemoteException
   {
     if (bezeichnungsachzuwendung != null)
     {
       return bezeichnungsachzuwendung;
     }
-    bezeichnungsachzuwendung = new TextInput(
-        getBuchung().getBezeichnungSachzuwendung(), 100);
+    bezeichnungsachzuwendung = new TextAreaInput(
+        getBuchung().getBezeichnungSachzuwendung(), 1000);
+    bezeichnungsachzuwendung.setHeight(50);
     bezeichnungsachzuwendung.setEnabled(editable);
     return bezeichnungsachzuwendung;
   }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -87,6 +87,7 @@ import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
@@ -131,7 +132,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
 
   private CheckboxInput ersatzaufwendungen;
 
-  private TextInput bezeichnungsachzuwendung;
+  private TextAreaInput bezeichnungsachzuwendung;
 
   private SelectInput herkunftspende;
 
@@ -388,14 +389,15 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return ersatzaufwendungen;
   }
 
-  public TextInput getBezeichnungSachzuwendung() throws RemoteException
+  public TextAreaInput getBezeichnungSachzuwendung() throws RemoteException
   {
     if (bezeichnungsachzuwendung != null)
     {
       return bezeichnungsachzuwendung;
     }
-    bezeichnungsachzuwendung = new TextInput(
-        getSpendenbescheinigung().getBezeichnungSachzuwendung(), 100);
+    bezeichnungsachzuwendung = new TextAreaInput(
+        getSpendenbescheinigung().getBezeichnungSachzuwendung(), 1000);
+    bezeichnungsachzuwendung.setHeight(50);
     bezeichnungsachzuwendung.disable();
     return bezeichnungsachzuwendung;
   }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0497.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0497.java
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0497 extends AbstractDDLUpdate
+{
+  public Update0497(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(alterColumn("buchung", new Column("bezeichnungsachzuwendung",
+        COLTYPE.VARCHAR, 1000, null, false, false)));
+
+    execute(alterColumn("spendenbescheinigung",
+        new Column("bezeichnungsachzuwendung", COLTYPE.VARCHAR, 1000, null,
+            false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -380,7 +380,7 @@ public class SpendenbescheinigungImpl extends AbstractJVereinDBObject
 
   /**
    * Liefert als Kennzeichen zurück, ob die Spendenbescheinigung eine echte
-   * Geldspende ist. Dies ist der Fall, wenn es sich um eine Gelspende handelt
+   * Geldspende ist. Dies ist der Fall, wenn es sich um eine Geldspende handelt
    * bei der bei keiner Buchung das Flag Erstattungsverzicht gesetzt ist.
    * 
    * @return Flag, ob echte Geldspende
@@ -389,8 +389,10 @@ public class SpendenbescheinigungImpl extends AbstractJVereinDBObject
   @Override
   public boolean isEchteGeldspende() throws RemoteException
   {
-    if (getBuchungen() == null)
+    if (getSpendenart() == Spendenart.SACHSPENDE)
+    {
       return false;
+    }
     for (Buchung buchung : getBuchungen())
     {
       if (buchung.getVerzicht())


### PR DESCRIPTION
Entsprechend der Diskussion in https://jverein-forum.de/viewtopic.php?t=7538 habe ich das Eingabefeld für die Bezeichnung der Sachspende vergrößert.

Damit auch bei 10 Zeilen der ganze Text auf eine Seite passt habe ich den oberen und unteren Rand des Dokuments verkleinert.

Dann gab es noch einen Bug bei der Abfrage zu echter Geldspende. Mit der Einführung von Buchungen bei Sachspenden stimmte der alte Code nicht mehr.