### PR TITLE
Keine Mindestbetrag Prüfung bei Spendenbescheinigung bei Mitglied Auswahl

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungNeuAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungNeuAction.java
@@ -214,21 +214,6 @@ public class SpendenbescheinigungNeuAction implements Action
       spb.setFormular((Formular) FormularInput.initdefault(
           (String) Einstellungen.getEinstellung(Property.FORMULARGELDSPENDE)));
     }
-
-    // Nur Geldspenden
-    if (anzahlGeldspenden == buchungen.size())
-    {
-      double minbetrag = (Double) Einstellungen
-          .getEinstellung(Property.SPENDENBESCHEINIGUNGMINBETRAG);
-      if (spb.getBetrag() < minbetrag)
-      {
-        throw new ApplicationException(
-            String.format(
-                "Der Betrag der Spendenbescheinigung ist unter %s Euro. "
-                    + "Siehe Einstellungen->Spendenbescheinigungen.",
-                minbetrag));
-      }
-    }
   }
 
   private void generiereSpendenbescheinigung(Buchung b)


### PR DESCRIPTION
Falls die automatische Generierung einer Spendenbescheinigung über das Mitglied Menü gestartet wird, wird der Minimumcheck nicht mehr gemacht.