### PR TITLE
ZUGFeRD Rechnung Rundungsbetrag

### DIFF
--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -88,6 +88,7 @@ import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.internal.action.Program;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class FormularAufbereitung
@@ -749,6 +750,10 @@ public class FormularAufbereitung
     if (diff.abs().doubleValue() >= .01d)
     {
       invoice.setRoundingAmount(diff);
+      if (diff.abs().doubleValue() > 0.1d)
+        Logger.warn(
+            "Differenz zwischen ZUGFeRD Summe (Netto-Berechnung) und Rechnungssumme (Brutto-Berechnung) größer als 10ct."
+                + " Füge Rundungsbetrag hinzu");
     }
 
     ze.setTransaction(invoice);


### PR DESCRIPTION
Wie bereits diskutiert, kann es bei der ZUGFeRD Rechnung zu Differenzen der angezeigten Rechnung kommen. Wir rechnen mit der Bruttometode, ZUGFeRD jedoch mit der Nettomethode. So so entstandene Differenz füge ich jetzt als Rundungsbetrag hinzu. Damit stimmt xml und pdf überein.