### PR TITLE
Fix Zahlungstermin bei Abrechnungslauf

### DIFF
--- a/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
+++ b/src/de/jost_net/JVerein/io/AbrechnungSEPA.java
@@ -525,8 +525,8 @@ public class AbrechnungSEPA
     Mitglied mZahler = m.getZahler();
     if (((Integer) Einstellungen.getEinstellung(
         Property.BEITRAGSMODEL) == Beitragsmodel.FLEXIBEL.getKey())
-        && (mZahler.getZahlungstermin() != null && !mZahler.getZahlungstermin()
-            .isAbzurechnen(param.abrechnungsmonat)))
+        && (m.getZahlungstermin() != null
+            && !m.getZahlungstermin().isAbzurechnen(param.abrechnungsmonat)))
     {
       return null;
     }
@@ -536,8 +536,8 @@ public class AbrechnungSEPA
       betr = BeitragsUtil.getBeitrag(
           Beitragsmodel.getByKey(
               (Integer) Einstellungen.getEinstellung(Property.BEITRAGSMODEL)),
-          mZahler.getZahlungstermin(), mZahler.getZahlungsrhythmus(), bg,
-          param.stichtag, m);
+          m.getZahlungstermin(), m.getZahlungsrhythmus(), bg, param.stichtag,
+          m);
     }
     catch (NullPointerException e)
     {


### PR DESCRIPTION
Beim Abrechnungslauf wurde als Zahlungstermin und Zahlungsrythmus der des Zahlers verwendet. Mit der Änderung für den abweichenden Zahler sind jetzt auch Nicht-Mitglieder als Zahler für Beiträge möglich.

Nicht-Mitglieder haben aber keinen Zahlungstermin und Zahlungsrythmus. Damit wird das Mitglied nicht abgerechnet. Es gibt eine Exception mit der Info die Werte einzugeben, was bei Nicht-Mitglieder aber ncht möglich ist.

Mit dem Patch werden für Zahlungstermin und Zahlungsrythmus die Werte des Mitglieds verwendet. Ich denke das ist auch ok. Es sagt wann und wie das Mitglied seinen Beitrag bezahlen soll. Wer das dann bezahlt ist ja egal.

Ich denke das ist ein gravierender Fehler und wir brauchen dafür doch noch eine 4.0.4.