### PR TITLE
Anzahl Spalten auch bei Zahlungsweg berücksichtigen

### DIFF
--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -607,7 +607,7 @@ public abstract class AbstractMitgliedDetailView extends AbstractDetailView
     }
 
     SimpleVerticalContainer cols1 = new SimpleVerticalContainer(
-        zahlungsweg.getComposite(), false, 1);
+        zahlungsweg.getComposite(), false, spaltenanzahl);
 
     cols1.addInput(control.getZahlungsweg());
     if (isMitgliedDetail())


### PR DESCRIPTION
Beim MitgliedDetailView wurde im Tab Zahlung bei Zahlungsweg nicht die Einstellung für die Spaltenanzahl berücksichtigt.