### PR TITLE
Fix boolean query

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -429,7 +429,7 @@ public class JahresabschlussControl extends KontensaldoControl
           Double betrag = 0d;
           it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
           it.addFilter("konto = ?", konto.getID());
-          it.addFilter("buchungsart.abschreibung IS NOT TRUE");
+          it.addFilter("IFNULL(buchungsart.abschreibung, 0) IS FALSE");
           it.addFilter("datum <= ?", bisgj);
           it.addColumn("sum(buchung.betrag) as summe");
           PseudoDBObject o = it.next();

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
@@ -309,7 +309,7 @@ public class BuchungsartZuordnungDialog extends AbstractDialog<Buchungsart>
     stliste.add(stloeschen);
     DBIterator<Steuer> it = Einstellungen.getDBService()
         .createList(Steuer.class);
-    it.addFilter("aktiv IS TRUE");
+    it.addFilter("IFNULL(aktiv, 1) IS TRUE");
     while (it.hasNext())
     {
       stliste.add(it.next());

--- a/src/de/jost_net/JVerein/gui/input/BuchungsartInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsartInput.java
@@ -71,7 +71,7 @@ public class BuchungsartInput
             sql += "AND (konto.aufloesung IS NULL OR "
                 + "(konto.aufloesung >= ? AND konto.aufloesung <= ?)) ";
             sql += "AND buchungsart.status = ?) OR buchungsart.status = ?) ";
-            sql += "AND (buchungsart.abschreibung IS NOT TRUE) ";
+            sql += "AND (IFNULL(buchungsart.abschreibung, 0) IS FALSE) ";
           }
           else if (art == buchungsarttyp.AFAART)
           {
@@ -129,7 +129,7 @@ public class BuchungsartInput
           it.addFilter("buchungsart.status != ?", StatusBuchungsart.INACTIVE);
           if (art == buchungsarttyp.ANLAGENART)
           {
-            it.addFilter("buchungsart.abschreibung IS NOT TRUE");
+            it.addFilter("IFNULL(buchungsart.abschreibung, 0) IS FALSE");
           }
           else if (art == buchungsarttyp.AFAART)
           {

--- a/src/de/jost_net/JVerein/gui/input/BuchungsartSearchInput.java
+++ b/src/de/jost_net/JVerein/gui/input/BuchungsartSearchInput.java
@@ -81,7 +81,7 @@ public class BuchungsartSearchInput extends SearchInput
           sql += "AND (konto.aufloesung IS NULL OR "
               + "(konto.aufloesung >= ? AND konto.aufloesung <= ?)) ";
           sql += "AND buchungsart.status = ?) OR buchungsart.status = ?) ";
-          sql += "AND (buchungsart.abschreibung IS NOT TRUE ";
+          sql += "AND (IFNULL(buchungsart.abschreibung, 0) IS FALSE ";
         }
         else if (art == buchungsarttyp.AFAART)
         {
@@ -155,7 +155,7 @@ public class BuchungsartSearchInput extends SearchInput
         result.addFilter("buchungsart.status != ?", StatusBuchungsart.INACTIVE);
         if (art == buchungsarttyp.ANLAGENART)
         {
-          result.addFilter("buchungsart.abschreibung IS NOT TRUE");
+          result.addFilter("IFNULL(buchungsart.abschreibung, 0) IS FALSE");
         }
         else if (art == buchungsarttyp.AFAART)
         {

--- a/src/de/jost_net/JVerein/io/MitgliederImport.java
+++ b/src/de/jost_net/JVerein/io/MitgliederImport.java
@@ -322,7 +322,7 @@ public class MitgliederImport implements Importer
             DBIterator<Beitragsgruppe> it = Einstellungen.getDBService()
                 .createList(Beitragsgruppe.class);
             it.addFilter("bezeichnung = ?", beitragsgruppe);
-            it.addFilter("sekundaer IS NOT TRUE");
+            it.addFilter("IFNULL(sekundaer, 0) IS FALSE");
             if (!it.hasNext())
               throw new ApplicationException("Zeile " + anz
                   + ": Beitragsgruppe nicht gefunden: " + beitragsgruppe);


### PR DESCRIPTION
In https://jverein-forum.de/viewtopic.php?t=7585 gab es ein Problem bei einem DB Query mit der Abfrage auf = false. Diese geht bei NULL schief.
Da wir momentan aber NULL bei boolean erlauben, oft als Default in der DB haben und diese nach false am GUI mappen wird oft auch später kein false in die DB geschrieben.

Ich habe das Query geändert so dass ich statt auf false auf NOT TRUE abfrage, das beinhaltet FALSE und NULL.

Ich habe dann sicherheitshalber auch noch andere Stellen geändert.