### PR TITLE
Fix Neues Nicht-Mitglied

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1948,6 +1948,10 @@ public class MitgliedControl extends FilterControl implements Savable
                     getZahlungsweg()
                         .setValue(new Zahlungsweg(Zahlungsweg.ÜBERWEISUNG));
                     deleteBankverbindung();
+                    mandatid.setMandatory(false);
+                    mandatdatum.setMandatory(false);
+                    mandatversion.setMandatory(false);
+                    iban.setMandatory(false);
                     m.clearKtoi();
                   }
                 }


### PR DESCRIPTION
Beim Erzeugen eines Nicht-Mitglied, im Zahlung Tab eines Mitglieds, wurde bei der Übernahme eines alten alternativen Kontoinhabers der Zahlungsweg auf Überweisung zurückgesetzt. Dabei muss auch das Mandatory für die Kontodaten gelöscht werden.