### PR TITLE
Fix Zusatzfeld speichern

### DIFF
--- a/src/de/jost_net/JVerein/server/FelddefinitionImpl.java
+++ b/src/de/jost_net/JVerein/server/FelddefinitionImpl.java
@@ -67,7 +67,6 @@ public class FelddefinitionImpl extends AbstractJVereinDBObject
       {
         throw new ApplicationException("Bitte Namen des Label eingeben");
       }
-      setName(getName().toLowerCase());
       String validChars = "abcdefghijklmnopqrstuvwxyz0123456789_";
       String testString = getName();
       for (int i = 0; i < testString.length(); i++)
@@ -75,7 +74,8 @@ public class FelddefinitionImpl extends AbstractJVereinDBObject
         char c = testString.charAt(i);
         if (validChars.indexOf(c) == -1)
           throw new ApplicationException(String.format(
-              "Ungültiges Zeichen (%s) im Feldnamen an Position %d", c, i));
+              "Ungültiges Zeichen (%s) im Feldnamen an Position %d, nur 0-9, a-z, _ erlaubt!",
+              c, i + 1));
       }
       Mitglied m = (Mitglied) Einstellungen.getDBService()
           .createObject(Mitglied.class, null);


### PR DESCRIPTION
Beim Speichern von Zusatzfeldern wurde im insertCheck der Name in lowercase gewandelt. Das führte dazu, dass man nach dem Speichern beim Verlassen des Dialogs angezeigt bekam, dass nicht gespeichert wurde. Erst wenn man den Dialog wieder öffnet sieht man, dass der Name geändert wurde.

Das Ganze ist nicht schön. Ich habe das automatische Umwandeln entfernt. So bekommt man gleich die Meldung, dass die Großbuchstaben nicht erlaubt sind und es bleibt die Verlassen Meldung aus.
Auch habe ich den Index um 1 erhöht, so dass er mit 1 als erster Stelle startet und nicht mit 0.