### PR TITLE
Projektauswahl bei Projektsaldo

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -86,12 +86,18 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
    */
   protected boolean mitBuchungsklasseSpalte = false;
 
-  private SaldoListTablePart saldoList;
+  protected SaldoListTablePart saldoList;
 
   /**
    * Sollen Umbuchungen mit augegeben werden? Default true.
    */
   protected boolean mitUmbuchung = true;
+
+  /**
+   * Soll Gesamtsaldo mit augegeben werden? Default true. Wird bei Projektsaldo
+   * wenn ein Projekt ausgewählt ist nicht angezeigt
+   */
+  protected boolean mitGesamtSaldo = true;
 
   public BuchungsklasseSaldoControl(AbstractView view) throws RemoteException
   {
@@ -400,17 +406,20 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       zeilen.add(saldogv);
     }
 
-    PseudoDBObject o = new PseudoDBObject();
-    o.setAttribute(ART, ART_LEERZEILE);
-    zeilen.add(o);
+    if (mitGesamtSaldo)
+    {
+      PseudoDBObject o = new PseudoDBObject();
+      o.setAttribute(ART, ART_LEERZEILE);
+      zeilen.add(o);
 
-    PseudoDBObject saldo = new PseudoDBObject();
-    saldo.setAttribute(ART, ART_GESAMTSALDOFOOTER);
-    saldo.setAttribute(GRUPPE, "Gesamt Saldo");
-    saldo.setAttribute(EINNAHMEN, einnahmenGesamt);
-    saldo.setAttribute(AUSGABEN, ausgabenGesamt);
-    saldo.setAttribute(UMBUCHUNGEN, umbuchungenGesamt);
-    zeilen.add(saldo);
+      PseudoDBObject saldo = new PseudoDBObject();
+      saldo.setAttribute(ART, ART_GESAMTSALDOFOOTER);
+      saldo.setAttribute(GRUPPE, "Gesamt Saldo");
+      saldo.setAttribute(EINNAHMEN, einnahmenGesamt);
+      saldo.setAttribute(AUSGABEN, ausgabenGesamt);
+      saldo.setAttribute(UMBUCHUNGEN, umbuchungenGesamt);
+      zeilen.add(saldo);
+    }
 
     Double summeOhneBuchungsart = 0d;
     if (mitOhneBuchungsart)
@@ -446,12 +455,15 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
       }
     }
 
-    PseudoDBObject saldogv = new PseudoDBObject();
-    saldogv.setAttribute(ART, ART_GESAMTGEWINNVERLUST);
-    saldogv.setAttribute(GRUPPE, "Gesamt Gewinn/Verlust");
-    saldogv.setAttribute(EINNAHMEN, einnahmenGesamt + ausgabenGesamt
-        + umbuchungenGesamt + summeOhneBuchungsart);
-    zeilen.add(saldogv);
+    if (mitGesamtSaldo)
+    {
+      PseudoDBObject saldogv = new PseudoDBObject();
+      saldogv.setAttribute(ART, ART_GESAMTGEWINNVERLUST);
+      saldogv.setAttribute(GRUPPE, "Gesamt Gewinn/Verlust");
+      saldogv.setAttribute(EINNAHMEN, einnahmenGesamt + ausgabenGesamt
+          + umbuchungenGesamt + summeOhneBuchungsart);
+      zeilen.add(saldogv);
+    }
 
     return zeilen;
   }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -94,8 +94,8 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
   protected boolean mitUmbuchung = true;
 
   /**
-   * Soll Gesamtsaldo mit augegeben werden? Default true. Wird bei Projektsaldo
-   * wenn ein Projekt ausgewählt ist nicht angezeigt
+   * Soll Gesamtsaldo mit ausgegeben werden? Default true. Wird bei Projektsaldo
+   * nicht angezeigt wenn ein Projekt ausgewählt ist.
    */
   protected boolean mitGesamtSaldo = true;
 

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -115,7 +115,7 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     List<Projekt> projektliste = new ArrayList<>();
     DBIterator<Projekt> list = Einstellungen.getDBService()
         .createList(Projekt.class);
