### PR TITLE
Fix Arbeitseinsatzüberprüfen

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -495,6 +495,7 @@ public class ArbeitseinsatzControl extends FilterControl implements Savable
             zb.setMitglied(
                 Integer.valueOf((String) z.getAttribute("mitgliedid")));
             zb.setZahlungsweg(new Zahlungsweg(Zahlungsweg.STANDARD));
+            zb.setMitgliedzahltSelbst(false);
             Mitglied m = (Mitglied) Einstellungen.getDBService().createObject(
                 Mitglied.class, (String) z.getAttribute("mitgliedid"));
             Beitragsgruppe b = m.getBeitragsgruppe();


### PR DESCRIPTION
Beim Generieren der Zusatzbeträge gab es eine Exception weil das Attribut mitgliedzahltselbst NULL war was in der DB nicht erlaubt ist.