### PR TITLE
Fix Migration

### DIFF
--- a/src/de/jost_net/JVerein/io/Migration.java
+++ b/src/de/jost_net/JVerein/io/Migration.java
@@ -311,6 +311,8 @@ public class Migration
       {
         Eigenschaft eigenschaftneu = (Eigenschaft) Einstellungen.getDBService()
             .createObject(Eigenschaft.class, null);
+        eigenschaftneu
+            .setName(eigenschaft.toLowerCase().replaceAll("[^a-z0-9_]", "_"));
         eigenschaftneu.setBezeichnung(eigenschaft);
         String id = HM_eigenschaftsgruppen.get(groupName);
         if (id != null) // no entry for this groupName
@@ -465,6 +467,7 @@ public class Migration
       /* create a default property group */
       eigenschaftgruppe = (EigenschaftGruppe) Einstellungen.getDBService()
           .createObject(EigenschaftGruppe.class, null);
+      eigenschaftgruppe.setName("noch_nicht_zugeordnet");
       eigenschaftgruppe.setBezeichnung("Noch nicht zugeordnet");
       eigenschaftgruppe.store();
 
@@ -489,6 +492,8 @@ public class Migration
 
           eigenschaftgruppe = (EigenschaftGruppe) Einstellungen.getDBService()
               .createObject(EigenschaftGruppe.class, null);
+          eigenschaftgruppe
+              .setName(groupName.toLowerCase().replaceAll("[^a-z0-9_]", "_"));
           eigenschaftgruppe.setBezeichnung(groupName);
           eigenschaftgruppe.store();
           HM_eigenschaftsgruppen.put(groupName, eigenschaftgruppe.getID());


### PR DESCRIPTION
Wie im Forum berichtet kommt es in der 4.0 bei der Migration zu der Fehlermeldung "Bitte Name eingeben!".

Dies liegt daran, dass wir bei Eigenschaftgruppe und Eigenschaft das Attribut Name eingeführt haben. Die wird aber bisher bei der Migration nicht gesetzt. Ich habe das jetzt korrigiert.

Dann sind auch noch die Sample Daten in der Help falsch. Ich werde diese auch korrigieren.