### PR TITLE
Fix Spendenbescheinigung Druck

### DIFF
--- a/src/de/jost_net/JVerein/io/SpendenbescheinigungAusgabe.java
+++ b/src/de/jost_net/JVerein/io/SpendenbescheinigungAusgabe.java
@@ -738,7 +738,7 @@ public class SpendenbescheinigungAusgabe extends AbstractAusgabe
   protected void closeDocument(FormularAufbereitung formularaufbereitung,
       DBObject object) throws IOException, DocumentException
   {
-    if (object != null && ((Spendenbescheinigung) object).getFormular() != null)
+    if (rpt == null)
     {
       super.closeDocument(formularaufbereitung, object);
     }


### PR DESCRIPTION
Der Druck von individuellen Spendenbescheinigungen hatte nicht mehr geklappt.