### PR TITLE
Jahr Auswahl bei automatischer Spendenbescheinigung bei Mitglied

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungNeuAction.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.control.MitgliedskontoNode;
+import de.jost_net.JVerein.gui.dialogs.JahrAuswahlDialog;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.view.SpendenbescheinigungDetailView;
 import de.jost_net.JVerein.keys.HerkunftSpende;
@@ -40,6 +41,7 @@ import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -62,7 +64,7 @@ public class SpendenbescheinigungNeuAction implements Action
           .createObject(Spendenbescheinigung.class, null);
       spb.setBescheinigungsdatum(new Date());
 
-      if (context != null && (context instanceof Mitglied))
+      if (context instanceof Mitglied)
       {
         Mitglied m = (Mitglied) context;
         SpbAdressaufbereitung.adressaufbereitung(m, spb);
@@ -136,6 +138,26 @@ public class SpendenbescheinigungNeuAction implements Action
   private void handleMitglied(Mitglied mg)
       throws RemoteException, ApplicationException
   {
+    Integer jahr = null;
+    JahrAuswahlDialog d = new JahrAuswahlDialog(
+        JahrAuswahlDialog.POSITION_CENTER);
+    try
+    {
+      jahr = d.open();
+      if (jahr == null)
+      {
+        throw new OperationCanceledException();
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (Exception e)
+    {
+      throw new ApplicationException(e);
+    }
+
     /* Ermitteln der Buchungen zu der neuen Spendenbescheinigung */
     Date minDatum = Calendar.getInstance().getTime();
     Date maxDatum = Calendar.getInstance().getTime();
@@ -157,18 +179,19 @@ public class SpendenbescheinigungNeuAction implements Action
     String sql = "SELECT buchung.id  FROM buchung "
         + "  JOIN buchungsart ON buchung.buchungsart = buchungsart.id "
         + "  JOIN " + Sollbuchung.TABLE_NAME + " ON " + Buchung.T_SOLLBUCHUNG
-        + " = " + Sollbuchung.TABLE_NAME_ID
-        + " WHERE buchungsart.spende = true " + "  AND " + Sollbuchung.T_ZAHLER
+        + " = " + Sollbuchung.TABLE_NAME_ID + " WHERE year(buchung.datum) = ? "
+        + " AND buchungsart.spende = true " + "  AND " + Sollbuchung.T_ZAHLER
         + " = ? " + "  AND buchung.spendenbescheinigung IS NULL " + "  AND "
         + Buchung.T_SOLLBUCHUNG + " IS NOT NULL " + "ORDER BY buchung.datum";
     @SuppressWarnings("unchecked")
     ArrayList<Buchung> buchungen = (ArrayList<Buchung>) Einstellungen
-        .getDBService().execute(sql, new Object[] { mg.getID() }, rs);
+        .getDBService().execute(sql, new Object[] { jahr, mg.getID() }, rs);
 
     if (buchungen.isEmpty())
     {
       throw new ApplicationException(
-          "Es wurden keine relevanten Buchungen gefunden");
+          "Es wurden keine relevanten Buchungen für das Jahr " + jahr
+              + " gefunden");
     }
 
     for (Buchung bu : buchungen)

--- a/src/de/jost_net/JVerein/gui/dialogs/JahrAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/JahrAuswahlDialog.java
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.util.Calendar;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.system.OperationCanceledException;
+
+/**
+ * Ein Dialog, zur Auswahl eines Kalenderjahres.
+ */
+public class JahrAuswahlDialog extends AbstractDialog<Integer>
+{
+  private SelectInput jahr;
+
+  private Integer selectedJahr = null;
+
+  public JahrAuswahlDialog(int position)
+  {
+    super(position);
+    setTitle("Jahr auswählen");
+    setSize(250, SWT.DEFAULT);
+  }
+
+  @Override
+  protected void paint(Composite parent) throws Exception
+  {
+    LabelGroup group = new LabelGroup(parent, "");
+    group.addLabelPair("Jahr", getJahr());
+    ButtonArea b = new ButtonArea();
+    b.addButton("Übernehmen", c -> {
+      selectedJahr = (Integer) getJahr().getValue();
+      close();
+    }, null, false, "ok.png");
+    b.addButton("Abbrechen", c -> {
+      throw new OperationCanceledException();
+    }, null, false, "process-stop.png");
+    b.paint(parent);
+  }
+
+  @Override
+  protected Integer getData() throws Exception
+  {
+    return selectedJahr;
+  }
+
+  public SelectInput getJahr()
+  {
+    if (jahr != null)
+    {
+      return jahr;
+    }
+    Calendar cal = Calendar.getInstance();
+    jahr = new SelectInput(
+        new Object[] { cal.get(Calendar.YEAR), cal.get(Calendar.YEAR) - 1,
+            cal.get(Calendar.YEAR) - 2, cal.get(Calendar.YEAR) - 3,
+            cal.get(Calendar.YEAR) - 4, cal.get(Calendar.YEAR) - 5,
+            cal.get(Calendar.YEAR) - 6, cal.get(Calendar.YEAR) - 7 },
+        cal.get(Calendar.YEAR));
+    return jahr;
+  }
+}


### PR DESCRIPTION
Falls Spendenbescheinigung aus dem MitgliedMenu aufgerufen wurde wird jetzt das Jahr abgefragt für welches die relevanten Buchungen gesucht werden sollen.
<img width="253" height="142" alt="Bildschirmfoto_20260310_104217" src="https://github.com/user-attachments/assets/5eeec713-8173-4f64-b460-920f8d0ab1ae" />

Siehe auch im Forum https://jverein-forum.de/viewtopic.php?t=7591