### PR TITLE
Fix mögliche Exception in Lastschrift Detail View

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -285,11 +285,18 @@ public class LastschriftControl extends FilterControl implements Savable
     String text = "";
     if (getLastschrift().getKursteilnehmer() != null)
       text = "Kursteilnehmer";
-    else if (getLastschrift().getMitglied().getMitgliedstyp().getID()
-        .equals(Mitgliedstyp.MITGLIED))
-      text = "Mitglied";
-    else
-      text = "Nicht-Mitglied";
+    else if (getLastschrift().getMitglied() != null)
+    {
+      if (getLastschrift().getMitglied().getMitgliedstyp().getID()
+          .equals(Mitgliedstyp.MITGLIED))
+      {
+        text = "Mitglied";
+      }
+      else
+      {
+        text = "Nicht-Mitglied";
+      }
+    }
     mitgliedstyp = new TextInput(text, 15);
     mitgliedstyp.setName("Mitgliedstyp");
     mitgliedstyp.setEnabled(false);


### PR DESCRIPTION
Im Lastschrift Detail View könnte es zu einer Exception kommen wenn weder Kursteilnehmer noch Mitglied gesetzt sind.
Eigentlich sollte immer eines gesetzt sein, aber besser so.