### PR TITLE
Mitgliedskonto Tree Ist Zahlungsweg statt Soll Zahlungsweg

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/MitgliedskontoNode.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedskontoNode.java
@@ -22,6 +22,7 @@ import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
+import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Sollbuchung;
@@ -54,7 +55,7 @@ public class MitgliedskontoNode implements GenericObjectNode
 
   private String zweck1 = null;
 
-  private Integer zahlungsweg = null;
+  private String zahlungsweg = null;
 
   private Double soll = null;
 
@@ -74,7 +75,7 @@ public class MitgliedskontoNode implements GenericObjectNode
   {
     type = MITGLIED;
     this.mitglied = m;
-    this.zahlungsweg = m.getZahlungsweg();
+    this.zahlungsweg = Zahlungsweg.get(m.getZahlungsweg());
     this.name = Adressaufbereitung.getNameVorname(m);
     this.soll = Double.valueOf(0);
     this.ist = Double.valueOf(0);
@@ -116,7 +117,7 @@ public class MitgliedskontoNode implements GenericObjectNode
     this.parent = parent;
     this.id = sollb.getID();
     this.mitglied = sollb.getMitglied();
-    this.zahlungsweg = sollb.getZahlungsweg();
+    this.zahlungsweg = Zahlungsweg.get(sollb.getZahlungsweg());
     this.datum = sollb.getDatum();
     this.zweck1 = sollb.getZweck1();
     this.soll = sollb.getBetrag();
@@ -148,7 +149,7 @@ public class MitgliedskontoNode implements GenericObjectNode
     this.parent = parent;
     this.id = bist.getID();
     this.mitglied = mk.getMitglied();
-    this.zahlungsweg = mk.getZahlungsweg();
+    this.zahlungsweg = bist.getArt();
     this.datum = bist.getDatum();
     this.zweck1 = bist.getZweck();
     this.ist = bist.getBetrag();

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -34,7 +34,6 @@ import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.Queries.SollbuchungQuery;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.EditAction;
-import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.menu.BuchungPartBearbeitenMenu;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
@@ -405,8 +404,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     mitgliedskontoTree.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     mitgliedskontoTree.addColumn("Zweck1", "zweck1");
-    mitgliedskontoTree.addColumn("Zahlungsweg", "zahlungsweg",
-        new ZahlungswegFormatter());
+    mitgliedskontoTree.addColumn("Zahlungsweg", "zahlungsweg");
     mitgliedskontoTree.addColumn("Soll", "soll",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     mitgliedskontoTree.addColumn("Ist", "ist",

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -30,7 +30,6 @@ import com.itextpdf.text.Paragraph;
 import de.jost_net.JVerein.gui.control.SollbuchungControl;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
 import de.jost_net.JVerein.keys.VorlageTyp;
-import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.util.StringTool;
@@ -119,7 +118,7 @@ public class Kontoauszug extends AbstractAusgabe
     }
     rpt.addColumn((Date) node.getAttribute("datum"), Element.ALIGN_CENTER);
     rpt.addColumn((String) node.getAttribute("zweck1"), Element.ALIGN_LEFT);
-    rpt.addColumn(Zahlungsweg.get((Integer) node.getAttribute("zahlungsweg")),
+    rpt.addColumn((String) node.getAttribute("zahlungsweg"),
         Element.ALIGN_LEFT);
     rpt.addColumn((Double) node.getAttribute("soll"));
     if (node.getType() != MitgliedskontoNode.SOLL)


### PR DESCRIPTION
Bei Mitgliedskonto Tree wurde bisher bei Soll und Ist Buchungen der Zahlungsweg aus der Sollbuchung angezeigt. Mit dieser Änderung wird bei der Istbuchung das Feld Art der Buchung angezeigt. Darin steht dort der zahlungsweg.
Die Änderungen gelten auch für den Kontoauszug.