### PR TITLE
Fix Anlagenverzeichnis Summen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -270,8 +270,8 @@ public class AnlagenlisteControl extends AbstractSaldoControl
         PseudoDBObject saldo = new PseudoDBObject();
         saldo.setAttribute(ART, ART_SALDOFOOTER);
         saldo.setAttribute(GRUPPE, "Saldo " + klasseAlt);
-        saldo.setAttribute(EINNAHMEN, summeStartwert);
-        saldo.setAttribute(AUSGABEN, summeZugang);
+        saldo.setAttribute(STARTWERT, summeStartwert);
+        saldo.setAttribute(ZUGANG, summeZugang);
         saldo.setAttribute(ABSCHREIBUNG, summeAbschreibung);
         saldo.setAttribute(ABGANG, summeAbgang);
         saldo.setAttribute(ENDWERT, summeEndwert);


### PR DESCRIPTION
In der Anlagenliste wurden bei Anlagegütern in verschiedenen Buchungsklassen bei der ersten Klasse nicht alle Summen angezeigt. Die Einträge wurden mit einem falschen Key eingefügt.