### PR TITLE
Fix Echte Geldspende Check in 3.2

### DIFF
--- a/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -389,8 +389,10 @@ public class SpendenbescheinigungImpl extends AbstractJVereinDBObject
   @Override
   public boolean isEchteGeldspende() throws RemoteException
   {
-    if (getBuchungen() == null)
+    if (getSpendenart() == Spendenart.SACHSPENDE)
+    {
       return false;
+    }
     for (Buchung buchung : getBuchungen())
     {
       if (buchung.getVerzicht())


### PR DESCRIPTION
Mit dem Support von Buchungen bei Sachspenden hat die alte Abfrage nicht mehr funktioniert.