### PR TITLE
Abhängingkeit Jameica 2.12 in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,8 +40,8 @@
     <consumer queue="jverein.dbobject.store" class="de.jost_net.JVerein.Messaging.MarkOverdueMessageConsumer" />
   </messaging>
   
-  <requires jameica="2.8+">
-    <import plugin="hibiscus" version="2.8.7+"/>
+  <requires jameica="2.12+">
+    <import plugin="hibiscus" version="2.12+"/>
   </requires>
 
 </plugin>


### PR DESCRIPTION
Durch die Dialog-Modeless Änderungen ist eine Abhängigkeit zu jameica 2.12.x entstanden. Diese ist nun im plugin.xml eingetragen, so dass Jverein 4.1.x wirklich nur bei jameica 2.12.x installiert werden kann.