### PR TITLE
Fix DummyRechnungMap ZAHLUNGSWEG und SUMME_OFFEN

### DIFF
--- a/src/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -149,6 +149,9 @@ public class RechnungMap extends AbstractMap
         case SUMME_OFFEN:
           value = Einstellungen.DECIMALFORMAT.format(summe - ist);
           break;
+        case QRCODE_SUMME_OFFEN:
+          value = summe - ist;
+          break;
         case MK_STAND:
         case STAND:
           value = Einstellungen.DECIMALFORMAT.format(ist - summe);
@@ -422,6 +425,9 @@ public class RechnungMap extends AbstractMap
           break;
         case SUMME_OFFEN:
           value = Einstellungen.DECIMALFORMAT.format(13.8);
+          break;
+        case QRCODE_SUMME_OFFEN:
+          value = 13.8;
           break;
         case QRCODE_INTRO:
           value = "Bequem bezahlen mit Girocode. Einfach mit der Banking-App auf dem Handy abscannen.";

--- a/src/de/jost_net/JVerein/Variable/RechnungVar.java
+++ b/src/de/jost_net/JVerein/Variable/RechnungVar.java
@@ -52,6 +52,7 @@ public enum RechnungVar
   MK_SUMME_OFFEN("mitgliedskonto_summe_offen"), //
   SUMME("rechnung_summe"), //
   SUMME_OFFEN("rechnung_summe_offen"), //
+  QRCODE_SUMME_OFFEN("qrcode_summe_offen"), //
   QRCODE_SUMME("qrcode_summe"), //
   QRCODE_INTRO("qrcode_intro"),
   DATUM("rechnung_datum"),

--- a/src/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -350,7 +350,7 @@ public class FormularAufbereitung
     DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols();
     otherSymbols.setDecimalSeparator('.');
     String betrag = new DecimalFormat("0.00", otherSymbols)
-        .format(fieldsMap.get(RechnungVar.SUMME_OFFEN.getName()));
+        .format(fieldsMap.get(RechnungVar.QRCODE_SUMME_OFFEN.getName()));
     sbEpc.append(betrag);
     sbEpc.append("\n");
     sbEpc.append("\n"); // currently purpose code not used here


### PR DESCRIPTION
Fix für https://jverein-forum.de/viewtopic.php?p=21502#p21502

In der DummyMap von Rechnung war Zahlungsweg ein String statt int.

Ich habe in ein Formular $qrcode_summe platziert und auf Anzeigen geklickt.

Es gibt aber dann aber noch eine weite Exception in Formularaufbereitung Zeile 353.
```
String betrag = new DecimalFormat("0.00", otherSymbols)
        .format(fieldsMap.get(RechnungVar.SUMME_OFFEN.getName()));
```

Das Problem war, dass SUMME_OFFEN einen String liefert und keine Number. Ich habe jetzt eine QRCODE_SUMME_OFFEN eingeführt die ein Double liefert. Damit geht es.