### PR TITLE
Fix Konto Speichern Exception

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -303,7 +303,7 @@ public class KontoControl extends FilterControl implements Savable
     {
       String fehler = "Fehler beim Speichern des Kontos";
       Logger.error(fehler, e);
-      GUI.getStatusBar().setErrorText(fehler);
+      throw new ApplicationException(fehler);
     }
   }
 

--- a/src/de/jost_net/JVerein/server/KontoImpl.java
+++ b/src/de/jost_net/JVerein/server/KontoImpl.java
@@ -87,23 +87,7 @@ public class KontoImpl extends AbstractJVereinDBObject implements Konto
   @Override
   protected void insertCheck() throws ApplicationException
   {
-    try
-    {
-      plausi();
-      DBIterator<Konto> it = Einstellungen.getDBService()
-          .createList(Konto.class);
-      it.addFilter("nummer = ?", new Object[] { getNummer() });
-      if (it.size() > 0)
-      {
-        throw new ApplicationException("Konto existiert bereits");
-      }
-    }
-    catch (RemoteException e)
-    {
-      Logger.error("insert check of konto failed", e);
-      throw new ApplicationException(
-          "Konto kann nicht gespeichert werden. Siehe system log");
-    }
+    plausi();
   }
 
   @Override
@@ -168,6 +152,18 @@ public class KontoImpl extends AbstractJVereinDBObject implements Konto
             throw new ApplicationException("Bitte Afa Folgejahre eingeben");
           }
         }
+      }
+      DBIterator<Konto> it = Einstellungen.getDBService()
+          .createList(Konto.class);
+      it.addFilter("nummer = ?", getNummer());
+      if (getID() != null)
+      {
+        it.addFilter("id != ?", getID());
+      }
+      if (it.size() > 0)
+      {
+        throw new ApplicationException(
+            "Konto mit dieser Nummer existiert bereits");
       }
     }
     catch (RemoteException e)


### PR DESCRIPTION
Wenn es beim Konto speichern zu einem Fehler kam, wurde trotzdem "Gespeichert" angezeigt. Hier muss eine ApplicationException geworfen werden.
Außerdem habe ich den plausi Test geändert, so dass auch bei vorhandenen Konten geprüft wird, ob die Kontonummer bereits existiert.