### PR TITLE
Fix Einstellungen Mitglieder Ansicht speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2970,7 +2970,7 @@ public class EinstellungControl extends AbstractControl
           (Boolean) getZeigeMitgliedschaftInTabCheckbox().getValue());
       Einstellungen.setSettingBoolean("ZeigeZahlungInTab",
           (Boolean) getZeigeZahlungInTabCheckbox().getValue());
-      Einstellungen.setSettingBoolean("ZeigeZusatzbetrageInTab",
+      Einstellungen.setSettingBoolean("ZeigeZusatzbetraegeInTab",
           (Boolean) getZeigeZusatzbetrageInTabCheckbox().getValue());
       Einstellungen.setSettingBoolean("ZeigeMitgliedskontoInTab",
           (Boolean) getZeigeMitgliedskontoInTabCheckbox().getValue());
@@ -2980,7 +2980,7 @@ public class EinstellungControl extends AbstractControl
           (Boolean) getZeigeWiedervorlageInTabCheckbox().getValue());
       Einstellungen.setSettingBoolean("ZeigeMailsInTab",
           (Boolean) getZeigeMailsInTabCheckbox().getValue());
-      Einstellungen.setSettingBoolean("ZeigeEigentschaftenInTab",
+      Einstellungen.setSettingBoolean("ZeigeEigenschaftenInTab",
           (Boolean) getZeigeEigenschaftenInTabCheckbox().getValue());
       Einstellungen.setSettingBoolean("ZeigeZusatzfelderInTab",
           (Boolean) getZeigeZusatzfelderInTabCheckbox().getValue());


### PR DESCRIPTION
Beim Speichern der Mitglieder-Ansicht in den Einstellungen waren zwei Typos, so dass Eigenschaften und Zusatzbeträge nicht ohne Tab gewählt gespeichert wurden.