### PR TITLE
Fix für Altergruppenparser

### DIFF
--- a/src/de/jost_net/JVerein/io/AltersgruppenParser.java
+++ b/src/de/jost_net/JVerein/io/AltersgruppenParser.java
@@ -29,7 +29,7 @@ public class AltersgruppenParser
   public AltersgruppenParser(String altersgruppe) throws RuntimeException
   {
     ArrayList<VonBis> elemente;
-    if (altersgruppe == null)
+    if (altersgruppe == null || altersgruppe.isEmpty())
     {
       throw new RuntimeException("Altersgruppe(n) müssen gefüllt sein!");
     }
@@ -63,8 +63,8 @@ public class AltersgruppenParser
         throw new RuntimeException(
             "Fehler in den Altergruppen" + " " + e.getMessage());
       }
-      iterator = elemente.iterator();
     }
+    iterator = elemente.iterator();
   }
 
   public boolean hasNext()

--- a/src/de/jost_net/JVerein/io/MitgliederStatistik.java
+++ b/src/de/jost_net/JVerein/io/MitgliederStatistik.java
@@ -142,7 +142,7 @@ public class MitgliederStatistik
     catch (Exception e)
     {
       Logger.error("Fehler", e);
-      throw new ApplicationException("Fehler", e);
+      throw new ApplicationException("Fehler: " + e.getMessage());
     }
   }
 


### PR DESCRIPTION
Fix für #1275.

Folgendes wurde behoben:
* altergruppe auch auf Leerstring geprüft
* Zuweisen des Iterator war in der Schleife, sollte aber danach sein
* in der Mitgliederstatistik neben dem Wort "Fehler" auch den Text der Exception ausgeben damit man sehen kann was das Problem war


Wobei noch die Frage wäre, ob ein Leerstring nicht doch erlaubt sein sollte. Wenn man keine Geburtstage hat braucht man sie evtl. nicht.
Mit dem Verschieben der Zuweisung nach der Schleife kommt es wenigstens nicht mehr zur Null Pointer Exception. 