### PR TITLE
Spendenbescheinigung anzeigen im Buchung Menü

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAnzeigenAction.java
+++ b/src/de/jost_net/JVerein/gui/action/SpendenbescheinigungAnzeigenAction.java
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.SpendenbescheinigungDetailView;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.Spendenbescheinigung;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.util.ApplicationException;
+
+public class SpendenbescheinigungAnzeigenAction implements Action
+{
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    Spendenbescheinigung spb = null;
+    try
+    {
+      if (context instanceof Buchung)
+      {
+        spb = ((Buchung) context).getSpendenbescheinigung();
+      }
+      else
+      {
+        throw new ApplicationException("Keine Buchung ausgewählt");
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      throw oce;
+    }
+    catch (Exception e)
+    {
+      throw new ApplicationException(
+          "Fehler bei der Anzeige einer Spendenbescheinigung", e);
+    }
+    if (spb != null)
+    {
+      GUI.startView(SpendenbescheinigungDetailView.class, spb);
+    }
+    else
+    {
+      throw new ApplicationException(
+          "Die ausgewählte Buchung hat keine Spendenbescheinigung");
+    }
+  }
+}

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -32,6 +32,7 @@ import de.jost_net.JVerein.gui.action.BuchungProjektZuordnungAction;
 import de.jost_net.JVerein.gui.action.BuchungSollbuchungZuordnungAction;
 import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.SollbuchungEditAction;
+import de.jost_net.JVerein.gui.action.SpendenbescheinigungAnzeigenAction;
 import de.jost_net.JVerein.gui.action.SpendenbescheinigungNeuAction;
 import de.jost_net.JVerein.gui.action.SplitBuchungAction;
 import de.jost_net.JVerein.gui.action.SplitbuchungBulkAufloesenAction;
@@ -90,24 +91,29 @@ public class BuchungMenu extends ContextMenu
           new MitgliedDetailAction(), "user-friends.png"));
       addItem(new MitgliedOeffnenItem("Sollbuchung anzeigen",
           new SollbuchungEditAction(), "calculator.png"));
-      if ((Boolean) Einstellungen.getEinstellung(Property.ANLAGENKONTEN))
-      {
-        addItem(new SingleGegenBuchungItem("Neues Anlagenkonto",
-            new AnlagenkontoNeuAction(), "document-new.png"));
-      }
     }
     try
     {
       if ((Boolean) Einstellungen
           .getEinstellung(Property.SPENDENBESCHEINIGUNGENANZEIGEN))
       {
-        addItem(new SpendenbescheinigungMenuItem("Spendenbescheinigung",
+        addItem(new SpendenbescheinigungAnzeigenMenuItem(
+            "Spendenbescheinigung anzeigen",
+            new SpendenbescheinigungAnzeigenAction(), "file-invoice.png"));
+        addItem(new SpendenbescheinigungErstellenMenuItem(
+            "Spendenbescheinigung erstellen",
             new SpendenbescheinigungNeuAction(), "file-invoice.png"));
       }
     }
     catch (RemoteException e)
     {
       // Dann nicht
+    }
+    if (geldkonto
+        && (Boolean) Einstellungen.getEinstellung(Property.ANLAGENKONTEN))
+    {
+      addItem(new SingleGegenBuchungItem("Neues Anlagenkonto",
+          new AnlagenkontoNeuAction(), "document-new.png"));
     }
     String text = "Buchungsart zuordnen";
     try
@@ -387,10 +393,38 @@ public class BuchungMenu extends ContextMenu
     }
   }
 
-  private static class SpendenbescheinigungMenuItem
+  private static class SpendenbescheinigungAnzeigenMenuItem
       extends CheckedSingleContextMenuItem
   {
-    private SpendenbescheinigungMenuItem(String text, Action action,
+    private SpendenbescheinigungAnzeigenMenuItem(String text, Action action,
+        String icon)
+    {
+      super(text, action, icon);
+    }
+
+    @Override
+    public boolean isEnabledFor(Object o)
+    {
+      try
+      {
+        if (o instanceof Buchung)
+        {
+          Buchung b = (Buchung) o;
+          return b.getSpendenbescheinigung() != null;
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+      }
+      return false;
+    }
+  }
+
+  private static class SpendenbescheinigungErstellenMenuItem
+      extends CheckedSingleContextMenuItem
+  {
+    private SpendenbescheinigungErstellenMenuItem(String text, Action action,
         String icon)
     {
       super(text, action, icon);


### PR DESCRIPTION
Ich habe im Menü der Buchung die Option Spendenbescheinigung anzeigen eingefügt. Es ist enabled wenn für die Buchung eine Spendenbescheinigung existiert.
Den Eintrag "Spendenbescheinigung" habe ich in "Spendenbescheinigung erstellen" umbenannt.

<img width="219" height="146" alt="Bildschirmfoto_20260327_111847" src="https://github.com/user-attachments/assets/a56ebb8b-bf18-4e26-b410-c3ef9170ecb5" />
