### PR TITLE
Mailempfänger Dialog Redesign

### DIFF
--- a/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
+++ b/src/de/jost_net/JVerein/Queries/MitgliedQuery.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.FilterControl;
 import de.jost_net.JVerein.gui.control.SollbuchungControl.DIFFERENZ;
+import de.jost_net.JVerein.gui.dialogs.EigenschaftenAuswahlDialog;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
@@ -483,63 +484,8 @@ public class MitgliedQuery
             }
           });
 
-      ArrayList<Long> mitgliederIdsFiltered = new ArrayList<>();
-      for (Long mitglied : mitgliederIds)
-      {
-        ArrayList<Long> mitgliedeigenschaftenIds = new ArrayList<>();
-        for (Long[] value : mitgliedEigenschaften)
-        {
-          if (value[0].equals(mitglied))
-            mitgliedeigenschaftenIds.add(value[1]);
-        }
-
-        boolean ok = false;
-        for (Long suchId : suchIds)
-        {
-          if (control.getEigenschaftenVerknuepfung().equals("und"))
-          {
-            ok = true;
-            if (suchauswahl.get(suchId).equals(EigenschaftenNode.PLUS))
-            {
-              if (!mitgliedeigenschaftenIds.contains(suchId))
-              {
-                ok = false;
-                break;
-              }
-            }
-            else // EigenschaftenNode2.MINUS
-            {
-              if (mitgliedeigenschaftenIds.contains(suchId))
-              {
-                ok = false;
-                break;
-              }
-            }
-          }
-          else // Oder
-          {
-            if (suchauswahl.get(suchId).equals(EigenschaftenNode.PLUS))
-            {
-              if (mitgliedeigenschaftenIds.contains(suchId))
-              {
-                ok = true;
-                break;
-              }
-            }
-            else // EigenschaftenNode2.MINUS
-            {
-              if (!mitgliedeigenschaftenIds.contains(suchId))
-              {
-                ok = true;
-                break;
-              }
-            }
-          }
-        }
-        if (ok)
-          mitgliederIdsFiltered.add(mitglied);
-      }
-      return getMitglieder(mitgliederIdsFiltered);
+      return getMitglieder(getFilteredIds(mitgliederIds, suchIds, suchauswahl,
+          mitgliedEigenschaften, control.getEigenschaftenVerknuepfung()));
     }
     else
     {
@@ -598,5 +544,84 @@ public class MitgliedQuery
     }
     and = true;
     sql += condition;
