### PR TITLE
Zahlungsweg Text nur RechnungMap

### DIFF
--- a/src/de/jost_net/JVerein/Variable/MitgliedMap.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedMap.java
@@ -16,7 +16,6 @@
  **********************************************************************/
 package de.jost_net.JVerein.Variable;
 
-import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,13 +27,11 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.GeschlechtInput;
 import de.jost_net.JVerein.io.BeitragsUtil;
-import de.jost_net.JVerein.io.VelocityTool;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.Beitragsmodel;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.keys.Zahlungsrhythmus;
 import de.jost_net.JVerein.keys.Zahlungstermin;
-import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Eigenschaft;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
 import de.jost_net.JVerein.rmi.Eigenschaften;
@@ -241,37 +238,6 @@ public class MitgliedMap extends AbstractMap
             : "");
     map.put(MitgliedVar.ZAHLUNGSWEG.getName(), mitglied.getZahlungsweg() + "");
 
-    String zahlungsweg = "";
-    switch (mitglied.getZahlungsweg())
-    {
-      case Zahlungsweg.BASISLASTSCHRIFT:
-        zahlungsweg = (String) Einstellungen
-            .getEinstellung(Property.RECHNUNGTEXTABBUCHUNG);
-        zahlungsweg = zahlungsweg.replaceAll("\\$\\{BIC\\}", mitglied.getBic());
-        zahlungsweg = zahlungsweg.replaceAll("\\$\\{IBAN\\}",
-            mitglied.getIban());
-        zahlungsweg = zahlungsweg.replaceAll("\\$\\{MANDATID\\}",
-            mitglied.getMandatID());
-        break;
-      case Zahlungsweg.BARZAHLUNG:
-        zahlungsweg = (String) Einstellungen
-            .getEinstellung(Property.RECHNUNGTEXTBAR);
-        break;
-      case Zahlungsweg.ÜBERWEISUNG:
-        zahlungsweg = (String) Einstellungen
-            .getEinstellung(Property.RECHNUNGTEXTUEBERWEISUNG);
-        break;
-    }
-    try
-    {
-      zahlungsweg = VelocityTool.eval(map, zahlungsweg);
-    }
-    catch (IOException e)
-    {
-      e.printStackTrace();
-    }
-    map.put(MitgliedVar.ZAHLUNGSWEGTEXT.getName(), zahlungsweg);
-
     DBIterator<Felddefinition> itfd = Einstellungen.getDBService()
         .createList(Felddefinition.class);
     while (itfd.hasNext())
@@ -467,8 +433,6 @@ public class MitgliedMap extends AbstractMap
     map.put(MitgliedVar.ZAHLUNGSTERMIN.getName(),
         Zahlungstermin.HALBJAEHRLICH4.toString());
     map.put(MitgliedVar.ZAHLUNGSWEG.getName(), "2");
-    map.put(MitgliedVar.ZAHLUNGSWEGTEXT.getName(),
-        "Bitte überweisen Sie den Betrag auf das angegebene Konto.");
     map.put(MitgliedVar.ZAHLERID.getName(), "123456");
     map.put(MitgliedVar.ALTERNATIVER_ZAHLER.getName(), "123456");
 

--- a/src/de/jost_net/JVerein/Variable/MitgliedVar.java
+++ b/src/de/jost_net/JVerein/Variable/MitgliedVar.java
@@ -104,7 +104,6 @@ public enum MitgliedVar
   ZAHLUNGSRHYTHMUS("mitglied_zahlungsrhythmus"), //
   ZAHLUNGSTERMIN("mitglied_zahlungstermin"), //
   ZAHLUNGSWEG("mitglied_zahlungsweg"), //
-  ZAHLUNGSWEGTEXT("mitglied_zahlungsweg_text"), //
   ZAHLERID("mitglied_zahlerid"),
   ALTERNATIVER_ZAHLER("mitglied_alternativer_zahlerid");
 

--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -223,10 +223,8 @@ public class RechnungMap extends AbstractMap
     }
     try
     {
-      Map<String, Object> zwMap = new MitgliedMap().getMap(re.getMitglied(),
-          null);
-      new AllgemeineMap().getMap(zwMap);
-      zahlungsweg = VelocityTool.eval(zwMap, zahlungsweg);
+      zahlungsweg = VelocityTool.eval(new AllgemeineMap().getMap(map),
+          zahlungsweg);
     }
     catch (IOException e)
     {

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import java.util.Map;
 
 import de.jost_net.JVerein.Variable.AllgemeineMap;
-import de.jost_net.JVerein.Variable.MitgliedMap;
+import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.control.EinstellungControl;
@@ -64,7 +64,7 @@ public class EinstellungenRechnungenView extends AbstractView
     cont.addLabelPair("Beschreibungstext für QR-Code",
         control.getQRCodeIntro());
 
-    Map<String, Object> map = MitgliedMap.getDummyMap(null);
+    Map<String, Object> map = RechnungMap.getDummyMap(null);
     map = new AllgemeineMap().getMap(map);
 
     ButtonArea buttons = new ButtonArea();


### PR DESCRIPTION
Der Zahlungsweg Text wird bei der MitgliedMap und der RechnungMap geparst. Da wird jetzt beides mal einheitlich die MitgliedMap und die AllgemeineMap verwendet. So kann der Text an beiden Orten gleich verwendet werden.