### PR TITLE
fix maven pom warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
     <bytebuddy.agent.version>1.18.8-jdk5</bytebuddy.agent.version>
     <jackson.version>2.21.3</jackson.version>
-    <jackson-annotations.version>2.21</jackson-annotations.version>
+    <jackson.annotations.version>2.21</jackson.annotations.version>
     <release.root>${project.build.directory}/releases</release.root>
     <release.plugin.dir>${release.root}/${project.artifactId}</release.plugin.dir>
     <release.nightly.generated.dir>${project.build.directory}/generated-resources/nightly</release.nightly.generated.dir>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson-annotations.version}</version>
+      <version>${jackson.annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,12 @@
       <artifactId>${swt.artifactId}</artifactId>
       <version>${swt.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.swt</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.ibm.icu</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
     <icu4j.version>52.2</icu4j.version>
     <jaxb.api.version>2.4.0-b180830.0359</jaxb.api.version>
     <bytebuddy.agent.version>1.18.8-jdk5</bytebuddy.agent.version>
+    <jackson.version>2.21.3</jackson.version>
+    <jackson-annotations.version>2.21</jackson-annotations.version>
     <release.root>${project.build.directory}/releases</release.root>
     <release.plugin.dir>${release.root}/${project.artifactId}</release.plugin.dir>
     <release.nightly.generated.dir>${project.build.directory}/generated-resources/nightly</release.nightly.generated.dir>
@@ -87,7 +89,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.3</version>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson-annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.activation</groupId>

--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,17 @@
         "provided"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "com.fasterxml.jackson.core:jackson-core",
+        "com.fasterxml.jackson.core:jackson-annotations"
+      ],
+      "groupName": "jackson core",
+      "groupSlug": "jackson-core"
     }
   ],
   "customManagers": [
@@ -22,9 +33,9 @@
         "/^pom\.xml$/"
       ],
       "matchStrings": [
-        "<!-- renovate: depName=(?<depName>\S+) datasource=(?<datasource>\S+) -->\s*<(?<propertyName>[A-Za-z0-9_.-]+\.version)>(?<currentValue>\d+\.\d+\.\d+)</\k<propertyName>>"
+        "<!-- renovate: depName=(?<depName>\S+) datasource=(?<datasource>\S+) -->\s*<(?<propertyName>[A-Za-z0-9_.-]+\.version)>(?<currentValue>\d+\.\d+(?:\.\d+)?)</\k<propertyName>>"
       ],
-      "versioningTemplate": "regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$"
+      "versioningTemplate": "regex:^(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?$"
     }
   ]
 }


### PR DESCRIPTION
In some classes the annotation `@JsonInclude(JsonInclude.Include.NON_EMPTY)` is used but the dependency `jackson-annotations` was missing. That caused the following warning during `mvn package` execution:

```
[WARNING] unknown enum constant com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
  reason: class file for com.fasterxml.jackson.annotation.JsonInclude$Include not found
```

The second commit fixes the warning/error:
```
[WARNING] The POM for org.eclipse.platform:org.eclipse.swt:jar:3.128.0 is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for org.eclipse.platform:org.eclipse.swt:3.128.0
[ERROR] 'dependencies.dependency.artifactId' for org.eclipse.platform:org.eclipse.swt.${osgi.platform}:jar with value 'org.eclipse.swt.${osgi.platform}' does not match a valid id pattern. @
```

Also, a group rule is added to `renovate.json5` to combine jackson updates into one PR. This could help version drifts between the jackson modules. The regex is also loosed to allow version updates without the patched part.