+  }
+
+  /**
+   * Die Methode evaluiert die Eigenschaften der Mitglieder.
+   * 
+   * @param mitgliederIds
+   *          Liste der Mitglieder IDs
+   * @param suchIds
+   *          Liste der auszuwertenden Eigenschaften IDs
+   * @param suchauswahl
+   *          Map mit dem Vorzeichen der Eigenschaft PLUS/MINUS
+   * @param mitgliedEigenschaften
+   *          Liste der Mitglied/Eigenschaften, Index 0 ist Mitglied, Index 1
+   *          ist Eigenschaft
+   * @param verknuepfung
+   *          Verknüpfung der Eigenschaften UND/ODER
+   * @return Gefilterte Mitglieder IDs
+   */
+  public static ArrayList<Long> getFilteredIds(ArrayList<Long> mitgliederIds,
+      ArrayList<Long> suchIds, HashMap<Long, String> suchauswahl,
+      List<Long[]> mitgliedEigenschaften, String verknuepfung)
+  {
+    ArrayList<Long> mitgliederIdsFiltered = new ArrayList<>();
+    for (Long mitglied : mitgliederIds)
+    {
+      ArrayList<Long> mitgliedeigenschaftenIds = new ArrayList<>();
+      for (Long[] value : mitgliedEigenschaften)
+      {
+        if (value[0].equals(mitglied))
+          mitgliedeigenschaftenIds.add(value[1]);
+      }
+
+      boolean ok = false;
+      for (Long suchId : suchIds)
+      {
+        if (verknuepfung.equals(EigenschaftenAuswahlDialog.UND))
+        {
+          ok = true;
+          if (suchauswahl.get(suchId).equals(EigenschaftenNode.PLUS))
+          {
+            if (!mitgliedeigenschaftenIds.contains(suchId))
+            {
+              ok = false;
+              break;
+            }
+          }
+          else // EigenschaftenNode2.MINUS
+          {
+            if (mitgliedeigenschaftenIds.contains(suchId))
+            {
+              ok = false;
+              break;
+            }
+          }
+        }
+        else // Oder
+        {
+          if (suchauswahl.get(suchId).equals(EigenschaftenNode.PLUS))
+          {
+            if (mitgliedeigenschaftenIds.contains(suchId))
+            {
+              ok = true;
+              break;
+            }
+          }
+          else // EigenschaftenNode2.MINUS
+          {
+            if (!mitgliedeigenschaftenIds.contains(suchId))
+            {
+              ok = true;
+              break;
+            }
+          }
+        }
+      }
+      if (ok)
+        mitgliederIdsFiltered.add(mitglied);
+    }
+    return mitgliederIdsFiltered;
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
@@ -46,6 +46,10 @@ public class EigenschaftenAuswahlDialog
     extends AbstractDialog<EigenschaftenAuswahlParameter>
 {
 
+  public static final String UND = "und";
+
+  public static final String ODER = "oder";
+
   private FilterControl control;
 
   private SelectInput eigenschaftenverknuepfung;
@@ -181,8 +185,8 @@ public class EigenschaftenAuswahlDialog
       return eigenschaftenverknuepfung;
     }
     ArrayList<String> werte = new ArrayList<>();
-    werte.add("und");
-    werte.add("oder");
+    werte.add(UND);
+    werte.add(ODER);
     eigenschaftenverknuepfung = new SelectInput(werte,
         control.getEigenschaftenVerknuepfung());
     eigenschaftenverknuepfung.setName("Gruppen-Verknüpfung");

--- a/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
@@ -69,9 +69,6 @@ public class EigenschaftenAuswahlDialog
    * 
    * @param defaults
    *          Liste der Eigenschaften-IDs durch Komma separiert.
-   * @param ohnePflicht
-   *          Spezifiziert ob Eigenschaftengruppen mit Pflicht und Max1
-   *          ignoriert werden. true: ignorieren
    * @param verknuepfung
    *          Spezifiziert ob der Input Verknüpfung (UND,ODER) im Dialog
    *          angezeigt werden soll.

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -332,6 +332,9 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       switch (selection)
       {
         case AKTIVE_MITGLIEDER:
+          it.addFilter("(eintritt IS NULL OR eintritt <= ?)"
+              + " AND (austritt IS NULL OR austritt > ?)", d, d);
+          break;
         case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
           it.addFilter(
               "adresstyp != ? OR ((eintritt IS NULL OR eintritt <= ?)"
@@ -339,6 +342,9 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
               Long.valueOf(Mitgliedstyp.MITGLIED), d, d);
           break;
         case INAKTIVE_MITGLIEDER:
+          it.addFilter("NOT ((eintritt IS NULL OR eintritt <= ?)"
+              + " AND (austritt IS NULL OR austritt > ?))", d, d);
+          break;
         case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
           it.addFilter(
               "adresstyp != ? OR NOT ((eintritt IS NULL OR eintritt <= ?)"

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -21,11 +21,12 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.gui.control.MailControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.jost_net.JVerein.keys.Eigenschaftenauswahl;
@@ -98,7 +99,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         try
         {
           EigenschaftenAuswahlDialog ead = new EigenschaftenAuswahlDialog(null,
-              true, new MitgliedControl(null), true);
+              true, new MitgliedControl(null), false);
           param = ead.open();
           setSelection();
         }
@@ -308,7 +309,7 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       if (eigenschaftenNodes != null)
       {
         it.addColumn("eigenschaft as " + EIGENSCHAFT);
-        it.join("eigenschaften", "mitglied.id = eigenschaften.mitglied");
+        it.leftJoin("eigenschaften", "mitglied.id = eigenschaften.mitglied");
       }
       // Filtern nach Mitgliedstyp
       switch (selection)
@@ -360,7 +361,8 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       it.setOrder("Order by mitglied.id");
 
       ArrayList<Long> selectedIds = new ArrayList<>();
-      HashMap<Long, Integer> map = new HashMap<>();
+      ArrayList<Long> mitgliederIds = new ArrayList<>();
+      List<Long[]> mitgliedEigenschaften = new ArrayList<>();
 
       while (it.hasNext())
       {
@@ -368,30 +370,11 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         Long mitglied_id = (Long) o.getAttribute(MITGLIED_ID);
         if (eigenschaftenNodes != null)
         {
+          mitgliederIds.add(mitglied_id);
           Long eigenschaft = (Long) o.getAttribute(EIGENSCHAFT);
-          if (param.getVerknuepfung().equals(EigenschaftenAuswahlDialog.ODER))
+          if (eigenschaft != null)
           {
-            for (EigenschaftenNode node : eigenschaftenNodes)
-            {
-              if (Long.valueOf(node.getEigenschaft().getID()) == eigenschaft)
-              {
-                selectedIds.add(mitglied_id);
-              }
-            }
-          }
-          else if (param.getVerknuepfung()
-              .equals(EigenschaftenAuswahlDialog.UND))
-          {
-            for (EigenschaftenNode node : eigenschaftenNodes)
-            {
-              if (Long.valueOf(node.getEigenschaft().getID()) == eigenschaft)
-              {
-                Integer count = map.get(mitglied_id) != null
-                    ? map.get(mitglied_id) + 1
-                    : 1;
-                map.put(mitglied_id, count);
-              }
-            }
+            mitgliedEigenschaften.add(new Long[] { mitglied_id, eigenschaft });
           }
         }
         else
@@ -400,18 +383,18 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         }
       }
 
-      if (eigenschaftenNodes != null
-          && param.getVerknuepfung().equals(EigenschaftenAuswahlDialog.UND))
+      if (eigenschaftenNodes != null)
       {
-        int anzahl = eigenschaftenNodes.size();
-        for (Map.Entry<Long, Integer> entry : map.entrySet())
+        ArrayList<Long> suchIds = new ArrayList<>();
+        HashMap<Long, String> suchauswahl = new HashMap<>();
+        for (EigenschaftenNode node : eigenschaftenNodes)
         {
-          // Wenn alle Eigenschaften enthalten waren, dann Mitglied selektieren
-          if (entry.getValue() == anzahl)
-          {
-            selectedIds.add(entry.getKey());
-          }
+          Long eigenschaftId = Long.valueOf(node.getEigenschaft().getID());
+          suchIds.add(eigenschaftId);
+          suchauswahl.put(eigenschaftId, node.getPreset());
         }
+        selectedIds = MitgliedQuery.getFilteredIds(mitgliederIds, suchIds,
+            suchauswahl, mitgliedEigenschaften, param.getVerknuepfung());
       }
 
       for (Object o : control.getMitgliedMitMail().getItems(false))

--- a/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -18,22 +18,28 @@
 package de.jost_net.JVerein.gui.dialogs;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.control.MailControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.rmi.Eigenschaften;
+import de.jost_net.JVerein.keys.Eigenschaftenauswahl;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.jost_net.JVerein.server.EigenschaftenNode;
-import de.willuhn.datasource.rmi.DBIterator;
+import de.jost_net.JVerein.server.ExtendedDBIterator;
+import de.jost_net.JVerein.server.PseudoDBObject;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -46,17 +52,36 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
 
   private MailControl control;
 
+  private TextInput auswahlinput;
+
+  private TextInput eigenschafteninput;
+
+  private TextInput verknuepfunginput;
+
+  public static final String MITGLIED_ID = "id";
+
+  public static final String EIGENSCHAFT = "eigenschaft";
+
+  private EigenschaftenAuswahlParameter param = null;
+
+  private Eigenschaftenauswahl selection = Eigenschaftenauswahl.KEINE;
+
   public MailEmpfaengerAuswahlDialog(MailControl control, int position)
   {
     super(position);
     this.control = control;
     setTitle("Mail-Empfänger");
-    setSize(920, 450);
+    setSize(650, 500);
   }
 
   @Override
   protected void paint(Composite parent) throws Exception
   {
+    LabelGroup group = new LabelGroup(parent, "");
+    group.addLabelPair("Auswahl", getAuswahl());
+    group.addLabelPair("Eigenschaften", getEigenschaften());
+    group.addLabelPair("Verknüpfung", getVerknuepfung());
+
     control.getMitgliedMitMail().paint(parent);
     for (Object o : control.getMitgliedMitMail().getItems(true))
     {
@@ -73,22 +98,9 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
         try
         {
           EigenschaftenAuswahlDialog ead = new EigenschaftenAuswahlDialog(null,
-              false, new MitgliedControl(null), true);
-          EigenschaftenAuswahlParameter param = ead.open();
-          if (param == null)
-            return;
-          for (EigenschaftenNode node : param.getEigenschaftenNodes())
-          {
-            DBIterator<Eigenschaften> it = Einstellungen.getDBService()
-                .createList(Eigenschaften.class);
-            it.addFilter("eigenschaft = ?",
-                new Object[] { node.getEigenschaft().getID() });
-            while (it.hasNext())
-            {
-              Eigenschaften ei = it.next();
-              control.getMitgliedMitMail().setChecked(ei.getMitglied(), true);
-            }
-          }
+              true, new MitgliedControl(null), true);
+          param = ead.open();
+          setSelection();
         }
         catch (OperationCanceledException oce)
         {
@@ -106,17 +118,8 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
-        try
-        {
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            control.getMitgliedMitMail().setChecked(o, true);
-          }
-        }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
+        selection = Eigenschaftenauswahl.ALLE;
+        setSelection();
       }
     });
 
