### PR TITLE
Fix Wirtschaftsplan speichern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -522,7 +522,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     {
       DBTransaction.rollback();
 
-      throw new ApplicationException(e.getMessage());
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -518,7 +518,13 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
 
       view.reload();
     }
-    catch (RemoteException e)
+    catch (ApplicationException e)
+    {
+      DBTransaction.rollback();
+
+      throw new ApplicationException(e.getMessage());
+    }
+    catch (Exception e)
     {
       DBTransaction.rollback();
 

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -457,7 +457,8 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     return wirtschaftsplan;
   }
 
-  public void handleStore()
+  @Override
+  public void handleStore() throws ApplicationException
   {
     try
     {
@@ -516,14 +517,6 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
       tableChanged = false;
 
       view.reload();
-
-      GUI.getStatusBar().setSuccessText("Wirtschaftsplan gespeichert");
-    }
-    catch (ApplicationException e)
-    {
-      DBTransaction.rollback();
-
-      GUI.getStatusBar().setErrorText(e.getMessage());
     }
     catch (RemoteException e)
     {
@@ -531,7 +524,7 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
 
       String fehler = "Fehler beim Speichern des Wirtschaftsplans";
       Logger.error(fehler, e);
-      GUI.getStatusBar().setErrorText(fehler);
+      throw new ApplicationException(fehler);
     }
   }
 


### PR DESCRIPTION
Beim Speichern eines Wirtschaftsplan wurde auch bei Fehlern ein Gespeichert ausgegeben weil handleStore() keinen Fehler zurückgab und der saveButton darum ein Success mit Gespeichert ausgibt. Dabei wurde die GUI Ausgabe von handleStore() überschrieben.