### PR TITLE
Rechnung bei Optiert immer Summe anzeigen

### DIFF
--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -99,7 +99,7 @@ public class RechnungMap extends AbstractMap
         betrag.add(Einstellungen.DECIMALFORMAT.format(steuerMap.get(satz)));
       }
     }
-    if (buchungDatum.size() > 1)
+    if (buchungDatum.size() > 1 || steuerMap.size() > 0)
     {
       zweck.add("Summe");
       betrag.add(Einstellungen.DECIMALFORMAT.format(summe));


### PR DESCRIPTION
Ich habe einige Rechungen mit nur einer Position erstellt, und finde es immer komisch, wenn da keine Summe steht. Daher hier mein Vorschlag, bei steuerpflichtigen Positionen immer die Summe in der Rechnung auszugeben.