### PR TITLE
Fix Abrechnungslauf bei Autosplit kopieren

### DIFF
--- a/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -344,6 +344,7 @@ public class SplitbuchungsContainer
   {
     Buchung buch = (Buchung) Einstellungen.getDBService()
         .createObject(Buchung.class, null);
+    buch.setAbrechnungslauf(b.getAbrechnungslauf());
     buch.setArt(b.getArt());
     buch.setAuszugsnummer(b.getAuszugsnummer());
     buch.setBetrag(b.getBetrag() * -1);
@@ -362,9 +363,8 @@ public class SplitbuchungsContainer
     buch.setIban(b.getIban());
     buch.setSteuer(b.getSteuer());
 
-    // Folgende Spalten werden nicht übertragen (Stand 4.0.0):
+    // Folgende Spalten werden nicht übertragen (Stand 4.1.4):
     // sollbuchung
-    // abrechnungslauf
     // splitid
     // splittyp
     // spendenbescheinigung


### PR DESCRIPTION
Beim Autosplit muss man auch den Abrechnungslauf kopieren, sonst erscheint in der Liste der Buchungen im Abrechnungslauf nur die Hauptbuchung und nicht die Gegenbuchung und die Splitbuchungen.

Beim PDF Ausdruck in 4.2 wäre dann auch nur die Hauptbuchung enthalten ohne Mitglied und Zahler weil keine Sollbuchung zugeordnet ist.