### PR TITLE
Fix UStvA

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -116,7 +116,7 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
 
       String art = null;
       Integer steuerArt = o.getInteger(ARTSTEUERBUCHUNGSART);
-      if (steuerArt == ArtBuchungsart.EINNAHME || steuerArt == null)
+      if (steuerArt == null || steuerArt == ArtBuchungsart.EINNAHME)
       {
         art = "Umsatzsteuer";
       }


### PR DESCRIPTION
Durch #1277 ist es zu einem Fehler bei der UmsatzsteuerVoranmeldung gekommen. Das entfernen des cast zu Integer hat zu einer NPE geführt.