### PR TITLE
Kontoinhaber Attribut für Kursteilnehmer

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -108,6 +108,8 @@ public class KursteilnehmerControl extends FilterControl implements Savable
 
   private GeschlechtInput geschlecht;
 
+  private TextInput kontoinhaber;
+
   private Kursteilnehmer ktn;
 
   private JVereinTablePart part;
@@ -404,6 +406,7 @@ public class KursteilnehmerControl extends FilterControl implements Savable
     part.addColumn("Verwendungszweck", "vzweck1");
     part.addColumn("BIC", "bic");
     part.addColumn("IBAN", "iban", new IBANFormatter());
+    part.addColumn("Kontoinhaber", "kontoinhaber");
     part.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     part.addColumn("Mandats-ID", "mandatid");
@@ -458,6 +461,18 @@ public class KursteilnehmerControl extends FilterControl implements Savable
     return b;
   }
 
+  public TextInput getKontoinhaber() throws RemoteException
+  {
+    if (kontoinhaber != null)
+    {
+      return kontoinhaber;
+    }
+    kontoinhaber = new TextInput(getKursteilnehmer().getKontoinhaber(), 70);
+    kontoinhaber.setName("Kontoinhaber");
+    kontoinhaber.setHint("Optional");
+    return kontoinhaber;
+  }
+
   @Override
   public JVereinDBObject prepareStore() throws RemoteException
   {
@@ -493,6 +508,7 @@ public class KursteilnehmerControl extends FilterControl implements Savable
     {
       k.setGeschlecht((String) getGeschlecht().getValue());
     }
+    k.setKontoinhaber((String) getKontoinhaber().getValue());
 
     if (k.getID() == null)
     {

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerDetailView.java
@@ -54,15 +54,16 @@ public class KursteilnehmerDetailView extends AbstractDetailView
     left.addInput(control.getStrasse());
     left.addInput(control.getAdressierungszusatz());
     left.addInput(control.getPLZ());
+    left.addInput(control.getOrt());
 
     SimpleContainer right = new SimpleContainer(cl.getComposite());
-    right.addInput(control.getOrt());
     right.addInput(control.getStaat());
     right.addInput(control.getEmail());
     right.addInput(control.getVZweck1());
     right.addInput(control.getMandatDatum());
     right.addInput(control.getIBAN());
     right.addInput(control.getBIC());
+    right.addInput(control.getKontoinhaber());
     right.addInput(control.getBetrag());
 
     LabelGroup grStatistik = new LabelGroup(scrolled.getComposite(),

--- a/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
+++ b/src/de/jost_net/JVerein/io/Ct1Ueberweisung.java
@@ -212,10 +212,11 @@ public class Ct1Ueberweisung
         }
         else if (ls.getKursteilnehmer() != null)
         {
-          ue.setGegenkontoName(StringTool.getStringWithMaxLength(
-              Zeichen.convert(
-                  Adressaufbereitung.getNameVorname(ls.getKursteilnehmer())),
-              255));
+          ue.setGegenkontoName(
+              StringTool.getStringWithMaxLength(
+                  Zeichen.convert(ls.getKursteilnehmer()
+                      .getKontoinhaber(Mitglied.namenformat.KONTOINHABER)),
+                  255));
         }
         ue.setTermin(faell);
         ue.setZweck(StringTool.getStringWithMaxLength(

--- a/src/de/jost_net/JVerein/rmi/Kursteilnehmer.java
+++ b/src/de/jost_net/JVerein/rmi/Kursteilnehmer.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.io.ILastschrift;
+import de.jost_net.JVerein.rmi.Mitglied.namenformat;
 import de.willuhn.util.ApplicationException;
 
 public interface Kursteilnehmer extends JVereinDBObject, ILastschrift
@@ -85,4 +86,9 @@ public interface Kursteilnehmer extends JVereinDBObject, ILastschrift
 
   public void insert() throws RemoteException, ApplicationException;
 
+  public String getKontoinhaber(namenformat art) throws RemoteException;
+
+  public String getKontoinhaber() throws RemoteException;
+
+  public void setKontoinhaber(String kontoinhaber) throws RemoteException;
 }

--- a/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0501.java
+++ b/src/de/jost_net/JVerein/server/DDLTool/Updates/Update0501.java
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0501 extends AbstractDDLUpdate
+{
+  public Update0501(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("kursteilnehmer",
+        new Column("kontoinhaber", COLTYPE.VARCHAR, 70, null, false, false)));
+  }
+}

--- a/src/de/jost_net/JVerein/server/KursteilnehmerImpl.java
+++ b/src/de/jost_net/JVerein/server/KursteilnehmerImpl.java
@@ -23,9 +23,11 @@ import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
+import de.jost_net.JVerein.rmi.Mitglied.namenformat;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.jost_net.OBanToo.SEPA.BIC;
 import de.jost_net.OBanToo.SEPA.IBAN;
@@ -496,6 +498,42 @@ public class KursteilnehmerImpl extends AbstractJVereinDBObject
     return d;
   }
 
+  public String getKontoinhaber(namenformat art) throws RemoteException
+  {
+    switch (art)
+    {
+      case KONTOINHABER:
+        String ktoi = getKontoinhaber();
+        if (ktoi != null && !ktoi.isEmpty())
+        {
+          return ktoi;
+        }
+        else
+        {
+          return Adressaufbereitung.getNameVorname(this);
+        }
+      case NAME_VORNAME:
+        return Adressaufbereitung.getNameVorname(this);
+      case VORNAME_NAME:
+        return Adressaufbereitung.getVornameName(this);
+      case ADRESSE:
+        return Adressaufbereitung.getAdressfeld(this);
+    }
+    return null;
+  }
+
+  @Override
+  public void setKontoinhaber(String kontoinhaber) throws RemoteException
+  {
+    setAttribute("kontoinhaber", kontoinhaber);
+  }
+
+  @Override
+  public String getKontoinhaber() throws RemoteException
+  {
+    return (String) getAttribute("kontoinhaber");
+  }
+
   @Override
   public Object getAttributeDefault(String fieldName)
   {
@@ -512,6 +550,7 @@ public class KursteilnehmerImpl extends AbstractJVereinDBObject
       case "bic":
       case "staat":
       case "email":
+      case "kontoinhaber":
         return "";
       default:
         return null;


### PR DESCRIPTION
Analog zum Mitglied gibt es jetzt auch den Kontoinhaber beim Kursteilnehmer.

Wegen der Migration ist der PR blockiert bis nach #1220 .