### PR TITLE
Fix Sollbuchung Zuordnen bei Überzahlung

### DIFF
--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -525,10 +525,10 @@ public class SplitbuchungsContainer
         }
       }
 
-      // Bei nur einem Eintrag und gleichem Betrag ist kein Splitten nötig, wir
-      // können also die
+      // Bei nur einem oder keinem Eintrag (kann bei Überzahlung passieren)
+      // und gleichem Betrag ist kein Splitten nötig, wir können also die
       // Daten direkt speichern
-      if (splitMap.size() == 1 && Math.abs(sollb.getBetrag()
+      if (splitMap.size() <= 1 && Math.abs(sollb.getBetrag()
           - sollb.getIstSumme() - buchung.getBetrag()) < 0.01d)
       {
         if (spArray.get(0).getBuchungsartId() != null)


### PR DESCRIPTION
Bei mir hat eine Sollbuchung Zuordnung nicht funktioniert.
Das Szenario war mit einer Sollbuchung und einer Sollbuchungposition. Dieser waren bereits 4 Buchungen zugeordnet. Allerdings kam es dabei zu einer Überzahlung. Ich wollte dann den überzahlten Betrag durch eine negative Buchung, die Teil einer Splitbuchung ist, ausgleichen. Diese Zuordnung hat nicht funktioniert.
Das Problem hier war, dass der Code autoSplit wegen der Überzahlung keinen Eintrag in der splitMap hat und darum eine Restbuchung erzeugt, die aber im Fall einer Gleichheit von Fehlbetrag und Buchungsbetrag in der Action nicht weiter betrachtet wird. Darum kommt es zu keiner Zuordnung.
Ich habe den Code so geändert, dass auch bei leerer SplitMap und gleichem Betrag eine direkte Zuweisung erfolgt.

Ein Workaround ist es die Zuordnung aus dem Buchung DetailView heraus zu machen. Hier wird ja einfach zugeordnet ohne irgendwelche Split Möglichkeiten. 