### PR TITLE
Fix Splitbuchung

### DIFF
--- a/src/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/de/jost_net/JVerein/server/BuchungImpl.java
@@ -531,7 +531,9 @@ public class BuchungImpl extends AbstractJVereinDBObject
   public void setAbrechnungslauf(Abrechnungslauf abrechnungslauf)
       throws RemoteException
   {
-    setAttribute("abrechnungslauf", Long.valueOf(abrechnungslauf.getID()));
+    Long value = abrechnungslauf == null ? null
+        : Long.valueOf(abrechnungslauf.getID());
+    setAttribute("abrechnungslauf", value);
   }
 
   @Override


### PR DESCRIPTION
Splittbuchung erzeugen resultierte in einer Exception weil Abrechnungslauf null ist. Siehe https://jverein-forum.de/viewtopic.php?t=7613

Ich glaube, da brauchen wir eine 4.1.5.