@@ -131,6 +134,11 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
           {
             control.getMitgliedMitMail().setChecked(o, false);
           }
+          selection = Eigenschaftenauswahl.KEINE;
+          auswahlinput.setValue(selection.getText());
+          eigenschafteninput.setValue(getEigenschaftenString());
+          verknuepfunginput
+              .setValue(param != null ? param.getVerknuepfung() : "");
         }
         catch (RemoteException e)
         {
@@ -144,23 +152,28 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
-        try
+        Eigenschaftenauswahl selection_old = selection;
+        switch (selection_old)
         {
-          Date stichtag = new Date();
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
-                && m.isAngemeldet(stichtag))
-            {
-              control.getMitgliedMitMail().setChecked(o, true);
-            }
-          }
+          case KEINE:
+            selection = Eigenschaftenauswahl.AKTIVE_MITGLIEDER;
+            break;
+          case INAKTIVE_MITGLIEDER:
+            selection = Eigenschaftenauswahl.MITGLIEDER;
+            break;
+          case NICHT_MITGLIEDER:
+            selection = Eigenschaftenauswahl.AKTIVE_MITGLIEDER_NICHT_MITGLIEDER;
+            break;
+          case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+            selection = Eigenschaftenauswahl.ALLE;
+            break;
+          case ALLE:
+          case MITGLIEDER:
+          case AKTIVE_MITGLIEDER:
+          case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+            break;
         }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
