### PR TITLE
Fix Saldo bei Projekten und manueller Steuer

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
@@ -71,12 +71,32 @@ public abstract class AbstractSaldoControl extends VorZurueckControl
    */
   public static final String BUCHUNGSKLASSE = "buchungsklasse";
 
+  public static final String BUCHUNGSKLASSE_NUMMER = "buchungsklasse_nummer";
+
+  public static final String BUCHUNGSKLASSE_ID = "buchungsklasse_id";
+
+  /**
+   * Buchungsklasse Text der angezeigt werden soll
+   */
+  public static final String BUCHUNGSKLASSE_TEXT = "buchungsklasse_text";
+
   /**
    * Die Buchungsart aus der DB.
    */
   public static final String BUCHUNGSART = "buchungsart";
 
+  public static final String BUCHUNGSART_NUMMER = "buchungsart_nummer";
+
+  public static final String BUCHUNGSART_ID = "buchungsart_id";
+
+  /**
+   * Buchungsart Text der angezeigt werden soll
+   */
+  public static final String BUCHUNGSART_TEXT = "buchungsart_text";
+
   public static final String PROJEKT = "projekt";
+
+  public static final String PROJEKT_ID = "projekt_id";
 
   /**
    * Anfangsbestand der Konten.

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -434,9 +434,14 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       it.addColumn("COALESCE(SUM(buchung.betrag),0) AS " + SUMME);
     }
 
-    it.leftJoin("buchung",
-        "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?",
-        getDatumvon().getDate(), getDatumbis().getDate());
+    String buchungOn = "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?";
+    // Bei Projektsaldo nur Buchungen verwenden, die auch ein Projekt haben
+    if (this instanceof ProjektSaldoControl)
+    {
+      buchungOn += " and buchung.projekt is not null";
+    }
+    it.leftJoin("buchung", buchungOn, getDatumvon().getDate(),
+        getDatumbis().getDate());
     it.leftJoin("konto", "buchung.konto = konto.id");
     it.addFilter("konto.kontoart is null OR konto.kontoart < ?",
         Kontoart.LIMIT.getKey());
@@ -474,8 +479,13 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     if (mitSteuer)
     {
       String subselect = "(SELECT steuer.buchungsart, steuer.buchungsklasse,"
-          + " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag, "
-          + "buchung.projekt " + " FROM buchung"
+          + " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag ";
+      // Bei Projektsaldo auch Projekt-Spalte
+      if (this instanceof ProjektSaldoControl)
+      {
+        subselect += ",buchung.projekt ";
+      }
+      subselect += " FROM buchung"
           // Keine Steuer bei Anlagekonten
           + " JOIN konto on buchung.konto = konto.id and konto.kontoart < ? and konto.kontoart != ?";
 
@@ -493,7 +503,13 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       subselect += " WHERE datum >= ? and datum <= ? "
           // Keine Steuer bei alten Steuerbuchungen mit dependencyid
           + " AND (buchung.dependencyid is null or  buchung.dependencyid = -1)"
-          + " GROUP BY steuer.buchungsart, buchung.projekt";
+          + " GROUP BY steuer.buchungsart";
+      // Bei Projektsaldo auch Steuer nach Projekt gruppieren
+      if (this instanceof ProjektSaldoControl)
+      {
+        subselect += ", buchung.projekt";
+      }
+
       if (klasseInBuchung)
       {
         subselect += ",steuer.buchungsklasse";

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -18,6 +18,8 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.formatter.SaldoFormatter;
@@ -36,6 +38,7 @@ import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.parts.Column;
@@ -53,6 +56,8 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
    * Steuerbuchungsart
    */
   protected static final String SUMME = "summe";
+
+  protected static final String STEUERBETRAG = "steuerbetrag";
 
   /**
    * true wenn Steuern verwendet werden sollen. Default wie in Einstellungen
@@ -74,7 +79,7 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
   /**
    * Spalte die für die Gruppe verwendet wird. Default Buchungsklasse
    */
