### PR TITLE
In Mitglied Spalte bei Buchung auch Sollbuchung Id anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1734,9 +1734,9 @@ public class BuchungsControl extends VorZurueckControl implements Savable
         }
       }
       if (geldkonto)
-        buchungsList.addColumn(new Column(Buchung.SOLLBUCHUNG, "Mitglied",
-            new SollbuchungFormatter(), false, Column.ALIGN_AUTO,
-            Column.SORT_BY_DISPLAY));
+        buchungsList.addColumn(new Column(Buchung.SOLLBUCHUNG,
+            "Mitglied - Sollbuchung", new SollbuchungFormatter(), false,
+            Column.ALIGN_AUTO, Column.SORT_BY_DISPLAY));
       if ((Boolean) Einstellungen.getEinstellung(Property.PROJEKTEANZEIGEN))
       {
         buchungsList.addColumn("Projekt", "projekt");
@@ -1833,7 +1833,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
           }, false, Column.ALIGN_RIGHT);
         }
       }
-      splitbuchungsList.addColumn("Mitglied", Buchung.SOLLBUCHUNG,
+      splitbuchungsList.addColumn("Mitglied - Sollbuchung", Buchung.SOLLBUCHUNG,
           new SollbuchungFormatter());
       if ((Boolean) Einstellungen.getEinstellung(Property.PROJEKTEANZEIGEN))
       {

--- a/src/de/jost_net/JVerein/gui/formatter/SollbuchungFormatter.java
+++ b/src/de/jost_net/JVerein/gui/formatter/SollbuchungFormatter.java
@@ -37,11 +37,13 @@ public class SollbuchungFormatter implements Formatter
         if ((Boolean) Einstellungen
             .getEinstellung(Property.MITGLIEDSNUMMERANZEIGEN))
         {
-          return Adressaufbereitung.getIdNameVorname(sollb.getMitglied());
+          return Adressaufbereitung.getIdNameVorname(sollb.getMitglied())
+              + " - " + sollb.getID();
         }
         else
         {
-          return Adressaufbereitung.getNameVorname(sollb.getMitglied());
+          return Adressaufbereitung.getNameVorname(sollb.getMitglied()) + " - "
+              + sollb.getID();
         }
       }
       catch (RemoteException e)

--- a/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
@@ -91,7 +91,8 @@ public class BuchungListPart extends BuchungListTablePart
         return "";
       }, false, Column.ALIGN_RIGHT);
     }
-    addColumn("Mitglied", Buchung.SOLLBUCHUNG, new SollbuchungFormatter());
+    addColumn("Mitglied - Sollbuchung", Buchung.SOLLBUCHUNG,
+        new SollbuchungFormatter());
     addColumn("Ersatz für Aufwendungen", "verzicht", new JaNeinFormatter());
     setContextMenu(menu);
     setRememberColWidths(true);

--- a/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
@@ -79,7 +79,7 @@ public class BuchungListeView extends AbstractView
     center.addLabelPair("Datum bis", control.getBisdatum());
     center.addLabelPair("Nur ungeprüfte", control.getUngeprueft());
     right.addLabelPair("Enthaltener Text", control.getSuchtext());
-    right.addLabelPair("Mitglied zugeordnet?",
+    right.addLabelPair("Mitglied zugeordnet",
         control.getSuchMitgliedZugeordnet());
     right.addLabelPair("Mitglied Name", control.getMitglied());
     if ((Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))


### PR DESCRIPTION
Gerade beim Test des Gutschrift Feature habe ich gesehen, dass in der Mitglied Spalte der Buchung ja eigentlich die Sollbuchung referenziert wird. Man sieht hier aber nur den Mitgliednamen. Wenn jetzt viele Splitbuchungen existieren sieht man eigentlich nicht ob beim gleichen Namen auch die gleiche Sollbuchung dahinter steckt.

Ich habe jetzt die Spaltenüberschrift in "Mitglied - Sollbuchung" geändert und füge im Eintrag die Sollbuchung Id hinzu. So kann man sehen ob es sich um unterschiedliche Sollbuchungen handelt.

Hier ein Beispiel für eine gesplittete Buchung, bei der es das gleiche Mitglied ist, aber die Splitbuchungen auf unterschiedliche Sollbuchungen verweisen.

<img width="335" height="107" alt="Bildschirmfoto_20260224_164038" src="https://github.com/user-attachments/assets/c1d76b87-25c9-464b-b9ae-d9179db37bf5" />

PS: Im Filter Bereich habe ich bei "Mitglied zugeordnet?" das Fragezeichen entfernt. Das haben wir sonst auch nirgends dabei.