-    // Nur Projekte anzeugen die in dem Zeitraum aktiv sind
+    // Nur Projekte anzeigen die in dem Zeitraum aktiv sind
     list.addFilter("(startdatum is null or startdatum <= ?)",
         getDatumbis().getDate());
     list.addFilter("(endedatum is null or endedatum >= ?)",
@@ -134,7 +134,7 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     List<String> ids = new ArrayList<>();
     DBIterator<Projekt> list = Einstellungen.getDBService()
         .createList(Projekt.class);
-    // Nur Projekte anzeugen die in dem Zeitraum aktiv sind
+    // Nur Projekte anzeigen die in dem Zeitraum aktiv sind
     list.addFilter("(startdatum is null or startdatum <= ?)",
         getDatumbis().getDate());
     list.addFilter("(endedatum is null or endedatum >= ?)",

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -18,6 +18,7 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
@@ -29,6 +30,7 @@ import de.jost_net.JVerein.rmi.Projekt;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.ObjectNotFoundException;
 import de.willuhn.jameica.gui.AbstractView;
@@ -60,23 +62,12 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     projekt.setAttribute("bezeichnung");
     projekt.setPleaseChoose("Keine Einschränkung");
     projekt.addListener(new ProjektListener());
-    if (p != null)
-    {
-      mitGesamtSaldo = false;
-    }
-    else
-    {
-      mitGesamtSaldo = true;
-    }
+    mitGesamtSaldo = p == null;
     return projekt;
   }
 
   public class ProjektListener implements Listener
   {
-
-    ProjektListener()
-    {
-    }
 
     @Override
     public void handleEvent(Event event)
@@ -110,9 +101,9 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     }
   }
 
