### PR TITLE
In MitgliedListeView Spalte "Zahler ID" in Vollzahler umbenannt

### DIFF
--- a/src/de/jost_net/JVerein/server/MitgliedImpl.java
+++ b/src/de/jost_net/JVerein/server/MitgliedImpl.java
@@ -1288,6 +1288,17 @@ public class MitgliedImpl extends AbstractJVereinDBObject implements Mitglied
         return "";
       }
     }
+    else if (fieldName.equals("vollzahlerstring"))
+    {
+      if (this.getVollZahler() != null)
+      {
+        return Adressaufbereitung.getNameVorname(this.getVollZahler());
+      }
+      else
+      {
+        return "";
+      }
+    }
     else if (fieldName.startsWith("zusatzfelder_"))
     {
       DBIterator<Felddefinition> it = Einstellungen.getDBService()

--- a/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
+++ b/src/de/jost_net/JVerein/util/MitgliedSpaltenauswahl.java
@@ -136,7 +136,7 @@ public class MitgliedSpaltenauswahl extends Spaltenauswahl
         new DateFormatter(new JVDateFormatTTMMJJJJ()), Column.ALIGN_AUTO,
         false);
     add("Leitweg ID", "leitwegid", false, true);
-    add("Zahler ID", "zahlerid", false, false);
+    add("Vollzahler", "vollzahlerstring", false, false);
     try
     {
       if ((Boolean) Einstellungen


### PR DESCRIPTION
Die Spalte "Zahler ID" war etwas missverständlich. Es handelt sich um den Vollzahler.

Ich habe die Spalte darum in Vollzahler umbenannt und statt der ID wird der Name des Vollzahlers ausgegeben, ähnlich wie bei "Abweichender Zahler".