### PR TITLE
Fix Altersgruppenparser und Default Einstellungen

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -347,7 +347,7 @@ public class Einstellungen
 
     // Statistik
     ALTERSGRUPPEN("altersgruppen", String.class,
-        "1-5,6-10,11-17,18-25,26-50,50-100"),
+        "1-5,6-10,11-17,18-25,26-50,51-100"),
     JUBILARSTARTALTER("jubilarstartalter", Integer.class, "0"),
     JUBILAEEN("jubilaeen", String.class, "10,25,40,50"),
     ALTERSJUBILAEEN("altersjubilaeen", String.class,

--- a/src/de/jost_net/JVerein/io/AltersgruppenParser.java
+++ b/src/de/jost_net/JVerein/io/AltersgruppenParser.java
@@ -64,7 +64,7 @@ public class AltersgruppenParser
             "Fehler in den Altergruppen" + " " + e.getMessage());
       }
     }
-    for (int i = 0; i < 100; i++)
+    for (int i = 1; i < 100; i++)
     {
       boolean found = false;
       for (VonBis vb : elemente)


### PR DESCRIPTION
Die 50 war in zwei Altersgruppen in den Einstellungen und der Check hatte bei 0 begonnen obwohl die Altersgruppen bei 1 starten.