### PR TITLE
Fix SQL Projektsaldo

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -67,7 +67,7 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
       case BuchungsartSort.NACH_BEZEICHNUNG:
       default:
         it.setOrder("ORDER BY projekt.bezeichnung,"
-            + "buchungsklassse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
+            + "buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
             + "buchungsart.bezeichnung is NUll, buchungsart.bezeichnung ");
         break;
     }


### PR DESCRIPTION
Im Sql vom Projectsaldo ist ein Typo, der Trat nur bei Sortierung nach Name auf und hatten wir beim Testen nicht gesehen.