### PR TITLE
Fix Buchungs Detail View Spenden ggf. ausblenden

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -355,7 +355,10 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     b.setZweck((String) getZweck().getValue());
     b.setDatum((Date) getDatum().getValue());
     b.setArt((String) getArt().getValue());
-    b.setVerzicht((Boolean) getVerzicht().getValue());
+    if (verzicht != null)
+    {
+      b.setVerzicht((Boolean) getVerzicht().getValue());
+    }
     b.setKommentar((String) getKommentar().getValue());
     b.setSollbuchung((Sollbuchung) getSollbuchungInput().getValue());
     b.setGeprueft((Boolean) getGeprueft().getValue());
@@ -363,12 +366,21 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     {
       b.setSteuer((Steuer) getSteuer().getValue());
     }
-    b.setBezeichnungSachzuwendung(
-        (String) getBezeichnungSachzuwendung().getValue());
-    HerkunftSpende hsp = (HerkunftSpende) getHerkunftSpende().getValue();
-    b.setHerkunftSpende(hsp.getKey());
-    b.setUnterlagenWertermittlung(
-        (Boolean) getUnterlagenWertermittlung().getValue());
+    if (bezeichnungsachzuwendung != null)
+    {
+      b.setBezeichnungSachzuwendung(
+          (String) getBezeichnungSachzuwendung().getValue());
+    }
+    if (herkunftspende != null)
+    {
+      HerkunftSpende hsp = (HerkunftSpende) getHerkunftSpende().getValue();
+      b.setHerkunftSpende(hsp.getKey());
+    }
+    if (unterlagenwertermittlung != null)
+    {
+      b.setUnterlagenWertermittlung(
+          (Boolean) getUnterlagenWertermittlung().getValue());
+    }
     return b;
   }
 

--- a/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -111,15 +111,19 @@ public class BuchungPart implements Part
     grBuchungsinfos.addLabelPair("Sollbuchung", control.getSollbuchungInput());
     grBuchungsinfos.addLabelPair("Geprüft", control.getGeprueft());
 
-    SimpleContainer grSpendeninfos = grBuchungsinfos;
-    grSpendeninfos.addHeadline("Geldspende");
-    grSpendeninfos.addLabelPair("Erstattungsverzicht", control.getVerzicht());
-    grSpendeninfos.addHeadline("Sachspende");
-    grSpendeninfos.addLabelPair("Bezeichnung Sachzuwendung",
-        control.getBezeichnungSachzuwendung());
-    grSpendeninfos.addLabelPair("Herkunft", control.getHerkunftSpende());
-    grSpendeninfos.addLabelPair("Unterlagen Wertermittlung",
-        control.getUnterlagenWertermittlung());
+    if ((Boolean) Einstellungen
+        .getEinstellung(Property.SPENDENBESCHEINIGUNGENANZEIGEN))
+    {
+      SimpleContainer grSpendeninfos = grBuchungsinfos;
+      grSpendeninfos.addHeadline("Geldspende");
+      grSpendeninfos.addLabelPair("Erstattungsverzicht", control.getVerzicht());
+      grSpendeninfos.addHeadline("Sachspende");
+      grSpendeninfos.addLabelPair("Bezeichnung Sachzuwendung",
+          control.getBezeichnungSachzuwendung());
+      grSpendeninfos.addLabelPair("Herkunft", control.getHerkunftSpende());
+      grSpendeninfos.addLabelPair("Unterlagen Wertermittlung",
+          control.getUnterlagenWertermittlung());
+    }
 
     if (JVereinPlugin.isArchiveServiceActive())
     {


### PR DESCRIPTION
Im Buchung Detailview blende ich die Spendenrelevanten Einträge aus, wenn in den Einstellungen Spendenbescheinigung deaktiviert ist.