-  protected String spalteGruppe = BUCHUNGSKLASSE;
+  protected String spalteGruppe = BUCHUNGSKLASSE_TEXT;
 
   /**
    * Soll eine Buchungsklasse-Spalte angezeigt werden? Default false.
@@ -115,9 +120,9 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       saldoList.addColumn(gruppenBezeichnung, GRUPPE, null, false);
       if (mitBuchungsklasseSpalte)
       {
-        saldoList.addColumn("Buchungsklasse", BUCHUNGSKLASSE);
+        saldoList.addColumn("Buchungsklasse", BUCHUNGSKLASSE_TEXT);
       }
-      saldoList.addColumn("Buchungsart", BUCHUNGSART);
+      saldoList.addColumn("Buchungsart", BUCHUNGSART_TEXT);
       saldoList.addColumn("Einnahmen", EINNAHMEN,
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
           Column.ALIGN_RIGHT);
@@ -145,10 +150,71 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public ArrayList<PseudoDBObject> getList() throws RemoteException
   {
-    ExtendedDBIterator<PseudoDBObject> it = getIterator();
+    List<PseudoDBObject> list = PseudoIterator.asList(getIterator());
+
+    if (mitSteuer)
+    {
+      List<PseudoDBObject> listNeu = new ArrayList<>();
+
+      List<PseudoDBObject> steuerList = PseudoIterator
+          .asList(getSteuerIterator());
+
+      // Steuerbeträge hinzurechnen
+      for (PseudoDBObject o : list)
+      {
+        Integer klasse = o.getInteger(BUCHUNGSKLASSE_ID);
+        Integer art = o.getInteger(BUCHUNGSART_ID);
+        Integer projekt = o.getInteger(PROJEKT_ID);
+
+        for (PseudoDBObject steuerObject : steuerList)
+        {
+          Integer klasseSteuer = steuerObject.getInteger(BUCHUNGSKLASSE_ID);
+          Integer artSteuer = steuerObject.getInteger(BUCHUNGSART_ID);
+          Integer projektSteuer = steuerObject.getInteger(PROJEKT_ID);
+
+          if (Objects.equals(klasse, klasseSteuer)
+              && Objects.equals(art, artSteuer)
+              && Objects.equals(projekt, projektSteuer))
+          {
+            o.setAttribute(SUMME,
+                o.getDouble(SUMME) + steuerObject.getDouble(SUMME));
+            o.setAttribute(ANZAHL,
+                o.getInteger(ANZAHL) + steuerObject.getInteger(ANZAHL));
+
+            if (o.getAttribute(EINNAHMEN) != null
+                && steuerObject.getAttribute(EINNAHMEN) != null)
+            {
+              o.setAttribute(EINNAHMEN,
+                  o.getDouble(EINNAHMEN) + steuerObject.getDouble(EINNAHMEN));
+            }
+
+            if (o.getAttribute(AUSGABEN) != null
+                && steuerObject.getAttribute(AUSGABEN) != null)
+            {
+              o.setAttribute(AUSGABEN,
+                  o.getDouble(AUSGABEN) + steuerObject.getDouble(AUSGABEN));
+            }
+            steuerObject.setAttribute("gefunden", true);
+            break;
+          }
+        }
+        listNeu.add(o);
+      }
+      // Alle Steuerobjecte hinzufügen, für die kein Eintrag gefunden wurde
+      for (PseudoDBObject steuerObject : steuerList)
+      {
+        if (steuerObject.getAttribute("gefunden") == null)
+        {
+          listNeu.add(steuerObject);
+        }
+      }
+      sortList(listNeu);
+      list = listNeu;
+    }
 
     ArrayList<PseudoDBObject> zeilen = new ArrayList<>();
 
@@ -164,9 +230,39 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     Double ausgabenGesamt = 0d;
     Double umbuchungenGesamt = 0d;
 
-    while (it.hasNext())
+    for (PseudoDBObject o : list)
     {
-      PseudoDBObject o = it.next();
+      String buchungsart = (String) o.getAttribute(BUCHUNGSART);
+      String buchungsartNummer = (String) o.getAttribute(BUCHUNGSART_NUMMER);
+
+      String buchungsklasse = (String) o.getAttribute(BUCHUNGSKLASSE);
+      String buchungsklasseNummer = (String) o
+          .getAttribute(BUCHUNGSKLASSE_NUMMER);
+      switch ((Integer) Einstellungen
+          .getEinstellung(Property.BUCHUNGSARTANZEIGE))
+      {
+        case BuchungsartAnzeige.NUMMER_BEZEICHNUNG:
+          o.setAttribute(BUCHUNGSART_TEXT,
+              (buchungsartNummer != null ? buchungsartNummer : "") + " - "
+                  + (buchungsart != null ? buchungsart : ""));
+          o.setAttribute(BUCHUNGSKLASSE_TEXT,
+              (buchungsklasseNummer != null ? buchungsklasseNummer : "") + " - "
+                  + (buchungsklasse != null ? buchungsklasse : ""));
+          break;
+        case BuchungsartAnzeige.BEZEICHNUNG_NUMMER:
+          o.setAttribute(BUCHUNGSART_TEXT,
+              (buchungsart != null ? buchungsart : "") + " ("
+                  + (buchungsartNummer != null ? buchungsartNummer : "") + ")");
+          o.setAttribute(BUCHUNGSKLASSE_TEXT,
+              (buchungsklasse != null ? buchungsklasse : "") + " ("
+                  + (buchungsklasseNummer != null ? buchungsklasseNummer : "")
+                  + ")");
+          break;
+        default:
+          o.setAttribute(BUCHUNGSART_TEXT, o.getAttribute(buchungsart));
+          o.setAttribute(BUCHUNGSKLASSE_TEXT, o.getAttribute(buchungsklasse));
+          break;
+      }
 
       String klasse = (String) o.getAttribute(spalteGruppe);
       if (klasse == null || klasse.equals(" - ") || klasse.equals(" ()"))
@@ -357,6 +453,69 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
   }
 
   /**
+   * Sortiert die Liste je nach Einstellung nach Buchungsklasse/Buchungsart
+   * Nummer oder Bezeichnung
+   * 
+   * @param list
+   * @throws RemoteException
+   */
+  protected void sortList(List<PseudoDBObject> list) throws RemoteException
+  {
+    int order = (Integer) Einstellungen
+        .getEinstellung(Property.BUCHUNGSARTSORT);
+    list.sort((o1, o2) -> {
+      try
+      {
+        String keyKlasse;
+        String keyArt;
+        switch (order)
+        {
+          case BuchungsartSort.NACH_NUMMER:
+            keyKlasse = BUCHUNGSKLASSE_NUMMER;
+            keyArt = BUCHUNGSART_NUMMER;
+            break;
+          case BuchungsartSort.NACH_BEZEICHNUNG:
+          default:
+            keyKlasse = BUCHUNGSKLASSE;
+            keyArt = BUCHUNGSART;
+            break;
+        }
+
+        if (o1.getAttribute(keyKlasse) == null)
+        {
+          return 1;
+        }
+        if (o2.getAttribute(keyKlasse) == null)
+        {
+          return -1;
+        }
+
+        int comp = ((String) o1.getAttribute(keyKlasse))
+            .compareTo((String) o2.getAttribute(keyKlasse));
+        if (comp != 0)
+        {
+          return comp;
+        }
+        if (o1.getAttribute(keyArt) == null)
+        {
+          return 1;
+        }
+        if (o2.getAttribute(keyArt) == null)
+        {
+          return -1;
+        }
+        comp = ((String) o1.getAttribute(keyArt))
+            .compareTo((String) o2.getAttribute(keyArt));
+        return comp;
+      }
+      catch (RemoteException e)
+      {
+        return 0;
+      }
+    });
+  }
+
+  /**
    * Holt den Iterator, auf dessen Basis die Salodliste erstellt wird.
    * 
    * @return der Iterator
@@ -376,96 +535,69 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
 
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
         "buchungsart");
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTANZEIGE))
-    {
-      case BuchungsartAnzeige.NUMMER_BEZEICHNUNG:
-        it.addColumn(
-            "CONCAT(buchungsart.nummer,' - ',buchungsart.bezeichnung) as "
-                + BUCHUNGSART);
-        it.addColumn(
-            "CONCAT(buchungsklasse.nummer,' - ',buchungsklasse.bezeichnung) as "
-                + BUCHUNGSKLASSE);
-        break;
-      case BuchungsartAnzeige.BEZEICHNUNG_NUMMER:
-        it.addColumn(
-            "CONCAT(buchungsart.bezeichnung,' (',buchungsart.nummer,')') as "
-                + BUCHUNGSART);
-        it.addColumn(
-            "CONCAT(buchungsklasse.bezeichnung,' (',buchungsklasse.nummer,')') as "
-                + BUCHUNGSKLASSE);
-        break;
-      default:
-        it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
-        it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
-        break;
-    }
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
-    {
-      case BuchungsartSort.NACH_NUMMER:
-        it.setOrder(
-            "Order by buchungsklasse.nummer is null,buchungsklasse.nummer,"
-                + " buchungsart.nummer is null, buchungsart.nummer");
-        break;
-      case BuchungsartSort.NACH_BEZEICHNUNG:
-      default:
-        it.setOrder(
-            "Order by buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-                + " buchungsart.bezeichnung is NULL, buchungsart.bezeichnung ");
-        break;
-    }
+
+    it.addColumn("buchungsart.nummer as " + BUCHUNGSART_NUMMER);
+    it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
     it.addColumn("buchungsart.art as " + ARTBUCHUNGSART);
-    it.addColumn("COUNT(buchung.id) as " + ANZAHL);
+    it.addColumn("buchungsart.id as " + BUCHUNGSART_ID);
     it.addColumn("buchungsart.status");
+
+    it.addColumn("buchungsklasse.id as " + BUCHUNGSKLASSE_ID);
+    it.addColumn("buchungsklasse.nummer as " + BUCHUNGSKLASSE_NUMMER);
+    it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
+    it.addColumn("COUNT(buchung.id) as " + ANZAHL);
 
     if (mitSteuer)
     {
-      // Nettobetrag berechnen und steuerbetrag der Steuerbuchungsart
-      // hinzurechnen
+      // Nettobetrag berechnen
       it.addColumn("COALESCE(SUM(CAST(buchung.betrag * 100 / (100 + "
           // Anlagenkonto immer Bruttobeträge.
           // Alte Steuerbuchungen mit dependencyid lassen wir bestehen ohne
           // Netto zu berehnen.
           + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 ELSE COALESCE(steuer.satz,0) END"
-          + ") AS DECIMAL(10,2))),0) + COALESCE(st.steuerbetrag,0) AS " + SUMME,
-          Kontoart.ANLAGE.getKey());
+          + ") AS DECIMAL(10,2))),0) AS " + SUMME, Kontoart.ANLAGE.getKey());
     }
     else
     {
       it.addColumn("COALESCE(SUM(buchung.betrag),0) AS " + SUMME);
     }
 
-    String buchungOn = "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?";
-    // Bei Projektsaldo nur Buchungen verwenden, die zu dem Projekt gehöhren
-    if (this instanceof ProjektSaldoControl)
+    it.leftJoin("buchung",
+        "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?",
+        getDatumvon().getDate(), getDatumbis().getDate());
+    it.join("konto", "buchung.konto = konto.id");
+
+    if (klasseInBuchung)
     {
-      // Bei H2 geht es nicht ohne ON Clause, daher machen wir hier diese
-      // sinnlose.
-      it.join("projekt", "projekt.id = projekt.id");
-      buchungOn += " and buchung.projekt = projekt.id";
+      it.leftJoin("buchungsklasse",
+          "buchungsklasse.id = buchung.buchungsklasse");
     }
-    it.leftJoin("buchung", buchungOn, getDatumvon().getDate(),
-        getDatumbis().getDate());
-    it.leftJoin("konto", "buchung.konto = konto.id");
+    else
+    {
+      it.leftJoin("buchungsklasse",
+          "buchungsklasse.id = buchungsart.buchungsklasse ");
+    }
+
     it.addFilter("konto.kontoart is null OR konto.kontoart < ?",
         Kontoart.LIMIT.getKey());
-    if (mitSteuer)
+
+    if (mitSteuer && steuerInBuchung)
     {
-      if (steuerInBuchung)
-      {
-        it.leftJoin("steuer", "steuer.id = buchung.steuer");
-      }
-      else
-      {
-        it.leftJoin("steuer", "steuer.id = buchungsart.steuer");
-      }
+      it.leftJoin("steuer", "steuer.id = buchung.steuer");
     }
-    it.addGroupBy("buchungsart.id");
+    else if (mitSteuer)
+    {
+      it.leftJoin("steuer", "steuer.id = buchungsart.steuer");
+    }
+
     it.addGroupBy("buchungsklasse.bezeichnung");
     it.addGroupBy("buchungsklasse.nummer");
+    it.addGroupBy("buchungsart.id");
     it.addGroupBy("buchungsart.bezeichnung");
     it.addGroupBy("buchungsart.art");
     it.addGroupBy("buchungsart.status");
     it.addGroupBy("buchungsart.nummer");
+
     // Ggf. Buchungsarten ausblenden
     if (unterdrueckung)
     {
@@ -478,69 +610,71 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           StatusBuchungsart.INACTIVE);
     }
 
-    // Für die Steuerbträge auf der Steuerbuchungsart machen wir ein Subselect
-    if (mitSteuer)
+    return it;
+  }
+
+  protected ExtendedDBIterator<PseudoDBObject> getSteuerIterator()
+      throws RemoteException
+  {
+    final boolean klasseInBuchung = (Boolean) Einstellungen
+        .getEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG);
+
+    final boolean steuerInBuchung = (Boolean) Einstellungen
+        .getEinstellung(Property.STEUERINBUCHUNG);
+
+    ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("buchung");
+
+    it.addColumn("COUNT(buchung.id) as " + ANZAHL);
+    it.addColumn("buchungsart.status");
+
+    it.addColumn("buchungsart.nummer as " + BUCHUNGSART_NUMMER);
+    it.addColumn("buchungsart.bezeichnung as " + BUCHUNGSART);
+    it.addColumn("buchungsart.art as " + ARTBUCHUNGSART);
+    it.addColumn("buchungsart.id as " + BUCHUNGSART_ID);
+    it.addColumn("buchungsart.status");
+
+    it.addColumn("buchungsklasse.id as " + BUCHUNGSKLASSE_ID);
+    it.addColumn("buchungsklasse.nummer as " + BUCHUNGSKLASSE_NUMMER);
+    it.addColumn("buchungsklasse.bezeichnung as " + BUCHUNGSKLASSE);
+
+    it.addColumn(
+        "SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS "
+            + SUMME);
+
+    // Keine Steuer bei Anlagekonten
+    it.join("konto",
+        "buchung.konto = konto.id and konto.kontoart < ? and konto.kontoart != ?",
+        Kontoart.LIMIT.getKey(), Kontoart.ANLAGE.getKey());
+    // Wenn die Steuer in der Buchung steht, können wir sie direkt nehmen,
+    // sonst müssen wir den Umweg über die Buchungsart nehmen.
+    if (steuerInBuchung)
     {
-      String subselect = "(SELECT steuer.buchungsart,";
-      if (klasseInBuchung)
-      {
-        subselect += " steuer.buchungsklasse,";
-      }
-      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag";
-      if (this instanceof ProjektSaldoControl)
-      {
-        subselect += ",buchung.projekt";
-      }
-      subselect += " FROM buchung"
-          // Keine Steuer bei Anlagekonten
-          + " JOIN konto on buchung.konto = konto.id and konto.kontoart < ? and konto.kontoart != ?";
-
-      // Wenn die Steuer in der Buchung steht, können wir sie direkt nehmen,
-      // sonst müssen wir den Umweg über die Buchungsart nehmen.
-      if (steuerInBuchung)
-      {
-        subselect += " JOIN steuer ON steuer.id = buchung.steuer ";
-      }
-      else
-      {
-        subselect += " JOIN buchungsart ON buchung.buchungsart = buchungsart.id "
-            + " JOIN steuer ON steuer.id = buchungsart.steuer ";
-      }
-      subselect += " WHERE datum >= ? and datum <= ? "
-          // Keine Steuer bei alten Steuerbuchungen mit dependencyid
-          + " AND (buchung.dependencyid is null or  buchung.dependencyid = -1)"
-          + " GROUP BY steuer.buchungsart";
-      // Bei Projektsaldo auch Steuer nach Projekt gruppieren
-      if (this instanceof ProjektSaldoControl)
-      {
-        subselect += ", buchung.projekt";
-      }
-
-      if (klasseInBuchung)
-      {
-        subselect += ",steuer.buchungsklasse";
-      }
-      subselect += ") AS st ";
-      String stOn = "st.buchungsart = buchungsart.id ";
-      if (this instanceof ProjektSaldoControl)
-      {
-        stOn += " and st.projekt = projekt.id ";
-      }
-      it.leftJoin(subselect, stOn, Kontoart.LIMIT.getKey(),
-          Kontoart.ANLAGE.getKey(), getDatumvon().getDate(),
-          getDatumbis().getDate());
+      it.join("steuer", "steuer.id = buchung.steuer");
     }
+    else
+    {
+      it.join("buchungsart babuchung", "buchung.buchungsart = babuchung.id");
+      it.join("steuer", "steuer.id = babuchung.steuer");
+    }
+    it.join("buchungsart", "steuer.buchungsart = buchungsart.id");
+    it.addFilter("datum between ? and ?", getDatumvon().getDate(),
+        getDatumbis().getDate());
+
+    // Keine Steuer bei alten Steuerbuchungen mit dependencyid
+    it.addFilter("buchung.dependencyid is null or  buchung.dependencyid = -1");
+    it.addGroupBy("steuer.buchungsart");
+    it.addGroupBy("buchungsklasse.id");
+    it.addGroupBy("buchungsklasse.nummer");
+
     if (klasseInBuchung)
     {
-      it.leftJoin("buchungsklasse", "buchungsklasse.id = buchung.buchungsklasse"
-          + (mitSteuer ? " OR buchungsklasse.id = st.buchungsklasse" : ""));
-      it.addGroupBy("buchung.buchungsklasse");
+      it.leftJoin("buchungsklasse",
+          "buchungsklasse.id = buchung.buchungsklasse");
     }
     else
     {
       it.leftJoin("buchungsklasse",
           "buchungsklasse.id = buchungsart.buchungsklasse ");
-      it.addGroupBy("buchungsart.buchungsklasse");
     }
 
     return it;

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -426,8 +426,8 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           // Alte Steuerbuchungen mit dependencyid lassen wir bestehen ohne
           // Netto zu berehnen.
           + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 ELSE COALESCE(steuer.satz,0) END"
-          + ") AS DECIMAL(10,2))),0) + COALESCE(SUM(st.steuerbetrag),0) AS "
-          + SUMME, Kontoart.ANLAGE.getKey());
+          + ") AS DECIMAL(10,2))),0) + COALESCE(st.steuerbetrag,0) AS " + SUMME,
+          Kontoart.ANLAGE.getKey());
     }
     else
     {
@@ -435,10 +435,11 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     }
 
     String buchungOn = "buchung.buchungsart = buchungsart.id AND datum >= ? AND datum <= ?";
-    // Bei Projektsaldo nur Buchungen verwenden, die auch ein Projekt haben
+    // Bei Projektsaldo nur Buchungen verwenden, die zu dem Projekt gehöhren
     if (this instanceof ProjektSaldoControl)
     {
-      buchungOn += " and buchung.projekt is not null";
+      it.join("projekt");
+      buchungOn += " and buchung.projekt = projekt.id";
     }
     it.leftJoin("buchung", buchungOn, getDatumvon().getDate(),
         getDatumbis().getDate());
@@ -482,15 +483,9 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       if (klasseInBuchung)
       {
         subselect += " steuer.buchungsklasse,";
-
       }
-      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag ";
-      // Bei Projektsaldo auch Projekt-Spalte
-      if (this instanceof ProjektSaldoControl)
-      {
-        subselect += ",buchung.projekt ";
-      }
-      subselect += " FROM buchung"
+      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag,"
+          + "buchung.projekt FROM buchung"
           // Keine Steuer bei Anlagekonten
           + " JOIN konto on buchung.konto = konto.id and konto.kontoart < ? and konto.kontoart != ?";
 
@@ -520,9 +515,14 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
         subselect += ",steuer.buchungsklasse";
       }
       subselect += ") AS st ";
-      it.leftJoin(subselect, "st.buchungsart = buchungsart.id ",
-          Kontoart.LIMIT.getKey(), Kontoart.ANLAGE.getKey(),
-          getDatumvon().getDate(), getDatumbis().getDate());
+      String stOn = "st.buchungsart = buchungsart.id ";
+      if (this instanceof ProjektSaldoControl)
+      {
+        stOn += " and st.projekt = projekt.id ";
+      }
+      it.leftJoin(subselect, stOn, Kontoart.LIMIT.getKey(),
+          Kontoart.ANLAGE.getKey(), getDatumvon().getDate(),
+          getDatumbis().getDate());
     }
     if (klasseInBuchung)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -438,7 +438,9 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     // Bei Projektsaldo nur Buchungen verwenden, die zu dem Projekt gehöhren
     if (this instanceof ProjektSaldoControl)
     {
-      it.join("projekt");
+      // Bei H2 geht es nicht ohne ON Clause, daher machen wir hier diese
+      // sinnlose.
+      it.join("projekt", "projekt.id = projekt.id");
       buchungOn += " and buchung.projekt = projekt.id";
     }
     it.leftJoin("buchung", buchungOn, getDatumvon().getDate(),
@@ -484,8 +486,12 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       {
         subselect += " steuer.buchungsklasse,";
       }
-      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag,"
-          + "buchung.projekt FROM buchung"
+      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag";
+      if (this instanceof ProjektSaldoControl)
+      {
+        subselect += ",buchung.projekt";
+      }
+      subselect += " FROM buchung"
           // Keine Steuer bei Anlagekonten
           + " JOIN konto on buchung.konto = konto.id and konto.kontoart < ? and konto.kontoart != ?";
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -182,8 +182,6 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           {
             o.setAttribute(SUMME,
                 o.getDouble(SUMME) + steuerObject.getDouble(SUMME));
-            o.setAttribute(ANZAHL,
-                o.getInteger(ANZAHL) + steuerObject.getInteger(ANZAHL));
 
             if (o.getAttribute(EINNAHMEN) != null
                 && steuerObject.getAttribute(EINNAHMEN) != null)
@@ -362,7 +360,7 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       o.setAttribute(ART, ART_DETAIL);
 
       // Anzahl null blenden wir aus
-      if (o.getInteger(ANZAHL).equals(0))
+      if (o.getInteger(ANZAHL) != null && o.getInteger(ANZAHL).equals(0))
       {
         o.setAttribute(ANZAHL, null);
       }
@@ -624,7 +622,6 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
 
     ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("buchung");
 
-    it.addColumn("COUNT(buchung.id) as " + ANZAHL);
     it.addColumn("buchungsart.status");
 
     it.addColumn("buchungsart.nummer as " + BUCHUNGSART_NUMMER);
@@ -669,7 +666,7 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     if (klasseInBuchung)
     {
       it.leftJoin("buchungsklasse",
-          "buchungsklasse.id = buchung.buchungsklasse");
+          "buchungsklasse.id = steuer.buchungsklasse");
     }
     else
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -212,9 +212,9 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           listNeu.add(steuerObject);
         }
       }
-      sortList(listNeu);
       list = listNeu;
     }
+    sortList(list);
 
     ArrayList<PseudoDBObject> zeilen = new ArrayList<>();
 
@@ -259,8 +259,8 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
                   + ")");
           break;
         default:
-          o.setAttribute(BUCHUNGSART_TEXT, o.getAttribute(buchungsart));
-          o.setAttribute(BUCHUNGSKLASSE_TEXT, o.getAttribute(buchungsklasse));
+          o.setAttribute(BUCHUNGSART_TEXT, buchungsart);
+          o.setAttribute(BUCHUNGSKLASSE_TEXT, buchungsklasse);
           break;
       }
 

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -478,8 +478,13 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
     // Für die Steuerbträge auf der Steuerbuchungsart machen wir ein Subselect
     if (mitSteuer)
     {
-      String subselect = "(SELECT steuer.buchungsart, steuer.buchungsklasse,"
-          + " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag ";
+      String subselect = "(SELECT steuer.buchungsart,";
+      if (klasseInBuchung)
+      {
+        subselect += " steuer.buchungsklasse,";
+
+      }
+      subselect += " SUM(CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS steuerbetrag ";
       // Bei Projektsaldo auch Projekt-Spalte
       if (this instanceof ProjektSaldoControl)
       {

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungSaldoControl.java
@@ -43,14 +43,13 @@ public class MittelverwendungSaldoControl extends BuchungsklasseSaldoControl
 
     // Bei der Mittelverwendung verwenden wir nur Geldkonten und zweckfremde
     // Anlagen.
-    String filter = "konto.kontoart is null OR (buchungsart.art != ? AND (konto.kontoart = ? OR (konto.kontoart = ? AND konto.zweck = ?)))"
-        + "OR (buchungsart.art = ? AND (konto.kontoart = ? OR (konto.kontoart = ? AND konto.zweck = ?))) ";
-
-    if (mitSteuer)
-    {
-      filter += "OR st.steuerbetrag is not null";
-    }
-    it.addFilter(filter, ArtBuchungsart.UMBUCHUNG, Kontoart.GELD.getKey(),
+    it.addFilter(
+        "konto.kontoart is null OR "
+            + "(buchungsart.art != ? AND (konto.kontoart = ? OR "
+            + "(konto.kontoart = ? AND konto.zweck = ?)))"
+            + "OR (buchungsart.art = ? AND (konto.kontoart = ? OR "
+            + "(konto.kontoart = ? AND konto.zweck = ?))) ",
+        ArtBuchungsart.UMBUCHUNG, Kontoart.GELD.getKey(),
         Kontoart.ANLAGE.getKey(), Anlagenzweck.ZWECKFREMD_EINGESETZT.getKey(),
         ArtBuchungsart.UMBUCHUNG, Kontoart.SCHULDEN.getKey(),
         Kontoart.ANLAGE.getKey(), Anlagenzweck.NUTZUNGSGEBUNDEN.getKey());
@@ -59,8 +58,7 @@ public class MittelverwendungSaldoControl extends BuchungsklasseSaldoControl
     // den Einnahmen bzw. Ausgaben ab.
     if (mitSteuer)
     {
-      // Nettobetrag berechnen und steuerbetrag der Steuerbuchungsart
-      // hinzurechnen
+      // Nettobetrag berechnen
       it.addColumn("COALESCE(SUM("
           + "(CASE WHEN buchungsart.art = ? AND buchung.betrag > 0 "
           + "THEN -1 WHEN buchungsart.art != ? THEN 0 ELSE 1 END) * "
@@ -68,11 +66,10 @@ public class MittelverwendungSaldoControl extends BuchungsklasseSaldoControl
           // Anlagenkonto immer Bruttobeträge.
           // Alte Steuerbuchungen mit dependencyid lassen wir bestehen ohne
           // Netto zu berehnen.
-          + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 ELSE COALESCE(steuer.satz,0) END"
-          + ") AS DECIMAL(10,2))),0) "
-          + "+ CASE WHEN buchungsart.art = ? THEN COALESCE(SUM(st.steuerbetrag),0) ELSE 0 END AS "
+          + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 "
+          + "ELSE COALESCE(steuer.satz,0) END" + ") AS DECIMAL(10,2))),0) AS "
           + AUSGABEN, ArtBuchungsart.UMBUCHUNG, ArtBuchungsart.AUSGABE,
-          Kontoart.ANLAGE.getKey(), ArtBuchungsart.AUSGABE);
+          Kontoart.ANLAGE.getKey());
 
       it.addColumn("COALESCE(SUM("
           + "(CASE WHEN buchungsart.art = ? AND buchung.betrag < 0 "
@@ -81,11 +78,10 @@ public class MittelverwendungSaldoControl extends BuchungsklasseSaldoControl
           // Anlagenkonto immer Bruttobeträge.
           // Alte Steuerbuchungen mit dependencyid lassen wir bestehen ohne
           // Netto zu berehnen.
-          + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 ELSE COALESCE(steuer.satz,0) END"
-          + ") AS DECIMAL(10,2))),0) "
-          + "+ CASE WHEN buchungsart.art = ? THEN COALESCE(SUM(st.steuerbetrag),0) ELSE 0 END AS "
+          + "CASE WHEN konto.kontoart = ? OR buchung.dependencyid > -1 THEN 0 "
+          + "ELSE COALESCE(steuer.satz,0) END" + ") AS DECIMAL(10,2))),0)  AS "
           + EINNAHMEN, ArtBuchungsart.UMBUCHUNG, ArtBuchungsart.EINNAHME,
-          Kontoart.ANLAGE.getKey(), ArtBuchungsart.EINNAHME);
+          Kontoart.ANLAGE.getKey());
     }
     else
     {
@@ -97,6 +93,38 @@ public class MittelverwendungSaldoControl extends BuchungsklasseSaldoControl
           + " THEN -buchung.betrag WHEN buchungsart.art != ? THEN 0 ELSE buchung.betrag END) AS "
           + EINNAHMEN, ArtBuchungsart.UMBUCHUNG, ArtBuchungsart.EINNAHME);
     }
+
+    return it;
+  }
+
+  @Override
+  protected ExtendedDBIterator<PseudoDBObject> getSteuerIterator()
+      throws RemoteException
+  {
+    ExtendedDBIterator<PseudoDBObject> it = super.getSteuerIterator();
+
+    // Bei der Mittelverwendung verwenden wir nur Geldkonten und zweckfremde
+    // Anlagen.
+    it.addFilter(
+        "konto.kontoart is null OR "
+            + "(buchungsart.art != ? AND (konto.kontoart = ? OR "
+            + "(konto.kontoart = ? AND konto.zweck = ?)))"
+            + "OR (buchungsart.art = ? AND (konto.kontoart = ? OR "
+            + "(konto.kontoart = ? AND konto.zweck = ?))) ",
+        ArtBuchungsart.UMBUCHUNG, Kontoart.GELD.getKey(),
+        Kontoart.ANLAGE.getKey(), Anlagenzweck.ZWECKFREMD_EINGESETZT.getKey(),
+        ArtBuchungsart.UMBUCHUNG, Kontoart.SCHULDEN.getKey(),
+        Kontoart.ANLAGE.getKey(), Anlagenzweck.NUTZUNGSGEBUNDEN.getKey());
+
+    it.addColumn("SUM(CASE WHEN buchungsart.art = ? AND buchung.betrag > 0"
+        + " THEN -1 WHEN buchungsart.art != ? THEN 0 ELSE 1 END * "
+        + "CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS "
+        + AUSGABEN, ArtBuchungsart.UMBUCHUNG, ArtBuchungsart.AUSGABE);
+
+    it.addColumn("SUM(CASE WHEN buchungsart.art = ? AND buchung.betrag < 0"
+        + " THEN -1 WHEN buchungsart.art != ? THEN 0 ELSE 1 END * "
+        + "CAST(buchung.betrag * steuer.satz/100 / (1 + steuer.satz/100) AS DECIMAL(10,2))) AS "
+        + EINNAHMEN, ArtBuchungsart.UMBUCHUNG, ArtBuchungsart.EINNAHME);
 
     return it;
   }

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -17,10 +17,8 @@
 package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
+import java.util.List;
 
-import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.keys.BuchungsartSort;
 import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
@@ -47,25 +45,52 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     ExtendedDBIterator<PseudoDBObject> it = super.getIterator();
 
     it.addColumn("projekt.bezeichnung as " + PROJEKT);
+    it.addColumn("buchung.projekt as " + PROJEKT_ID);
 
+    it.join("projekt", "buchung.projekt = projekt.id");
     it.addGroupBy("projekt.id");
     it.addGroupBy("projekt.bezeichnung");
 
-    switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
-    {
-      case BuchungsartSort.NACH_NUMMER:
-        it.setOrder("ORDER BY projekt.bezeichnung,"
-            + "buchungsklasse.nummer is NULL,buchungsklasse.nummer,"
-            + "buchungsart.nummer is null, buchungsart.nummer ");
-        break;
-      case BuchungsartSort.NACH_BEZEICHNUNG:
-      default:
-        it.setOrder("ORDER BY projekt.bezeichnung,"
-            + "buchungsklasse.bezeichnung is NULL, buchungsklasse.bezeichnung,"
-            + "buchungsart.bezeichnung is NUll, buchungsart.bezeichnung ");
-        break;
-    }
     return it;
+  }
+
+  @Override
+  protected ExtendedDBIterator<PseudoDBObject> getSteuerIterator()
+      throws RemoteException
+  {
+    ExtendedDBIterator<PseudoDBObject> it = super.getSteuerIterator();
+    it.join("projekt", "buchung.projekt = projekt.id");
+    it.addGroupBy("buchung.projekt");
+    it.addColumn("projekt.id as " + PROJEKT_ID);
+    it.addColumn("projekt.bezeichnung as " + PROJEKT);
+
+    return it;
+  }
+
+  @Override
+  protected void sortList(List<PseudoDBObject> list) throws RemoteException
+  {
+    super.sortList(list);
+    list.sort((o1, o2) -> {
+      try
+      {
+        if (o1.getAttribute(PROJEKT) == null)
+        {
+          return 1;
+        }
+        if (o2.getAttribute(PROJEKT) == null)
+        {
+          return -1;
+        }
+
+        return ((String) o1.getAttribute(PROJEKT))
+            .compareTo((String) o2.getAttribute(PROJEKT));
+      }
+      catch (RemoteException e)
+      {
+        return 0;
+      }
+    });
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -50,12 +50,6 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
 
     it.addGroupBy("projekt.id");
     it.addGroupBy("projekt.bezeichnung");
-    String on = "projekt.id = buchung.projekt ";
-    if (mitSteuer)
-    {
-      on += " OR projekt.id = st.projekt";
-    }
-    it.join("projekt", on);
 
     switch ((Integer) Einstellungen.getEinstellung(Property.BUCHUNGSARTSORT))
     {


### PR DESCRIPTION
Bei Manuellen Steuerbuchungen und Projekten wurde die Manuelle Steuer mehrfach berechnet. Siehe: https://jverein-forum.de/viewtopic.php?p=21475#p21475

Dabei habe ich festgestellt, dass bei der Umsatzsteuer Voranmeldung manuelle Steuerbuchungen nicht richtig ausgewiesen werden. Das ist jedoch auch nicht wirklich möglich, da man sie auf keine Weise eindeutig als solche erkennen kann. Wie sollen wir damit umgehen? Ein Hinweis in der Doku? Oder eine Hinweis im Dialog?