### PR TITLE
Fix Entfernen Button Text bei Buchungsart Zuordnung

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungsartZuordnungDialog.java
@@ -80,6 +80,8 @@ public class BuchungsartZuordnungDialog extends AbstractDialog<Buchungsart>
 
   public final static String KEINE_STEUER = "Keine Steuer";
 
+  private String entfernenText = "Entfernen";
+
   /**
    * @param position
    */
@@ -98,6 +100,10 @@ public class BuchungsartZuordnungDialog extends AbstractDialog<Buchungsart>
         .getEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG);
     steuerInBuchung = (Boolean) Einstellungen
         .getEinstellung(Property.STEUERINBUCHUNG);
+    if (klasseInBuchung || steuerInBuchung)
+    {
+      entfernenText = "Alle entfernen";
+    }
 
     LabelGroup group = new LabelGroup(parent, "");
     group.addLabelPair("Buchungsart", getBuchungsartAuswahl());
@@ -158,7 +164,7 @@ public class BuchungsartZuordnungDialog extends AbstractDialog<Buchungsart>
         close();
       }
     }, null, true, "ok.png");
-    buttons.addButton("Alle Entfernen", new Action()
+    buttons.addButton(entfernenText, new Action()
     {
 
       @Override


### PR DESCRIPTION
Im Buchungsart Zuordnung Dialog war der Text für den Entfernen Button immer "Alle Entfernen". 
Wenn aber nur die Buchungsart gesetzt/entfernt werden kann weil weder Buchungsklasse noch Steuer Inputs angezeigt werden dann sollte die Beschriftung des Buttons nur "Entfernen" lauten.