+        setSelection();
       }
     });
 
@@ -169,23 +182,28 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
-        try
+        Eigenschaftenauswahl selection_old = selection;
+        switch (selection_old)
         {
-          Date stichtag = new Date();
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            Mitglied m = (Mitglied) o;
-            if (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
-                && !m.isAngemeldet(stichtag))
-            {
-              control.getMitgliedMitMail().setChecked(o, true);
-            }
-          }
+          case KEINE:
+            selection = Eigenschaftenauswahl.INAKTIVE_MITGLIEDER;
+            break;
+          case AKTIVE_MITGLIEDER:
+            selection = Eigenschaftenauswahl.MITGLIEDER;
+            break;
+          case NICHT_MITGLIEDER:
+            selection = Eigenschaftenauswahl.INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER;
+            break;
+          case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+            selection = Eigenschaftenauswahl.ALLE;
+            break;
+          case ALLE:
+          case MITGLIEDER:
+          case INAKTIVE_MITGLIEDER:
+          case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+            break;
         }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
+        setSelection();
       }
     });
 
@@ -194,47 +212,28 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       @Override
       public void handleAction(Object context)
       {
-        try
+        Eigenschaftenauswahl selection_old = selection;
+        switch (selection_old)
         {
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            Mitglied m = (Mitglied) o;
-            if (!m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED))
-            {
-              control.getMitgliedMitMail().setChecked(o, true);
-            }
-          }
+          case KEINE:
+            selection = Eigenschaftenauswahl.NICHT_MITGLIEDER;
+            break;
+          case AKTIVE_MITGLIEDER:
+            selection = Eigenschaftenauswahl.AKTIVE_MITGLIEDER_NICHT_MITGLIEDER;
+            break;
+          case INAKTIVE_MITGLIEDER:
+            selection = Eigenschaftenauswahl.INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER;
+            break;
+          case MITGLIEDER:
+            selection = Eigenschaftenauswahl.ALLE;
+            break;
+          case ALLE:
+          case NICHT_MITGLIEDER:
+          case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+          case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+            break;
         }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
