### PR TITLE
Fix Mitgliederauswahl bei Arbeitseinsätze Neu

### DIFF
--- a/src/de/jost_net/JVerein/gui/input/MitgliedInput.java
+++ b/src/de/jost_net/JVerein/gui/input/MitgliedInput.java
@@ -32,12 +32,23 @@ public class MitgliedInput
   public AbstractInput getMitgliedInput(AbstractInput mitgliedInput,
       Mitglied mitglied, int auswahl) throws RemoteException
   {
+    return getMitgliedInput(mitgliedInput, mitglied, auswahl, null);
+  }
+
+  public AbstractInput getMitgliedInput(AbstractInput mitgliedInput,
+      Mitglied mitglied, int auswahl, Integer mitgliedstyp)
+      throws RemoteException
+  {
     switch (auswahl)
     {
       case AbstractInputAuswahl.ComboBox:
         // Hole alle Mitglieder aus Datenbank um sie später anzuzeigen.
         DBIterator<Mitglied> it = Einstellungen.getDBService()
             .createList(Mitglied.class);
+        if (mitgliedstyp != null)
+        {
+          it.addFilter("adresstyp = ?", mitgliedstyp);
+        }
         it.setOrder("order by name, vorname");
         ArrayList<Mitglied> mitgliederList = new ArrayList<>();
         while (it.hasNext())
@@ -55,7 +66,7 @@ public class MitgliedInput
         break;
       case AbstractInputAuswahl.SearchInput:
       default:
-        mitgliedInput = new MitgliedSearchInput();
+        mitgliedInput = new MitgliedSearchInput(mitgliedstyp);
         ((MitgliedSearchInput) mitgliedInput)
             .setSearchString("Zum Suchen tippen");
         mitgliedInput.setValue(mitglied);

--- a/src/de/jost_net/JVerein/gui/input/MitgliedSearchInput.java
+++ b/src/de/jost_net/JVerein/gui/input/MitgliedSearchInput.java
@@ -27,9 +27,18 @@ import de.willuhn.logging.Logger;
 
 public class MitgliedSearchInput extends SearchInput
 {
+
+  private Integer mitgliedstyp = null;
+
   public MitgliedSearchInput()
   {
     super();
+  }
+
+  public MitgliedSearchInput(Integer mitgliedstyp)
+  {
+    super();
+    this.mitgliedstyp = mitgliedstyp;
   }
 
   @Override
@@ -46,6 +55,10 @@ public class MitgliedSearchInput extends SearchInput
         text = "%" + text.toUpperCase() + "%";
         result.addFilter("(UPPER(name) like ? or UPPER(vorname) like ?)",
             new Object[] { text, text });
+      }
+      if (mitgliedstyp != null)
+      {
+        result.addFilter("adresstyp = ?", mitgliedstyp);
       }
       result.setOrder("order by name, vorname");
 

--- a/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/ArbeitseinsatzPart.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.input.AbstractInput;
@@ -130,7 +131,8 @@ public class ArbeitseinsatzPart implements Part
     else
     {
       mitglied = new MitgliedInput().getMitgliedInput(mitglied, null,
-          (Integer) Einstellungen.getEinstellung(Property.MITGLIEDAUSWAHL));
+          (Integer) Einstellungen.getEinstellung(Property.MITGLIEDAUSWAHL),
+          Integer.valueOf(Mitgliedstyp.MITGLIED));
     }
     mitglied.setMandatory(true);
     return mitglied;


### PR DESCRIPTION
Entsprechend #1432 gibt es keine Arbeitseinsätze für Nicht-Mitglieder. Beim Erzeugen eines neuen Arbeitseinsatzes wird beim Mitglied Input aber auch Nicht-Mitglieder angeboten. Das passiert jetzt nicht mehr.
Man kann jetzt bei der Mitglieder Suche den Mitgliedstyp optional angeben.