+  @SuppressWarnings("unchecked")
   private List<Projekt> getProjektliste() throws RemoteException
   {
-    List<Projekt> projektliste = new ArrayList<>();
     DBIterator<Projekt> list = Einstellungen.getDBService()
         .createList(Projekt.class);
     // Nur Projekte anzeigen die in dem Zeitraum aktiv sind
@@ -121,38 +112,28 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     list.addFilter("(endedatum is null or endedatum >= ?)",
         getDatumvon().getDate());
     list.setOrder("ORDER BY bezeichnung");
-    while (list.hasNext())
-    {
-      Projekt p = list.next();
-      projektliste.add(p);
-    }
-    return projektliste;
+    return PseudoIterator.asList(list);
   }
 
   private Projekt getDefaultProjekt() throws RemoteException
   {
-    List<String> ids = new ArrayList<>();
-    DBIterator<Projekt> list = Einstellungen.getDBService()
-        .createList(Projekt.class);
-    // Nur Projekte anzeigen die in dem Zeitraum aktiv sind
-    list.addFilter("(startdatum is null or startdatum <= ?)",
-        getDatumbis().getDate());
-    list.addFilter("(endedatum is null or endedatum >= ?)",
-        getDatumvon().getDate());
-    list.setOrder("ORDER BY bezeichnung");
-    while (list.hasNext())
-    {
-      Projekt p = list.next();
-      ids.add(p.getID());
-    }
     Projekt p = null;
     String pid = settings.getString("projekt", "");
-    if (pid.length() > 0 && ids.contains(pid))
+    if (pid.length() > 0)
     {
       try
       {
         p = (Projekt) Einstellungen.getDBService().createObject(Projekt.class,
             pid);
+        Date start = p.getStartDatum();
+        Date ende = p.getEndeDatum();
+        if (start != Einstellungen.NODATE
+            && start.after(getDatumbis().getDate())
+            || ende != Einstellungen.NODATE
+                && ende.before(getDatumvon().getDate()))
+        {
+          return null;
+        }
       }
       catch (ObjectNotFoundException e)
       {

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -17,16 +17,29 @@
 package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.keys.VorlageTyp;
+import de.jost_net.JVerein.rmi.Projekt;
 import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.ObjectNotFoundException;
 import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class ProjektSaldoControl extends BuchungsklasseSaldoControl
 {
+  private SelectInput projekt;
+
   public ProjektSaldoControl(AbstractView view) throws RemoteException
   {
     super(view);
@@ -34,6 +47,150 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
     mitOhneBuchungsart = false;
     mitBuchungsklasseSpalte = true;
     spalteGruppe = PROJEKT;
+  }
+
+  public SelectInput getProjekt() throws RemoteException
+  {
+    if (projekt != null)
+    {
+      return projekt;
+    }
+    Projekt p = getDefaultProjekt();
+    projekt = new SelectInput(getProjektliste(), p);
+    projekt.setAttribute("bezeichnung");
+    projekt.setPleaseChoose("Keine Einschränkung");
+    projekt.addListener(new ProjektListener());
+    if (p != null)
+    {
+      mitGesamtSaldo = false;
+    }
+    else
+    {
+      mitGesamtSaldo = true;
+    }
+    return projekt;
+  }
+
+  public class ProjektListener implements Listener
+  {
+
+    ProjektListener()
+    {
+    }
+
+    @Override
+    public void handleEvent(Event event)
+    {
+      if (event.type != SWT.Selection && event.type != SWT.FocusOut)
+      {
+        return;
+      }
+      try
+      {
+        if (saldoList == null)
+        {
+          return;
+        }
+        saveProjektSettings();
+        ArrayList<PseudoDBObject> zeile = getList();
+        getSaldoList().removeAll();
+        for (PseudoDBObject sz : zeile)
+        {
+          getSaldoList().addItem(sz);
+        }
+      }
+      catch (RemoteException e1)
+      {
+        Logger.error("Fehler", e1);
+      }
+      catch (ApplicationException e)
+      {
+        Logger.error("Fehler bei neu laden der Liste.");
+      }
+    }
+  }
+
+  private List<Projekt> getProjektliste() throws RemoteException
+  {
+    List<Projekt> projektliste = new ArrayList<>();
+    DBIterator<Projekt> list = Einstellungen.getDBService()
+        .createList(Projekt.class);
+    // Nur Projekte anzeugen die in dem Zeitraum aktiv sind
+    list.addFilter("(startdatum is null or startdatum <= ?)",
+        getDatumbis().getDate());
+    list.addFilter("(endedatum is null or endedatum >= ?)",
+        getDatumvon().getDate());
+    list.setOrder("ORDER BY bezeichnung");
+    while (list.hasNext())
+    {
+      Projekt p = list.next();
+      projektliste.add(p);
+    }
+    return projektliste;
+  }
+
+  private Projekt getDefaultProjekt() throws RemoteException
+  {
+    List<String> ids = new ArrayList<>();
+    DBIterator<Projekt> list = Einstellungen.getDBService()
+        .createList(Projekt.class);
+    // Nur Projekte anzeugen die in dem Zeitraum aktiv sind
+    list.addFilter("(startdatum is null or startdatum <= ?)",
+        getDatumbis().getDate());
+    list.addFilter("(endedatum is null or endedatum >= ?)",
+        getDatumvon().getDate());
+    list.setOrder("ORDER BY bezeichnung");
+    while (list.hasNext())
+    {
+      Projekt p = list.next();
+      ids.add(p.getID());
+    }
+    Projekt p = null;
+    String pid = settings.getString("projekt", "");
+    if (pid.length() > 0 && ids.contains(pid))
+    {
+      try
+      {
+        p = (Projekt) Einstellungen.getDBService().createObject(Projekt.class,
+            pid);
+      }
+      catch (ObjectNotFoundException e)
+      {
+        // Dann kein Default
+      }
+    }
+    return p;
+  }
+
+  private void saveProjektSettings() throws RemoteException
+  {
+    Projekt p = (Projekt) getProjekt().getValue();
+    if (p != null)
+    {
+      settings.setAttribute("projekt", p.getID());
+      mitGesamtSaldo = false;
+    }
+    else
+    {
+      settings.setAttribute("projekt", "");
+      mitGesamtSaldo = true;
+    }
+  }
+
+  @Override
+  public void reloadList() throws ApplicationException
+  {
+    try
+    {
+      projekt.setList(getProjektliste());
+      projekt.setValue(getDefaultProjekt());
+      saveProjektSettings();
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler bei neu laden der Liste.");
+    }
+    super.reloadList();
   }
 
   @Override
@@ -46,8 +203,12 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
 
     it.addColumn("projekt.bezeichnung as " + PROJEKT);
     it.addColumn("projekt.id as " + PROJEKT_ID);
-
     it.join("projekt", "buchung.projekt = projekt.id");
+    Projekt p = (Projekt) getProjekt().getValue();
+    if (p != null)
+    {
+      it.addFilter("projekt.id = ?", p.getID());
+    }
     it.addGroupBy("projekt.id");
     it.addGroupBy("projekt.bezeichnung");
 
@@ -60,6 +221,11 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
   {
     ExtendedDBIterator<PseudoDBObject> it = super.getSteuerIterator();
     it.join("projekt", "buchung.projekt = projekt.id");
+    Projekt p = (Projekt) getProjekt().getValue();
+    if (p != null)
+    {
+      it.addFilter("projekt.id = ?", p.getID());
+    }
     it.addGroupBy("buchung.projekt");
     it.addColumn("projekt.id as " + PROJEKT_ID);
     it.addColumn("projekt.bezeichnung as " + PROJEKT);

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -16,6 +16,8 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.ProjektSaldoControl;
 import de.willuhn.jameica.gui.AbstractView;
@@ -40,6 +42,12 @@ public class ProjektSaldoView extends AbstractView
 
     QuickAccessPart qpart = new QuickAccessPart(control, true);
     qpart.paint(this.getParent());
+
+    if ((Boolean) Einstellungen.getEinstellung(Property.PROJEKTEANZEIGEN))
+    {
+      LabelGroup projekt = new LabelGroup(getParent(), "Projekt");
+      projekt.addLabelPair("Projekt", control.getProjekt());
+    }
 
     LabelGroup group = new LabelGroup(getParent(), "Saldo", true);
     group.addPart(control.getSaldoList());

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -16,8 +16,6 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
-import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.ProjektSaldoControl;
 import de.willuhn.jameica.gui.AbstractView;
@@ -43,11 +41,8 @@ public class ProjektSaldoView extends AbstractView
     QuickAccessPart qpart = new QuickAccessPart(control, true);
     qpart.paint(this.getParent());
 
-    if ((Boolean) Einstellungen.getEinstellung(Property.PROJEKTEANZEIGEN))
-    {
-      LabelGroup projekt = new LabelGroup(getParent(), "Projekt");
-      projekt.addLabelPair("Projekt", control.getProjekt());
-    }
+    LabelGroup projekt = new LabelGroup(getParent(), "Projekt");
+    projekt.addLabelPair("Projekt", control.getProjekt());
 
     LabelGroup group = new LabelGroup(getParent(), "Saldo", true);
     group.addPart(control.getSaldoList());


### PR DESCRIPTION
Entsprechend dem Topic im Forum https://jverein-forum.de/viewtopic.php?t=7611 habe ich die Möglichkeit eingebaut im Projektsaldo auch einzelne Projekte auszuwählen.
Die Projektauswahl zeigt nur Projekte die im Auswahlzeitraum aktiv sind, also nicht vor dem Von Datum beendet wurden oder nach dem Bis Datum beginnen.
Falls nur ein Projekt angezeigt wird, wird das Summensaldo über alle Projekte nicht ausgegeben.

<img width="200" height="342" alt="Bildschirmfoto_20260424_180256" src="https://github.com/user-attachments/assets/025b8c16-5738-4790-aafc-2604f9533c13" />
