### PR TITLE
Fix für Dateiname bei Prenotification für Kursteilnehmer

### DIFF
--- a/src/de/jost_net/JVerein/keys/VorlageTyp.java
+++ b/src/de/jost_net/JVerein/keys/VorlageTyp.java
@@ -65,6 +65,11 @@ public enum VorlageTyp
       "Pre-Notification-MitgliedDateiname",
       "Prenotification-$mitglied_name-$mitglied_vorname-$aktuellesdatum-$aktuellezeit",
       Vorlageart.DATEINAME.getKey()),
+  PRENOTIFICATION_KURSTEILNEHMER_DATEINAME(
+      "pre-notification-kursteilnehmer-dateiname",
+      "Pre-Notification-KursteilnehmerDateiname",
+      "Prenotification-$lastschrift_name-$lastschrift_vorname-$aktuellesdatum-$aktuellezeit",
+      Vorlageart.DATEINAME.getKey()),
 
   // Reports aus Mitglieder
   PERSONALBOGEN_DATEINAME("personalbogen-dateiname", "PersonalbogenDateiname",

--- a/src/de/jost_net/JVerein/util/VorlageUtil.java
+++ b/src/de/jost_net/JVerein/util/VorlageUtil.java
@@ -111,6 +111,9 @@ public class VorlageUtil
           map = new LastschriftMap().getMap((Lastschrift) obj, map);
           map = new MitgliedMap().getMap(mitglied, map);
           break;
+        case PRENOTIFICATION_KURSTEILNEHMER_DATEINAME:
+          map = new LastschriftMap().getMap((Lastschrift) obj, map);
+          break;
         case PERSONALBOGEN_MITGLIED_DATEINAME:
         case PERSONALBOGEN_TITEL:
         case PERSONALBOGEN_SUBTITEL:
@@ -334,6 +337,9 @@ public class VorlageUtil
         case PRENOTIFICATION_MITGLIED_DATEINAME:
           map = LastschriftMap.getDummyMap(map);
           map = MitgliedMap.getDummyMap(map);
+          break;
+        case PRENOTIFICATION_KURSTEILNEHMER_DATEINAME:
+          map = LastschriftMap.getDummyMap(map);
           break;
         case PERSONALBOGEN_MITGLIED_DATEINAME:
         case PERSONALBOGEN_TITEL:


### PR DESCRIPTION
Ich habe hier die Unterstützung des Dateinamen bei Prenotification für Kursteilnehmer eingeführt. Das hatte bisher gefehlt.

Dabei habe ich auch noch den alten Code für die PDF Ausgabe angepasst, so dass auch hier bei mehreren Dateien der Dateiauswahldialog angezeigt wird. Mit dieser Änderung hätten wir auch eine Lösung für 4.0 auch ohne #1021.