### PR TITLE
Diff Rechung und Sollbuchung immer 0.5ct

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -356,7 +356,7 @@ public class SollbuchungQuery
     sql.append(
         " GROUP BY " + Sollbuchung.TABLE_NAME_ID + ", " + Sollbuchung.T_BETRAG);
 
-    Double limit = Double.valueOf(0d);
+    Double limit = Double.valueOf(0.005d);
     if (control.isDoubleAuswAktiv()
         && control.getDoubleAusw().getValue() != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -341,7 +341,7 @@ public class RechnungControl extends DruckMailControl implements Savable
 
     if (isDifferenzAktiv() && getDifferenz().getValue() != DIFFERENZ.EGAL)
     {
-      Double limit = Double.valueOf(0d);
+      Double limit = Double.valueOf(0.005d);
       if (isDoubleAuswAktiv() && getDoubleAusw().getValue() != null)
       {
         // Es ist egal ob der Betrag positiv oder negativ eingetragen wurde


### PR DESCRIPTION
Ich hab immer wieder den Fall, dass ist und Soll gleich sind, und auch so angezeigt werden, jedoch ein Fehlbetrag oder eine Überzahlung angezeigt werden. Daher hab ich jetzt einen Defaultbetrag von 0.5ct eingebaut.