### PR TITLE
Fix Mail Text Vorschau Dialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
+++ b/src/de/jost_net/JVerein/gui/action/MailTextVorschauAction.java
@@ -16,6 +16,7 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.action;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import de.jost_net.JVerein.gui.control.IMailControl;
@@ -33,7 +34,7 @@ public class MailTextVorschauAction implements Action
   public MailTextVorschauAction(Map<String, Object> map, boolean mitMitglied)
   {
     super();
-    this.map = map;
+    this.map = new HashMap<String, Object>(map);
     this.mitMitglied = mitMitglied;
   }
 


### PR DESCRIPTION
Im Mail-Text-Vorschau Dialog wurde die übergebene Map geändert. Das führte dazu, dass beim anschliesenden Öffnen des Variable Auswahl Dialog nicht mehr die Mitglied DummyMap verwendet wurde sondern die Daten des letzten Mitglieds. Nun wird eine Kopie erzeugt und nicht das Original geändert.