### PR TITLE
Fix Abrechnung SEPA GUI

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungSEPAControl.java
@@ -230,6 +230,10 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.vondatum.setText("Bitte Anfangsdatum der Abrechnung wählen");
     boolean mode = (Integer) modus
         .getValue() == Abrechnungsmodi.EINGETRETENEMITGLIEDER;
+    if (mode)
+    {
+      vondatum.setValue(new Date());
+    }
     this.vondatum.setEnabled(mode);
     this.vondatum.addListener(event -> {
       if (vondatum.hasChanged())
@@ -251,6 +255,10 @@ public class AbrechnungSEPAControl extends AbstractControl
     this.voneingabedatum = new DateInput(null, new JVDateFormatTTMMJJJJ());
     boolean mode = (Integer) modus
         .getValue() == Abrechnungsmodi.EINGETRETENEMITGLIEDER;
+    if (mode)
+    {
+      voneingabedatum.setValue(new Date());
+    }
     this.voneingabedatum.setMandatory(mode && this.vondatum.getValue() == null);
     this.voneingabedatum.setEnabled(mode);
     // Das kann erst gemacht werden wenn voneingabedatum existiert
@@ -555,11 +563,11 @@ public class AbrechnungSEPAControl extends AbstractControl
       {
         if (rechnungsformular.getValue() == null)
         {
-          throw new ApplicationException("Rechnung Formular fehlt");
+          throw new ApplicationException("Rechnungsformular fehlt");
         }
         if (rechnungsdatum.getValue() == null)
         {
-          throw new ApplicationException("Rechnung Datum fehlt");
+          throw new ApplicationException("Rechnungsdatum fehlt");
         }
       }
     }

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungSEPAView.java
@@ -79,9 +79,9 @@ public class AbrechnungSEPAView extends AbstractView
     {
       rigth.addHeadline("Rechnungen");
       rigth.addLabelPair("Rechnung(en) erstellen²", control.getRechnung());
-      rigth.addLabelPair("Rechnung Formular", control.getRechnungFormular());
-      rigth.addLabelPair("Rechnung Text", control.getRechnungstext());
-      rigth.addLabelPair("Rechnung Datum", control.getRechnungsdatum());
+      rigth.addLabelPair("Rechnungsformular", control.getRechnungFormular());
+      rigth.addLabelPair("Rechnungstext", control.getRechnungstext());
+      rigth.addLabelPair("Rechnungsdatum", control.getRechnungsdatum());
     }
 
     group.addSeparator();


### PR DESCRIPTION
Bei Anbrechnung SEPA habe ich folgendes korrigiert:
* Check ob bei Rechnung das Rechnung Formular und das Rechnung Datum gesetzt sind
* Die Pflichtfelder Formular und Datum bei Rechnung auf Mandatory setzen/rücksetzen
* Stichtag und Fälligkeit Mandatory
* Großschrift bei Texten
* Mandatory auch für die Von und Bis Felder. Bei Eintrittsdatum und Eingabedatum sind beide mandatory solange bei einem nichts eingegeben ist. Wenn eines eingegeben ist verschwindet mandatory beim anderen. Bin mir aber nicht sicher ob das verwirrend ist. Aber keines auf mandatory zu setzen wenn beide leer sind ist ja auch nicht wirklich richtig und könnte auch verwirren. Ich kann das aber wieder weg nehmen wenn ihr meint
* Bei den Von Datum wurde beim Einschalten von Eingetretene Mitglieder das aktuelle Datum gesetzt. Wenn die Option aber beim Öffnen des View schon aktiv war, dann waren die Felder leer. Ich setzte jetzt auch das aktuelle Datum beim Öffnen