### PR TITLE
Fix Lehrgänge auch bei Nicht-Mitglieder anzeigen auch in 4.0

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -402,8 +402,7 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
   private void zeichneLehrgaenge(Composite parentComposite)
       throws RemoteException
   {
-    if (isMitgliedDetail()
-        && (Boolean) Einstellungen.getEinstellung(Property.LEHRGAENGE))
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEHRGAENGE))
     {
       Container cont = getTabOrLabelContainer(parentComposite, "Lehrgänge");
 


### PR DESCRIPTION
Man kann Lehrgänge auch für Nicht-Mitglieder erzeugen, der entsprechende Tab wurde aber nicht im MitgliedDetail View angezeigt.