### PR TITLE
Projektliste in Wirtschaftsplan filtern

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -46,7 +46,9 @@ import de.jost_net.JVerein.rmi.Wirtschaftsplan;
 import de.jost_net.JVerein.rmi.WirtschaftsplanItem;
 import de.jost_net.JVerein.server.WirtschaftsplanImpl;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.BeanUtil;
 import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
@@ -155,25 +157,52 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     {
       return projekt;
     }
-    ArrayList<Projekt> projektliste = new ArrayList<>();
+    if (getWirtschaftsplan().isNewObject())
+    {
+      projekt = new SelectInput(new Object[0], null);
+      projekt.setPleaseChoose("Zur Auswahl erst Speichern");
+      projekt.disable();
+    }
+    else
+    {
+      projekt = new SelectInput(getProjektliste(),
+          getWirtschaftsplan().getProjekt());
+      projekt.setPleaseChoose("Keine Einschränkung");
+    }
+    projekt.setAttribute("bezeichnung");
+    return projekt;
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<Projekt> getProjektliste() throws RemoteException
+  {
     DBIterator<Projekt> list = Einstellungen.getDBService()
         .createList(Projekt.class);
+    // Nur Projekte anzeigen die in dem Zeitraum aktiv sind
+    list.addFilter("(startdatum is null or startdatum <= ?)",
+        getWirtschaftsplan().getDatumBis());
+    list.addFilter("(endedatum is null or endedatum >= ?)",
+        getWirtschaftsplan().getDatumVon());
     list.setOrder("ORDER BY bezeichnung");
-    while (list.hasNext())
+    List<Projekt> finallist = PseudoIterator.asList(list);
+    Projekt projekt = getWirtschaftsplan().getProjekt();
+    if (finallist != null && projekt != null)
     {
-      projektliste.add(list.next());
+      boolean found = false;
+      for (Projekt p : finallist)
+      {
+        if (BeanUtil.equals(p, projekt))
+        {
+          found = true;
+          break;
+        }
+      }
+      if (!found)
+      {
+        finallist.add(projekt);
+      }
     }
-    Long pid = getWirtschaftsplan().getProjektID();
-    Projekt p = null;
-    if (pid != null)
-    {
-      p = (Projekt) Einstellungen.getDBService().createObject(Projekt.class,
-          pid.toString());
-    }
-    projekt = new SelectInput(projektliste, p);
-    projekt.setAttribute("bezeichnung");
-    projekt.setPleaseChoose("Keine Einschränkung");
-    return projekt;
+    return finallist;
   }
 
   public EditTreePart getEinnahmen() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/parts/WirtschaftsplanUebersichtPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/WirtschaftsplanUebersichtPart.java
@@ -90,13 +90,12 @@ public class WirtschaftsplanUebersichtPart implements Part
         new JVDateFormatTTMMJJJJ());
     bisContainer.addLabelPair("Bis", bis);
 
-    if ((Boolean) Einstellungen
-        .getEinstellung(Property.PROJEKTEANZEIGEN))
+    if ((Boolean) Einstellungen.getEinstellung(Property.PROJEKTEANZEIGEN))
     {
-    SimpleContainer projektContainer = new SimpleContainer(
-        baseData.getComposite());
-    projekt = control.getProjekt();
-    projektContainer.addLabelPair("Projekt", projekt);
+      SimpleContainer projektContainer = new SimpleContainer(
+          baseData.getComposite());
+      projekt = control.getProjekt();
+      projektContainer.addLabelPair("Projekt", projekt);
     }
 
     ColumnLayout finanzData = new ColumnLayout(uebersicht.getComposite(), 6);

--- a/src/de/jost_net/JVerein/rmi/Wirtschaftsplan.java
+++ b/src/de/jost_net/JVerein/rmi/Wirtschaftsplan.java
@@ -32,6 +32,8 @@ public interface Wirtschaftsplan extends JVereinDBObject
 
   void setDatumBis(Date date) throws RemoteException;
 
+  public Projekt getProjekt() throws RemoteException;
+
   public Long getProjektID() throws RemoteException;
 
   public void setProjektID(Long projektID) throws RemoteException;

--- a/src/de/jost_net/JVerein/server/WirtschaftsplanImpl.java
+++ b/src/de/jost_net/JVerein/server/WirtschaftsplanImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.Kontoart;
+import de.jost_net.JVerein.rmi.Projekt;
 import de.jost_net.JVerein.rmi.Wirtschaftsplan;
 import de.willuhn.util.ApplicationException;
 
@@ -119,9 +120,22 @@ public class WirtschaftsplanImpl extends AbstractJVereinDBObject
   }
 
   @Override
+  public Projekt getProjekt() throws RemoteException
+  {
+    Object p = (Object) super.getAttribute("projekt");
+    if (p == null)
+    {
+      return null; // Kein Projekt zugeordnet
+    }
+
+    Cache cache = Cache.get(Projekt.class, true);
+    return (Projekt) cache.get(p);
+  }
+
+  @Override
   public Long getProjektID() throws RemoteException
   {
-    return (Long) getAttribute("projekt");
+    return (Long) super.getAttribute("projekt");
   }
 
   @Override


### PR DESCRIPTION
Im Wirtschaftsplan wird die Auswahlliste beim Projekt Input entsprechend der aktiven Projekte im Witschaftsplan Zeitraum gefiltert.

PS: Wenn der Zeitraum geändert wird, muss man erst speichern damit die Projektliste neu aufgebaut wird. Ich denke, das ist akzeptabel. Listener beim Datum feuern meiner Erfahrung nach dauernd was nicht so schön ist.
Das aktuell selektierte Projekt bleibt ja auch in jedem Fall erhalten, auch wenn es nicht mehr in den aktuellen Zeitraum fallen würde.