### PR TITLE
Cent Beträge in Worten in Spendenbescheinigunung

### DIFF
--- a/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
+++ b/src/de/jost_net/JVerein/Variable/SpendenbescheinigungMap.java
@@ -116,10 +116,20 @@ public class SpendenbescheinigungMap extends AbstractMap
           value = Einstellungen.DECIMALFORMAT.format(spb.getBetrag());
           break;
         case BETRAGINWORTEN:
+          Double ganzbetrag = spb.getBetrag() * 100;
+          long euro = spb.getBetrag().longValue();
+          long cent = ganzbetrag.longValue() - 100 * euro;
           try
           {
-            value = "-" + GermanNumber.toString(spb.getBetrag().longValue())
-                + "-";
+            String wort = GermanNumber.toString(euro);
+            if (cent == 0)
+            {
+              value = "-" + wort + "-";
+            }
+            else
+            {
+              value = "-" + wort + " Euro " + GermanNumber.toString(cent) + "-";
+            }
           }
           catch (Exception e)
           {


### PR DESCRIPTION
Siehe  #1411 

Ich habe gelesen, dass man "Cent" am Ende auch weg lassen kann. Ich habe es weg gelassen, damit der Text nicht zu lang wird.
<img width="642" height="39" alt="Bildschirmfoto_20260326_175841" src="https://github.com/user-attachments/assets/46073079-a76c-40ab-999b-c6f36d01ba6c" />

