### PR TITLE
Fix Heap Mailanhang

### DIFF
--- a/src/de/jost_net/JVerein/server/MailImpl.java
+++ b/src/de/jost_net/JVerein/server/MailImpl.java
@@ -127,6 +127,7 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
     DBIterator<MailAnhang> it = Einstellungen.getDBService()
         .createList(MailAnhang.class);
     it.addFilter("mail = ?", getID());
+
     anhang = new TreeSet<>();
     while (it.hasNext())
     {
@@ -189,7 +190,12 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
   {
     if ("anhaenge".equals(fieldName))
     {
-      return getAnhang().size();
+      ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<PseudoDBObject>(
+          "mailanhang");
+      it.addFilter("mail = ?", getID());
+      it.addColumn("count(id) as count");
+      PseudoDBObject o = it.next();
+      return o.getAttribute("count");
     }
     return super.getAttribute(fieldName);
   }


### PR DESCRIPTION
In der Mailliste wurden alle Anhänge der Mails gelesen und in den Heap geladen, nur um die Anzahl zu bekommen. Das hat bei vielen Aufrufen irgendwann zu übervollem Heap geführt.
Jetzt bestimme ich nur noch die Anzahl mit einem eigenen Querry.
Ganz schön ist das mit den Mailanhängen immer noch nicht. Da auch beim laden der Mail die Anhänge geladen werden. Da habe ich jedoch keine Idee, wie man das anders machen könnte.Nach meiner Analyse werden die jedoch schneller wieder aus dem Heap entfernt.