### PR TITLE
Fix aus Familenverband entfernen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -628,7 +628,7 @@ public class MitgliedControl extends FilterControl implements Savable
       @Override
       public void handleEvent(Event event)
       {
-        if (event != null && event.type == SWT.Selection && mandatid != null)
+        if (event != null && event.type == SWT.Selection)
         {
           try
           {

--- a/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/FamilienmitgliedEntfernenDialog.java
@@ -18,6 +18,7 @@
 package de.jost_net.JVerein.gui.dialogs;
 
 import java.rmi.RemoteException;
+import java.util.Date;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -82,6 +83,10 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
     LabelGroup lgBank = new LabelGroup(parent, "Bankverbindung");
     lgBank.addLabelPair("IBAN", control.getIban());
     lgBank.addLabelPair("BIC", control.getBic());
+
+    lgBank.addInput(control.getMandatDatum());
+    lgBank.addInput(control.getMandatID());
+    lgBank.addInput(control.getMandatVersion());
     LabelGroup lgZahlungsweg = new LabelGroup(parent, "Zahlungsweg");
     lgZahlungsweg.addLabelPair("Zahlungsweg", control.getZahlungsweg());
     // lgBank.addLabelPair("Kontoinhaber", control.getKontoinhaber());
@@ -106,6 +111,9 @@ public class FamilienmitgliedEntfernenDialog extends AbstractDialog<String>
           m.setLetzteAenderung();
           m.setIban(control.getIban().getValue().toString().replace(" ", ""));
           m.setBic(control.getBic().getValue().toString());
+          m.setMandatDatum((Date) control.getMandatDatum().getValue());
+          m.setMandatID((String) control.getMandatID().getValue());
+          m.setMandatVersion((Integer) control.getMandatVersion().getValue());
           m.setZahlungsweg(
               ((Zahlungsweg) control.getZahlungsweg().getValue()).getKey());
           m.store();


### PR DESCRIPTION
Hier kam es zu einer NPE, da es keine Madatsdatum etc. Eingabefelder gab.
Außerdem hat das ersetzen der Leerzeichen bei der IBAN gefehlt.
