### PR TITLE
Fix Projektsaldo SKR42

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
@@ -76,6 +76,8 @@ public abstract class AbstractSaldoControl extends VorZurueckControl
    */
   public static final String BUCHUNGSART = "buchungsart";
 
+  public static final String PROJEKT = "projekt";
+
   /**
    * Anfangsbestand der Konten.
    */

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -71,6 +71,16 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
    */
   protected String gruppenBezeichnung = "Buchnugsklasse";
 
+  /**
+   * Spalte die für die Gruppe verwendet wird. Default Buchungsklasse
+   */
+  protected String spalteGruppe = BUCHUNGSKLASSE;
+
+  /**
+   * Soll eine Buchungsklasse-Spalte angezeigt werden? Default false.
+   */
+  protected boolean mitBuchungsklasseSpalte = false;
+
   private SaldoListTablePart saldoList;
 
   /**
@@ -103,6 +113,10 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
         }
       };
       saldoList.addColumn(gruppenBezeichnung, GRUPPE, null, false);
+      if (mitBuchungsklasseSpalte)
+      {
+        saldoList.addColumn("Buchungsklasse", BUCHUNGSKLASSE);
+      }
       saldoList.addColumn("Buchungsart", BUCHUNGSART);
       saldoList.addColumn("Einnahmen", EINNAHMEN,
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
@@ -154,7 +168,7 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     {
       PseudoDBObject o = it.next();
 
-      String klasse = (String) o.getAttribute(BUCHUNGSKLASSE);
+      String klasse = (String) o.getAttribute(spalteGruppe);
       if (klasse == null || klasse.equals(" - ") || klasse.equals(" ()"))
       {
         klasse = "Nicht zugeordnet";

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -34,6 +34,8 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     super(view);
     gruppenBezeichnung = "Projekt";
     mitOhneBuchungsart = false;
+    mitBuchungsklasseSpalte = true;
+    spalteGruppe = PROJEKT;
   }
 
   @Override
@@ -41,11 +43,11 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
       throws RemoteException
   {
     // Den Iterator aus BuchungsklasseSaldo erweitern um nach Projekten statt
-    // nach Buchungsklassenzu gruppieren
+    // nach Buchungsklassen zu gruppieren
     ExtendedDBIterator<PseudoDBObject> it = super.getIterator();
 
-    // Wir überschreiben das "buchungsklasse" Feld mit dem Projektname
-    it.addColumn("projekt.bezeichnung as " + BUCHUNGSKLASSE);
+    it.addColumn("projekt.bezeichnung as " + PROJEKT);
+
     it.addGroupBy("projekt.id");
     it.addGroupBy("projekt.bezeichnung");
     String on = "projekt.id = buchung.projekt ";
@@ -58,14 +60,15 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
     {
       case BuchungsartSort.NACH_NUMMER:
-        it.setOrder(
-            "ORDER BY projekt.bezeichnung, buchungsart.nummer is null, buchungsart.nummer ");
+        it.setOrder("ORDER BY projekt.bezeichnung,"
+            + "buchungsklasse.nummer is NULL,buchungsklasse.nummer,"
+            + "buchungsart.nummer is null, buchungsart.nummer ");
         break;
       case BuchungsartSort.NACH_BEZEICHNUNG:
       default:
-        it.setOrder(
-            "ORDER BY projekt.bezeichnung, buchungsart.bezeichnung is NUll,"
-                + "buchungsart.bezeichnung ");
+        it.setOrder("ORDER BY projekt.bezeichnung,"
+            + "buchungsklassse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+            + "buchungsart.bezeichnung is NUll, buchungsart.bezeichnung ");
         break;
     }
     return it;


### PR DESCRIPTION
Im Projektsaldo konnte es bei SKR42 vorkommen, dass eine Buchungsart mehrfach vorkommt, ohne dass man sieht, zu welcher Buchungsklasse sie gehört. Daher habe ich dort eine Buchungsklasse Spalte hinzugefügt.