### PR TITLE
Multi Selektion in Empfänger Liste Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
@@ -61,6 +61,7 @@ public class DruckMailMitgliedDialog extends AbstractDialog<Object>
     empfaenger.addColumn("Vorname", "vorname");
     empfaenger.addColumn("Mitgliedstyp", "mitgliedstyp");
     empfaenger.setRememberOrder(true);
+    empfaenger.setMulti(true);
     empfaenger.paint(parent);
 
     ButtonArea buttons = new ButtonArea();


### PR DESCRIPTION
Wegen der Diskussion in https://jverein-forum.de/viewtopic.php?t=7553 habe ich Multi Selektion im Empfänger Liste Dialog hinzugefügt.
Dadurch kann man alle Einträge selektieren und mit CRT+C rauskopieren.