### PR TITLE
Fix Jahresabschluss Warnung

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -437,11 +437,13 @@ public class JahresabschlussControl extends KontensaldoControl
           {
             betrag = o.getDouble("summe");
           }
-          if (Math.abs(betrag - konto.getBetrag()) > Double.MIN_NORMAL)
+          if (Math.abs(betrag - konto.getBetrag()) >= 0.01d)
           {
             text += "Für das Anlagenkonto mit der Nummer " + konto.getNummer()
-                + " stimmt die Summe der Buchungen (" + betrag
-                + ") nicht mit den Anschaffungskosten (" + konto.getBetrag()
+                + " stimmt die Summe der Buchungen ("
+                + Einstellungen.DECIMALFORMAT.format(betrag)
+                + ") nicht mit den Anschaffungskosten ("
+                + Einstellungen.DECIMALFORMAT.format(konto.getBetrag())
                 + ") überein. Bitte auf Plausibilität prüfen!\n";
           }
         }


### PR DESCRIPTION
Beim Jahresabschluss war der Test der Anlagensumme falsch, es wurde jede Betragsdifferenz größer 2.22>E-308  ausgegeben, das brauchen wir aber nicht, es soll nur bei einer Differenz von mindestens einem Cent angezeigt werden.
Außerdem habe ich die Beträge formattiert.

Ich denke, es wäre sinnvoll, insgesamt bei alle Beträgen BigDecimal statt doulbe zu verwenden, damit wir nicht immer solche Rundungsprobleme haben.