### PR TITLE
Fix ReleaseAction ordner in repository.xml erstellen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         if [ ! -d website/$path ];then
           mkdir -p website/$path
           #Add new directory in repository.xml
-          sed -i "s#<plugins name=\"OpenJVerein\" certificate=\"https://eickedorfer-hof.de/testrepro/openjverein.crt\">#\0\n<plugin url=\"https://openjverein.github.io/$path\"/>#" website/jameica-repository/repository.xml
+          sed -i "s#<plugins name=\"OpenJVerein\" [^>]*>#\0\n<plugin url=\"https://openjverein.github.io/$path\"/>#" website/jameica-repository/repository.xml
         fi
 
         cp "jverein/${{ steps.openjverein.outputs.selected_path }}" "website/$path/${{ steps.openjverein.outputs.selected_filename }}"


### PR DESCRIPTION
Das einfügen des neuen Ordners in repository.xml hat nicht automatisch geklappt. Daher hab ich die Action korrigiert.