-      }
-    });
-
-    b.addButton("Aktive Mitglieder und Nicht-Mitglieder", new Action()
-    {
-      @Override
-      public void handleAction(Object context)
-      {
-        try
-        {
-          Date stichtag = new Date();
-          for (Object o : control.getMitgliedMitMail().getItems(false))
-          {
-            Mitglied m = (Mitglied) o;
-            if (!m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
-                || (m.getMitgliedstyp().getID().equals(Mitgliedstyp.MITGLIED)
-                    && m.isAngemeldet(stichtag)))
-            {
-              control.getMitgliedMitMail().setChecked(o, true);
-            }
-          }
-        }
-        catch (RemoteException e)
-        {
-          Logger.error("Fehler", e);
-        }
+        setSelection();
       }
     });
 
@@ -284,4 +283,210 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
     return null;
   }
 
+  private void setSelection()
+  {
+    try
+    {
+      auswahlinput.setValue(selection.getText());
+      eigenschafteninput.setValue(getEigenschaftenString());
+      verknuepfunginput.setValue(param != null ? param.getVerknuepfung() : "");
+
+      if (selection == Eigenschaftenauswahl.KEINE)
+      {
+        return;
+      }
+
+      ArrayList<EigenschaftenNode> eigenschaftenNodes = null;
+      if (param != null && param.getEigenschaftenNodes().size() > 0)
+      {
+        eigenschaftenNodes = param.getEigenschaftenNodes();
+      }
+
+      ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+          "mitglied");
+      it.addColumn("mitglied.id as " + MITGLIED_ID);
+      if (eigenschaftenNodes != null)
+      {
+        it.addColumn("eigenschaft as " + EIGENSCHAFT);
+        it.join("eigenschaften", "mitglied.id = eigenschaften.mitglied");
+      }
+      // Filtern nach Mitgliedstyp
+      switch (selection)
+      {
+        case AKTIVE_MITGLIEDER:
+        case INAKTIVE_MITGLIEDER:
+        case MITGLIEDER:
+          it.addFilter("adresstyp = ?", Long.valueOf(Mitgliedstyp.MITGLIED));
+          break;
+        case NICHT_MITGLIEDER:
+          it.addFilter("adresstyp != ?", Long.valueOf(Mitgliedstyp.MITGLIED));
+          break;
+        case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+        case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+        case KEINE:
+        case ALLE:
+          break;
+      }
+      // Filtern nach Aktiv
+      Date d = new Date();
+      switch (selection)
+      {
+        case AKTIVE_MITGLIEDER:
+        case AKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+          it.addFilter(
+              "adresstyp != ? OR ((eintritt IS NULL OR eintritt <= ?)"
+                  + " AND (austritt IS NULL OR austritt > ?))",
+              Long.valueOf(Mitgliedstyp.MITGLIED), d, d);
+          break;
+        case INAKTIVE_MITGLIEDER:
+        case INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER:
+          it.addFilter(
+              "adresstyp != ? OR NOT ((eintritt IS NULL OR eintritt <= ?)"
+                  + " AND (austritt IS NULL OR austritt > ?))",
+              Long.valueOf(Mitgliedstyp.MITGLIED), d, d);
+          break;
+        case MITGLIEDER:
+        case NICHT_MITGLIEDER:
+        case KEINE:
+        case ALLE:
+          break;
+      }
+      it.setOrder("Order by mitglied.id");
+
+      ArrayList<Long> selectedIds = new ArrayList<>();
+      HashMap<Long, Integer> map = new HashMap<>();
+
+      while (it.hasNext())
+      {
+        PseudoDBObject o = it.next();
+        Long mitglied_id = (Long) o.getAttribute(MITGLIED_ID);
+        if (eigenschaftenNodes != null)
+        {
+          Long eigenschaft = (Long) o.getAttribute(EIGENSCHAFT);
+          if (param.getVerknuepfung().equals(EigenschaftenAuswahlDialog.ODER))
+          {
+            for (EigenschaftenNode node : eigenschaftenNodes)
+            {
+              if (Long.valueOf(node.getEigenschaft().getID()) == eigenschaft)
+              {
+                selectedIds.add(mitglied_id);
+              }
+            }
+          }
+          else if (param.getVerknuepfung()
+              .equals(EigenschaftenAuswahlDialog.UND))
+          {
+            for (EigenschaftenNode node : eigenschaftenNodes)
+            {
+              if (Long.valueOf(node.getEigenschaft().getID()) == eigenschaft)
+              {
+                Integer count = map.get(mitglied_id) != null
+                    ? map.get(mitglied_id) + 1
+                    : 1;
+                map.put(mitglied_id, count);
+              }
+            }
+          }
+        }
+        else
+        {
+          selectedIds.add(mitglied_id);
+        }
+      }
+
+      if (eigenschaftenNodes != null
+          && param.getVerknuepfung().equals(EigenschaftenAuswahlDialog.UND))
+      {
+        int anzahl = eigenschaftenNodes.size();
+        for (Map.Entry<Long, Integer> entry : map.entrySet())
+        {
+          // Wenn alle Eigenschaften enthalten waren, dann Mitglied selektieren
+          if (entry.getValue() == anzahl)
+          {
+            selectedIds.add(entry.getKey());
+          }
+        }
+      }
+
+      for (Object o : control.getMitgliedMitMail().getItems(false))
+      {
+        Mitglied m = (Mitglied) o;
+        if (selectedIds.contains(Long.valueOf(m.getID())))
+        {
+          control.getMitgliedMitMail().setChecked(o, true);
+        }
+        else
+        {
+          control.getMitgliedMitMail().setChecked(o, false);
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+    }
+  }
+
+  private TextInput getAuswahl()
+  {
+    if (auswahlinput != null)
+    {
+      return auswahlinput;
+    }
+    auswahlinput = new TextInput(selection.getText());
+    auswahlinput.disable();
+    return auswahlinput;
+  }
+
+  private TextInput getEigenschaften()
+  {
+    if (eigenschafteninput != null)
+    {
+      return eigenschafteninput;
+    }
+    eigenschafteninput = new TextInput(getEigenschaftenString());
+    eigenschafteninput.disable();
+    return eigenschafteninput;
+  }
+
+  private TextInput getVerknuepfung()
+  {
+    if (verknuepfunginput != null)
+    {
+      return verknuepfunginput;
+    }
+    verknuepfunginput = new TextInput(
+        param != null ? param.getVerknuepfung() : "");
+    verknuepfunginput.disable();
+    return verknuepfunginput;
+  }
+
+  private String getEigenschaftenString()
+  {
+    if (param != null && param.getEigenschaftenNodes().size() > 0)
+    {
+      StringBuilder text = new StringBuilder();
+      for (Object o : param.getEigenschaftenNodes())
+      {
+        if (text.length() > 0)
+        {
+          text.append(", ");
+        }
+        EigenschaftenNode node = (EigenschaftenNode) o;
+        try
+        {
+          String prefix = "+";
+          if (node.getPreset().equals(EigenschaftenNode.MINUS))
+            prefix = "-";
+          text.append(prefix + node.getEigenschaft().getBezeichnung());
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler", e);
+        }
+      }
+      return text.toString();
+    }
+    return "";
+  }
 }

--- a/src/de/jost_net/JVerein/keys/Eigenschaftenauswahl.java
+++ b/src/de/jost_net/JVerein/keys/Eigenschaftenauswahl.java
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ **********************************************************************/
+package de.jost_net.JVerein.keys;
+
+/**
+ * Eigenschaftenauswahl
+ */
+public enum Eigenschaftenauswahl
+{
+
+  KEINE(1, "Keine Auswahl"),
+  ALLE(2, "Alles ausgewählt"),
+  AKTIVE_MITGLIEDER(3, "Aktive Mitglieder"),
+  INAKTIVE_MITGLIEDER(4, "Inaktive Mitglieder"),
+  NICHT_MITGLIEDER(5, "Nicht-Mitglieder"),
+  MITGLIEDER(6, "Mitglieder"),
+  INAKTIVE_MITGLIEDER_NICHT_MITGLIEDER(7,
+      "Inaktive Mitglieder und Nicht-Mitglieder"),
+  AKTIVE_MITGLIEDER_NICHT_MITGLIEDER(8,
+      "Aktive Mitglieder und Nicht-Mitglieder");
+
+  private final String text;
+
+  private final int key;
+
+  Eigenschaftenauswahl(int key, String text)
+  {
+    this.key = key;
+    this.text = text;
+  }
+
+  public int getKey()
+  {
+    return key;
+  }
+
+  public String getText()
+  {
+    return text;
+  }
+
+  public static Eigenschaftenauswahl getByKey(int key)
+  {
+    for (Eigenschaftenauswahl ara : Eigenschaftenauswahl.values())
+    {
+      if (ara.getKey() == key)
+      {
+        return ara;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString()
+  {
+    return getText();
+  }
+}


### PR DESCRIPTION
Ich habe den Mailempfänger Dialog umgebaut, so dass man im Eigenschaften Dialog die Verknüpfung angeben kann. Eigenschaften werden dann mit der Mitgliederauswahl entsprechend verknüpft.
Siehe auch Diskussion im Forum: https://jverein-forum.de/viewtopic.php?t=7608

Dann habe ich auch noch Felder eingebaut bei denen man die aktuelle Mitgliedauswahl sehen kann.
Im Eigenschaften Dialog wird jetzt auch die Nicht-Eigenschaft unterstützt, also statt Haken nun +/-.

Die Auswahlbuttons der Mitglieder sind nach wie vor additiv.

<img width="651" height="530" alt="Bildschirmfoto_20260410_173132" src="https://github.com/user-attachments/assets/77dfb024-41e6-48d9-a841-4b9727cf2675" />

Eigenschaften Dialog:
<img width="400" height="431" alt="Bildschirmfoto_20260411_114151" src="https://github.com/user-attachments/assets/baa3728b-a8e9-413d-91a8-a9d790a86cc7" />


