### PR TITLE
AbstractJVereinControl mit getTablePart und überall Spalten-PanelButton

### DIFF
--- a/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
+++ b/src/de/jost_net/JVerein/Queries/SollbuchungQuery.java
@@ -38,7 +38,6 @@ import de.willuhn.datasource.GenericIterator;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
-import de.willuhn.util.ApplicationException;
 
 public class SollbuchungQuery
 {
@@ -58,8 +57,7 @@ public class SollbuchungQuery
   }
 
   @SuppressWarnings("unchecked")
-  public GenericIterator<Sollbuchung> get()
-      throws RemoteException, ApplicationException
+  public GenericIterator<Sollbuchung> get() throws RemoteException
   {
     Date d1 = null;
     java.sql.Date vd = null;

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -272,13 +272,6 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     return bemerkung;
   }
 
-  final class StatData
-  {
-    Double summe;
-
-    Integer anzahl;
-  }
-
   @Override
   public JVereinDBObject prepareStore() throws RemoteException
   {
@@ -303,7 +296,8 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     }
   }
 
-  public JVereinTablePart getAbrechnungslaeufeList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (abrechnungslaufList != null)
     {
@@ -612,7 +606,7 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     return zusatzbetraegeList;
   }
 
-  public PanelButton getPanelButton()
+  public PanelButton getDetailPanelButton()
   {
     return new PanelButton("document-properties.png", context -> {
       try

--- a/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
@@ -1,0 +1,48 @@
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.parts.PanelButton;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public abstract class AbstractJVereinControl extends AbstractControl
+{
+
+  public AbstractJVereinControl(AbstractView view)
+  {
+    super(view);
+  }
+
+  public PanelButton getSpaltenPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+        new TabelleSpaltenAuswahlDialog(getTablePart()).open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
+  }
+
+  /**
+   * Holten den TablePart mit der Auflistung aller Objecte
+   * 
+   * @return
+   * @throws RemoteException
+   */
+  protected abstract JVereinTablePart getTablePart() throws RemoteException;
+}

--- a/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.Datum;
@@ -174,15 +173,6 @@ public abstract class AbstractSaldoControl extends VorZurueckControl
   }
 
   /**
-   * Erstellt den TablePart mit allen Spalten, die Liste wird aus getList()
-   * geholt.
-   * 
-   * @return der TablePart
-   * @throws ApplicationException
-   */
-  public abstract JVereinTablePart getSaldoList() throws ApplicationException;
-
-  /**
    * Liefert die Liste
    * 
    * @return die Liste der Einträge
@@ -211,10 +201,10 @@ public abstract class AbstractSaldoControl extends VorZurueckControl
       }
 
       ArrayList<PseudoDBObject> zeile = getList();
-      getSaldoList().removeAll();
+      getTablePart().removeAll();
       for (PseudoDBObject sz : zeile)
       {
-        getSaldoList().addItem(sz);
+        getTablePart().addItem(sz);
       }
     }
     catch (RemoteException re)

--- a/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
@@ -33,7 +33,6 @@ import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.DateInput;
@@ -156,7 +155,8 @@ public class AnfangsbestandControl extends FilterControl implements Savable
     }
   }
 
-  public Part getAnfangsbestandList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (anfangsbestandList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -72,63 +72,55 @@ public class AnlagenlisteControl extends AbstractSaldoControl
   }
 
   @Override
-  public SaldoListTablePart getSaldoList() throws ApplicationException
+  public SaldoListTablePart getTablePart() throws RemoteException
   {
-    try
+    if (saldoList != null)
     {
-      if (saldoList != null)
-      {
-        return saldoList;
-      }
-      saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
-      {
-        // Sortieren verhindern
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      saldoList.addColumn("Anlagenart", GRUPPE);
-      saldoList.addColumn("Bezeichnung", KONTO);
-      saldoList.addColumn("Nutzungsdauer", NUTZUNGSDAUER, null, false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Afa Art", AFAART);
-      saldoList.addColumn("Anschaffung", ANSCHAFFUNG_DATUM,
-          new DateFormatter(new JVDateFormatTTMMJJJJ()), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Anschaffungskosten", BETRAG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Buchwert Start GJ", STARTWERT,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Zugang", ZUGANG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Abschreibung", ABSCHREIBUNG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Abgang", ABGANG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Buchwert Ende GJ", ENDWERT,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      // Dummy Spalte, damit endwert nicht am rechten Rand klebt
-      saldoList.addColumn(" ", " ",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_LEFT);
-      saldoList.setFormatter(new SaldoFormatter());
-      saldoList.setMulti(true);
-      saldoList.setContextMenu(new SaldoMenu(this));
       return saldoList;
     }
-    catch (RemoteException e)
+    saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
     {
-      throw new ApplicationException(
-          String.format("Fehler aufgetreten %s", e.getMessage()));
-    }
+      // Sortieren verhindern
+      @Override
+      protected void orderBy(int index)
+      {
+        return;
+      }
+    };
+    saldoList.addColumn("Anlagenart", GRUPPE);
+    saldoList.addColumn("Bezeichnung", KONTO);
+    saldoList.addColumn("Nutzungsdauer", NUTZUNGSDAUER, null, false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Afa Art", AFAART);
+    saldoList.addColumn("Anschaffung", ANSCHAFFUNG_DATUM,
+        new DateFormatter(new JVDateFormatTTMMJJJJ()), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Anschaffungskosten", BETRAG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Buchwert Start GJ", STARTWERT,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Zugang", ZUGANG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Abschreibung", ABSCHREIBUNG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Abgang", ABGANG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Buchwert Ende GJ", ENDWERT,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    // Dummy Spalte, damit endwert nicht am rechten Rand klebt
+    saldoList.addColumn(" ", " ",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_LEFT);
+    saldoList.setFormatter(new SaldoFormatter());
+    saldoList.setMulti(true);
+    saldoList.setContextMenu(new SaldoMenu(this));
+    return saldoList;
   }
 
   protected ExtendedDBIterator<PseudoDBObject> getIterator()

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -116,7 +116,8 @@ public class ArbeitseinsatzControl extends FilterControl implements Savable
     }
   }
 
-  public JVereinTablePart getArbeitseinsatzTable() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (arbeitseinsatzList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.widgets.TableItem;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
-import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
@@ -70,7 +69,6 @@ import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.PanelButton;
-import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
@@ -125,25 +123,6 @@ public class BeitragsgruppeControl extends VorZurueckControl implements Savable
     }
     beitrag = (Beitragsgruppe) getCurrentObject();
     return beitrag;
-  }
-
-  public PanelButton getPanelButton()
-  {
-    return new PanelButton("document-properties.png", context -> {
-      try
-      {
-        new TabelleSpaltenAuswahlDialog(getBeitragsgruppeTable()).open();
-      }
-      catch (OperationCanceledException | ApplicationException e)
-      {
-        throw e;
-      }
-      catch (Exception e)
-      {
-        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
-        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
-      }
-    }, "Spalten auswählen");
   }
 
   public Input getBezeichnung(boolean withFocus) throws RemoteException
@@ -580,7 +559,8 @@ public class BeitragsgruppeControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getBeitragsgruppeTable() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (beitragsgruppeList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1482,7 +1482,8 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     }
   }
 
-  public BuchungListTablePart getBuchungsList() throws RemoteException
+  @Override
+  public BuchungListTablePart getTablePart() throws RemoteException
   {
     params = new TreeMap<>();
 
@@ -2229,7 +2230,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
 
       try
       {
-        getBuchungsList();
+        getTablePart();
       }
       catch (RemoteException e)
       {
@@ -2243,7 +2244,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
   {
     try
     {
-      getBuchungsList();
+      getTablePart();
     }
     catch (RemoteException e)
 
@@ -2645,7 +2646,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
         }
         try
         {
-          getBuchungsList();
+          getTablePart();
         }
         catch (RemoteException ex)
         {
@@ -2693,7 +2694,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
         }
         try
         {
-          getBuchungsList();
+          getTablePart();
         }
         catch (RemoteException ex)
         {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -213,7 +213,7 @@ public class BuchungsartControl extends FilterControl implements Savable
     return steuer;
   }
 
-  public String getBuchungartAttribute()
+  private String getBuchungartAttribute()
   {
     try
     {
@@ -238,7 +238,7 @@ public class BuchungsartControl extends FilterControl implements Savable
     return "bezeichnung";
   }
 
-  public String getBuchungartSortOrder()
+  private String getBuchungartSortOrder()
   {
     try
     {
@@ -340,7 +340,8 @@ public class BuchungsartControl extends FilterControl implements Savable
     }
   }
 
-  public JVereinTablePart getBuchungsartList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (buchungsartList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
@@ -40,8 +40,6 @@ import de.willuhn.util.ApplicationException;
 
 public class BuchungsklasseControl extends VorZurueckControl implements Savable
 {
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart buchungsklassenList;
 
   private TextInput nummer;
@@ -53,8 +51,6 @@ public class BuchungsklasseControl extends VorZurueckControl implements Savable
   public BuchungsklasseControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   private Buchungsklasse getBuchungsklasse()
@@ -125,7 +121,8 @@ public class BuchungsklasseControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getBuchungsklasseList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (buchungsklassenList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -106,53 +106,46 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
   }
 
   @Override
-  public JVereinTablePart getSaldoList() throws ApplicationException
+  public JVereinTablePart getTablePart() throws RemoteException
   {
-    try
+    if (saldoList != null)
     {
-      if (saldoList != null)
-      {
-        return saldoList;
-      }
-      saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
-      {
-        // Sortieren verhindern
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      saldoList.addColumn(gruppenBezeichnung, GRUPPE, null, false);
-      if (mitBuchungsklasseSpalte)
-      {
-        saldoList.addColumn("Buchungsklasse", BUCHUNGSKLASSE_TEXT);
-      }
-      saldoList.addColumn("Buchungsart", BUCHUNGSART_TEXT);
-      saldoList.addColumn("Einnahmen", EINNAHMEN,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Ausgaben", AUSGABEN,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      if (mitUmbuchung)
-      {
-        saldoList.addColumn("Umbuchungen", UMBUCHUNGEN,
-            new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-            Column.ALIGN_RIGHT);
-      }
-      saldoList.addColumn("Anzahl", ANZAHL);
-      saldoList.setMulti(true);
-      saldoList.setRememberState(true);
-      saldoList.setContextMenu(new SaldoMenu(this));
-      saldoList.setFormatter(new SaldoFormatter());
-
       return saldoList;
     }
-    catch (RemoteException e)
+    saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
     {
-      throw new ApplicationException("Fehler aufgetreten " + e.getMessage());
+      // Sortieren verhindern
+      @Override
+      protected void orderBy(int index)
+      {
+        return;
+      }
+    };
+    saldoList.addColumn(gruppenBezeichnung, GRUPPE, null, false);
+    if (mitBuchungsklasseSpalte)
+    {
+      saldoList.addColumn("Buchungsklasse", BUCHUNGSKLASSE_TEXT);
     }
+    saldoList.addColumn("Buchungsart", BUCHUNGSART_TEXT);
+    saldoList.addColumn("Einnahmen", EINNAHMEN,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Ausgaben", AUSGABEN,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    if (mitUmbuchung)
+    {
+      saldoList.addColumn("Umbuchungen", UMBUCHUNGEN,
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+          Column.ALIGN_RIGHT);
+    }
+    saldoList.addColumn("Anzahl", ANZAHL);
+    saldoList.setMulti(true);
+    saldoList.setRememberState(true);
+    saldoList.setContextMenu(new SaldoMenu(this));
+    saldoList.setFormatter(new SaldoFormatter());
+
+    return saldoList;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -262,6 +262,7 @@ public class DokumentControl extends AbstractControl
     target.addDropListener(new DropTargetListener()
     {
 
+      @Override
       public void dragEnter(DropTargetEvent event)
       {
         if (event.detail == DND.DROP_DEFAULT)
@@ -284,6 +285,7 @@ public class DokumentControl extends AbstractControl
         }
       }
 
+      @Override
       public void drop(DropTargetEvent event)
       {
         if (event.data == null)

--- a/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
@@ -44,9 +44,6 @@ import de.willuhn.util.ApplicationException;
 
 public class EigenschaftControl extends VorZurueckControl implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart eigenschaftList;
 
   private Input bezeichnung;
@@ -60,8 +57,6 @@ public class EigenschaftControl extends VorZurueckControl implements Savable
   public EigenschaftControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   private Eigenschaft getEigenschaft() throws RemoteException
@@ -154,7 +149,8 @@ public class EigenschaftControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getEigenschaftList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (eigenschaftList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/EigenschaftGruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EigenschaftGruppeControl.java
@@ -33,7 +33,6 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.TextInput;
@@ -44,9 +43,6 @@ import de.willuhn.util.ApplicationException;
 public class EigenschaftGruppeControl extends VorZurueckControl
     implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart eigenschaftgruppeList;
 
   private Input bezeichnung;
@@ -62,8 +58,6 @@ public class EigenschaftGruppeControl extends VorZurueckControl
   public EigenschaftGruppeControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   private EigenschaftGruppe getEigenschaftGruppe()
@@ -149,7 +143,8 @@ public class EigenschaftGruppeControl extends VorZurueckControl
     }
   }
 
-  public Part getEigenschaftGruppeList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (eigenschaftgruppeList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/FelddefinitionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FelddefinitionControl.java
@@ -158,7 +158,8 @@ public class FelddefinitionControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getFelddefinitionTable() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (felddefinitionList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -31,6 +31,7 @@ import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.action.FormularfeldNeuAction;
 import de.jost_net.JVerein.gui.action.FormularfelderExportAction;
 import de.jost_net.JVerein.gui.action.FormularfelderImportAction;
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.FormularLinkFormatter;
 import de.jost_net.JVerein.gui.formatter.FormularartFormatter;
 import de.jost_net.JVerein.gui.input.FormularInput;
@@ -55,14 +56,12 @@ import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.PanelButton;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class FormularControl extends FormularPartControl implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart formularList;
 
   private TextInput bezeichnung;
@@ -86,8 +85,6 @@ public class FormularControl extends FormularPartControl implements Savable
   public FormularControl(AbstractView view, Formular formular)
   {
     super(view, formular);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public Formular getFormular()
@@ -349,7 +346,8 @@ public class FormularControl extends FormularPartControl implements Savable
     }
   }
 
-  public JVereinTablePart getFormularList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (formularList != null)
     {
@@ -411,8 +409,7 @@ public class FormularControl extends FormularPartControl implements Savable
       throws ApplicationException
   {
     return new PanelButton(
-        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png",
-        context -> {
+        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png", context -> {
           if (formularfelderList == null)
           {
             throw new ApplicationException(
@@ -436,5 +433,24 @@ public class FormularControl extends FormularPartControl implements Savable
               "formularfelder", art);
           GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
+  }
+
+  public PanelButton getDetailSpaltenPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+        new TabelleSpaltenAuswahlDialog(getFormularfeldList()).open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
@@ -264,7 +264,7 @@ public class FormularfeldControl extends FormularPartControl implements Savable
   @Override
   protected JVereinTablePart getTablePart() throws RemoteException
   {
-    // TODO ist das so richtig?
-    return super.getFormularfeldList();
+    // Es gitb keine FormularfeldListe View
+    return null;
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularfeldControl.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungMap;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.keys.Ausrichtung;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Formularfeld;
@@ -42,9 +43,6 @@ import de.willuhn.util.ApplicationException;
 
 public class FormularfeldControl extends FormularPartControl implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private TextAreaInput name;
 
   private IntegerInput seite;
@@ -64,8 +62,6 @@ public class FormularfeldControl extends FormularPartControl implements Savable
   public FormularfeldControl(AbstractView view, Formular formular)
   {
     super(view, formular);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public Formularfeld getFormularfeld()
@@ -263,5 +259,12 @@ public class FormularfeldControl extends FormularPartControl implements Savable
         break;
     }
     return map;
+  }
+
+  @Override
+  protected JVereinTablePart getTablePart() throws RemoteException
+  {
+    // TODO ist das so richtig?
+    return super.getFormularfeldList();
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FreieFormulareControl.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import de.jost_net.JVerein.Queries.MitgliedQuery;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.FreiesFormularAusgabe;
 import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Mitglied;
@@ -125,6 +126,7 @@ public class FreieFormulareControl extends DruckMailControl
     return getMitglieder(this.view.getCurrentObject());
   }
 
+  @Override
   public String getInfoText(Object selection) throws RemoteException
   {
     Mitglied[] mitglieder = null;
@@ -167,5 +169,12 @@ public class FreieFormulareControl extends DruckMailControl
   protected void TabRefresh()
   {
     // Nichts tun, hier ist keine Tabelle implementiert
+  }
+
+  @Override
+  protected JVereinTablePart getTablePart() throws RemoteException
+  {
+    // Nichts tun, hier ist keine Tabelle implementiert
+    return null;
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -27,6 +27,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.menu.JahresabschlussMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart.ExportArt;
@@ -54,13 +55,15 @@ import de.willuhn.jameica.gui.input.DateInput;
 import de.willuhn.jameica.gui.input.DecimalInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.PanelButton;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class JahresabschlussControl extends KontensaldoControl
 {
 
-  private de.willuhn.jameica.system.Settings settings;
+  private Settings settings;
 
   private JVereinTablePart jahresabschlussList;
 
@@ -85,7 +88,7 @@ public class JahresabschlussControl extends KontensaldoControl
   public JahresabschlussControl(AbstractView view) throws RemoteException
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+    settings = new Settings(this.getClass());
     settings.setStoreWhenRead(true);
     summensaldo = false;
   }
@@ -366,7 +369,8 @@ public class JahresabschlussControl extends KontensaldoControl
     }
   }
 
-  public JVereinTablePart getJahresabschlussList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (jahresabschlussList != null)
     {
@@ -392,6 +396,12 @@ public class JahresabschlussControl extends KontensaldoControl
         new EditAction(JahresabschlussDetailView.class, jahresabschlussList));
     VorZurueckControl.setObjektListe(null, null);
     return jahresabschlussList;
+  }
+
+  public JVereinTablePart getSaldoList() throws RemoteException
+  {
+    // TablePart von Kontosaldo verwenden
+    return super.getTablePart();
   }
 
   /**
@@ -461,6 +471,25 @@ public class JahresabschlussControl extends KontensaldoControl
     return text;
   }
 
+  public PanelButton getSpaltenDetailPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+        new TabelleSpaltenAuswahlDialog(getSaldoList()).open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
+  }
+
   public PanelButton exportButton(ExportArt art) throws ApplicationException
   {
     if (jahresabschlussList == null)
@@ -469,18 +498,18 @@ public class JahresabschlussControl extends KontensaldoControl
           "PDF Button kann nicht erstellt werden, Tabelle ist nicht geladen.");
     }
     return new PanelButton(
-        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png",
-        context -> {
-      jahresabschlussList.export(
-          VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_TITEL),
-          VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_SUBTITEL),
-          VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_DATEINAME),
-          "jahresabschluesse", art);
-      GUI.getStatusBar().setSuccessText("Auswertung fertig.");
+        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png", context -> {
+          jahresabschlussList.export(
+              VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_TITEL),
+              VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_SUBTITEL),
+              VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUESSE_DATEINAME),
+              "jahresabschluesse", art);
+          GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
   }
 
-  public PanelButton exportJahresabschlussButton(ExportArt art) throws ApplicationException
+  public PanelButton exportJahresabschlussButton(ExportArt art)
+      throws ApplicationException
   {
     if (saldoList == null)
     {
@@ -488,14 +517,13 @@ public class JahresabschlussControl extends KontensaldoControl
           "PDF Button kann nicht erstellt werden, Tabelle ist nicht geladen.");
     }
     return new PanelButton(
-        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png",
-        context -> {
+        art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png", context -> {
           saldoList.export(
               VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUSS_TITEL, this),
               VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUSS_SUBTITEL, this),
               VorlageUtil.getName(VorlageTyp.JAHRESABSCHLUSS_DATEINAME, this),
-          "jahresabschluss", art);
-      GUI.getStatusBar().setSuccessText("Auswertung fertig.");
+              "jahresabschluss", art);
+          GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -64,49 +64,42 @@ public class KontensaldoControl extends AbstractSaldoControl
   }
 
   @Override
-  public JVereinTablePart getSaldoList() throws ApplicationException
+  public JVereinTablePart getTablePart() throws RemoteException
   {
-    try
+    if (saldoList != null)
     {
-      if (saldoList != null)
+      return saldoList;
+    }
+    saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
+    {
+      @Override
+      protected void orderBy(int index)
       {
-        return saldoList;
+        return;
       }
-      saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
-      {
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      saldoList.addColumn("Kontonummer", KONTO_NUMMER, null, false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Bezeichnung", GRUPPE);
-      saldoList.addColumn("Anfangsbestand", ANFANGSBESTAND,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Einnahmen", EINNAHMEN,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Ausgaben", AUSGABEN,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Umbuchungen", UMBUCHUNGEN,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Endbestand", ENDBESTAND,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Bemerkung", BEMERKUNG);
-      saldoList.setMulti(true);
-      saldoList.setFormatter(new SaldoFormatter());
-      saldoList.setContextMenu(new SaldoMenu(this));
-    }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException("Fehler aufgetreten " + e.getMessage());
-    }
+    };
+    saldoList.addColumn("Kontonummer", KONTO_NUMMER, null, false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Bezeichnung", GRUPPE);
+    saldoList.addColumn("Anfangsbestand", ANFANGSBESTAND,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Einnahmen", EINNAHMEN,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Ausgaben", AUSGABEN,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Umbuchungen", UMBUCHUNGEN,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Endbestand", ENDBESTAND,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Bemerkung", BEMERKUNG);
+    saldoList.setMulti(true);
+    saldoList.setFormatter(new SaldoFormatter());
+    saldoList.setContextMenu(new SaldoMenu(this));
     return saldoList;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -330,7 +330,8 @@ public class KontoControl extends FilterControl implements Savable
     }
   }
 
-  public JVereinTablePart getKontenList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (kontenList != null)
     {
@@ -697,8 +698,9 @@ public class KontoControl extends FilterControl implements Savable
     {
       return anlagenart;
     }
-    anlagenart = new BuchungsartInput().getBuchungsartInput(getKonto().getAnlagenart(),
-        buchungsarttyp.ANLAGENART, (Integer) Einstellungen
+    anlagenart = new BuchungsartInput().getBuchungsartInput(
+        getKonto().getAnlagenart(), buchungsarttyp.ANLAGENART,
+        (Integer) Einstellungen
             .getEinstellung(Property.BUCHUNGBUCHUNGSARTAUSWAHL));
     anlagenart.addListener(new AnlagenartListener());
     if (getKontoArt().getValue() == Kontoart.ANLAGE)
@@ -1071,13 +1073,8 @@ public class KontoControl extends FilterControl implements Savable
     return "bezeichnung";
   }
 
-  public class AnlagenartListener implements Listener
+  private class AnlagenartListener implements Listener
   {
-
-    AnlagenartListener()
-    {
-    }
-
     @Override
     public void handleEvent(Event event)
     {

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -41,6 +41,7 @@ import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.input.StaatSearchInput;
 import de.jost_net.JVerein.gui.menu.KursteilnehmerMenu;
 import de.jost_net.JVerein.gui.parts.BetragSummaryTablePart;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart.ExportArt;
 import de.jost_net.JVerein.gui.view.KursteilnehmerDetailView;
 import de.jost_net.JVerein.io.FileViewer;
@@ -55,7 +56,6 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.DateInput;
@@ -391,7 +391,8 @@ public class KursteilnehmerControl extends FilterControl implements Savable
     return geschlecht;
   }
 
-  public Part getKursteilnehmerTable() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (kursteilnehmerList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -30,6 +30,7 @@ import de.jost_net.JVerein.gui.input.PersonenartInput;
 import de.jost_net.JVerein.gui.menu.LastschriftMenu;
 import de.jost_net.JVerein.gui.parts.BetragSummaryTablePart;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart.ExportArt;
 import de.jost_net.JVerein.gui.view.LastschriftDetailView;
 import de.jost_net.JVerein.gui.view.PreNotificationMailView;
@@ -46,7 +47,6 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.DateInput;
@@ -111,7 +111,8 @@ public class LastschriftControl extends FilterControl implements Savable
     settings.setStoreWhenRead(true);
   }
 
-  public Part getLastschriftList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (lastschriftList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
@@ -319,7 +319,8 @@ public class LehrgangControl extends FilterControl implements Savable
     return lehrgaenge;
   }
 
-  public JVereinTablePart getLehrgaengeList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (lehrgaengeList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
@@ -43,9 +43,6 @@ import de.willuhn.util.ApplicationException;
 
 public class LehrgangsartControl extends VorZurueckControl implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart lehrgangsartList;
 
   private TextInput bezeichnung;
@@ -61,8 +58,6 @@ public class LehrgangsartControl extends VorZurueckControl implements Savable
   public LehrgangsartControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public Lehrgangsart getLehrgangsart()
@@ -166,7 +161,8 @@ public class LehrgangsartControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getLehrgangsartList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (lehrgangsartList != null)
     {
@@ -190,18 +186,6 @@ public class LehrgangsartControl extends VorZurueckControl implements Savable
         new EditAction(LehrgangsartDetailView.class, lehrgangsartList));
     VorZurueckControl.setObjektListe(null, null);
     return lehrgangsartList;
-  }
-
-  public void refreshTable() throws RemoteException
-  {
-    lehrgangsartList.removeAll();
-    DBIterator<Lehrgangsart> lehrgangsarten = Einstellungen.getDBService()
-        .createList(Lehrgangsart.class);
-    while (lehrgangsarten.hasNext())
-    {
-      lehrgangsartList.addItem(lehrgangsarten.next());
-    }
-    lehrgangsartList.sort();
   }
 
   public PanelButton exportButton(ExportArt art) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/control/LesefeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LesefeldControl.java
@@ -173,13 +173,8 @@ public class LesefeldControl extends VorZurueckControl implements Savable
    * Listener, der Änderungen bei suchMitglied überwacht.
    * 
    */
-  public class SuchMitgliedListener implements Listener
+  private class SuchMitgliedListener implements Listener
   {
-
-    SuchMitgliedListener()
-    {
-    }
-
     @Override
     public void handleEvent(Event event)
     {
@@ -231,13 +226,8 @@ public class LesefeldControl extends VorZurueckControl implements Savable
    * Listener, der Änderungen bei mitglied überwacht.
    * 
    */
-  public class MitgliedListener implements Listener
+  private class MitgliedListener implements Listener
   {
-
-    MitgliedListener()
-    {
-    }
-
     @Override
     public void handleEvent(Event event)
     {
@@ -427,7 +417,8 @@ public class LesefeldControl extends VorZurueckControl implements Savable
    * @return Die Lesefelder Tabelle für den LesefeldListeView.
    * 
    */
-  public JVereinTablePart getLesefelderList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (lesefeldList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -665,7 +665,8 @@ public class MailControl extends FilterControl implements IMailControl, Savable
 
   }
 
-  public JVereinTablePart getMailList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (mailsList != null)
     {
@@ -781,6 +782,7 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     target.addDropListener(new DropTargetListener()
     {
 
+      @Override
       public void dragEnter(DropTargetEvent event)
       {
         if (event.detail == DND.DROP_DEFAULT)
@@ -803,6 +805,7 @@ public class MailControl extends FilterControl implements IMailControl, Savable
         }
       }
 
+      @Override
       public void drop(DropTargetEvent event)
       {
         if (event.data == null)

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -31,7 +31,6 @@ import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
-import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
@@ -131,8 +130,8 @@ public class MailVorlageControl extends VorZurueckControl
     }
   }
 
-  public JVereinTablePart getMailVorlageTable(Action action)
-      throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (mailvorlageList != null)
     {
@@ -143,16 +142,10 @@ public class MailVorlageControl extends VorZurueckControl
     mailvorlageList = new JVereinTablePart(fdef, null);
     mailvorlageList.addColumn("Betreff", "betreff");
     mailvorlageList.setContextMenu(new MailVorlageMenu(mailvorlageList));
-    if (action != null)
-    {
-      mailvorlageList.setAction(action);
-    }
-    else
-    {
-      mailvorlageList.setMulti(true);
-      mailvorlageList.setAction(
-          new EditAction(MailVorlageDetailView.class, mailvorlageList));
-    }
+    mailvorlageList.setMulti(true);
+    mailvorlageList.setAction(
+        new EditAction(MailVorlageDetailView.class, mailvorlageList));
+
     VorZurueckControl.setObjektListe(null, null);
     return mailvorlageList;
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2155,7 +2155,14 @@ public class MitgliedControl extends FilterControl implements Savable
         null, false, "document-new.png");
   }
 
-  public JVereinTablePart getMitgliedTable(int atyp, Action detailaction)
+  // TODO nötig?
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
+  {
+    return getTablePart(0, null);
+  }
+
+  public JVereinTablePart getTablePart(int atyp, Action detailaction)
       throws RemoteException
   {
     if (mitgliedList != null)

--- a/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
@@ -40,8 +40,6 @@ import de.willuhn.util.ApplicationException;
 
 public class MitgliedstypControl extends VorZurueckControl implements Savable
 {
-  private de.willuhn.jameica.system.Settings settings;
-
   private JVereinTablePart mitgliedstypList;
 
   private Input bezeichnung;
@@ -55,8 +53,6 @@ public class MitgliedstypControl extends VorZurueckControl implements Savable
   public MitgliedstypControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public Mitgliedstyp getMitgliedstyp()
@@ -134,7 +130,8 @@ public class MitgliedstypControl extends VorZurueckControl implements Savable
     }
   }
 
-  public JVereinTablePart getMitgliedstypList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (mitgliedstypList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -274,7 +274,7 @@ public class MittelverwendungControl extends AbstractSaldoControl
   }
 
   @Override
-  public JVereinTablePart getSaldoList() throws ApplicationException
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     switch (selectedTab)
     {
@@ -292,87 +292,71 @@ public class MittelverwendungControl extends AbstractSaldoControl
    * Den TablePart für die Saldobasierte Mittelverwendung holen
    * 
    * @return TablePart
-   * @throws ApplicationException
+   * @throws RemoteException
    */
-  public JVereinTablePart getMittelverwendungSaldoTable()
-      throws ApplicationException
+  public JVereinTablePart getMittelverwendungSaldoTable() throws RemoteException
   {
-    try
+    if (saldoList != null)
     {
-      if (saldoList != null)
-      {
-        return saldoList;
-      }
-      saldoList = new JVereinTablePart(getMittelverwendungSaldoList(), null)
-      {
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      saldoList.addColumn("Art", GRUPPE);
-      saldoList.addColumn("Konto", BEZEICHNUNG);
-      saldoList.addColumn("Betrag", BETRAG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Summe", SUMME,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Kommentar", KOMMENTAR);
-      saldoList.removeFeature(FeatureSummary.class);
-      saldoList.setFormatter(new SaldoFormatter());
       return saldoList;
     }
-    catch (RemoteException e)
+    saldoList = new JVereinTablePart(getMittelverwendungSaldoList(), null)
     {
-      throw new ApplicationException("Fehler aufgetreten " + e.getMessage());
-    }
+      @Override
+      protected void orderBy(int index)
+      {
+        return;
+      }
+    };
+    saldoList.addColumn("Art", GRUPPE);
+    saldoList.addColumn("Konto", BEZEICHNUNG);
+    saldoList.addColumn("Betrag", BETRAG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Summe", SUMME,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Kommentar", KOMMENTAR);
+    saldoList.removeFeature(FeatureSummary.class);
+    saldoList.setFormatter(new SaldoFormatter());
+    return saldoList;
   }
 
   /**
    * Den TablePart für die Zuflussbsiere Mittelverwendung holen
    * 
    * @return TablePart
-   * @throws ApplicationException
+   * @throws RemoteException
    */
-  public JVereinTablePart getMittelverwendungFlowTable()
-      throws ApplicationException
+  public JVereinTablePart getMittelverwendungFlowTable() throws RemoteException
   {
-    try
+    if (zuflussList != null)
     {
-      if (zuflussList != null)
-      {
-        return zuflussList;
-      }
-      zuflussList = new JVereinTablePart(getMittelverwendungFlowList(
-          getDatumvon().getDate(), getDatumbis().getDate()), null)
-      {
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      zuflussList.addColumn("Nr", NR);
-      zuflussList.addColumn("Mittel", GRUPPE);
-      zuflussList.addColumn("Betrag", BETRAG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      zuflussList.addColumn("Summe", SUMME,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      // Dummy Spalte, damit Summe nicht am rechten Rand klebt
-      zuflussList.addColumn(" ", " ",
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_LEFT);
-      zuflussList.removeFeature(FeatureSummary.class);
       return zuflussList;
     }
-    catch (RemoteException e)
+    zuflussList = new JVereinTablePart(getMittelverwendungFlowList(
+        getDatumvon().getDate(), getDatumbis().getDate()), null)
     {
-      throw new ApplicationException("Fehler aufgetreten" + e.getMessage());
-    }
+      @Override
+      protected void orderBy(int index)
+      {
+        return;
+      }
+    };
+    zuflussList.addColumn("Nr", NR);
+    zuflussList.addColumn("Mittel", GRUPPE);
+    zuflussList.addColumn("Betrag", BETRAG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    zuflussList.addColumn("Summe", SUMME,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    // Dummy Spalte, damit Summe nicht am rechten Rand klebt
+    zuflussList.addColumn(" ", " ",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_LEFT);
+    zuflussList.removeFeature(FeatureSummary.class);
+    return zuflussList;
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/control/PersonalbogenControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PersonalbogenControl.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import de.jost_net.JVerein.Queries.MitgliedQuery;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.PersonalbogenAusgabe;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.keys.Ausgabeart;
@@ -189,6 +190,7 @@ public class PersonalbogenControl extends DruckMailControl
     return getMitglieder(this.view.getCurrentObject());
   }
 
+  @Override
   public String getInfoText(Object selection) throws RemoteException
   {
     Mitglied[] mitglieder = null;
@@ -326,5 +328,12 @@ public class PersonalbogenControl extends DruckMailControl
   protected void TabRefresh()
   {
     // Nichts tun, hier ist keine Tabelle implementiert
+  }
+
+  @Override
+  protected JVereinTablePart getTablePart() throws RemoteException
+  {
+    // Nichts tun, hier ist keine Tabelle implementiert
+    return null;
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.TabFolder;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.PreNotificationAusgabe;
 import de.jost_net.JVerein.io.Ueberweisung;
 import de.jost_net.JVerein.keys.Ausgabeart;
@@ -486,5 +487,12 @@ public class PreNotificationControl extends DruckMailControl
     text.setName("Abrechnungslauf");
     text.disable();
     return text;
+  }
+
+  @Override
+  protected JVereinTablePart getTablePart() throws RemoteException
+  {
+    // Nichts tun, hier ist keine Tabelle implementiert
+    return null;
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/ProjektControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektControl.java
@@ -147,7 +147,8 @@ public class ProjektControl extends FilterControl implements Savable
     }
   }
 
-  public JVereinTablePart getProjektList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (projektList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektSaldoControl.java
@@ -84,19 +84,15 @@ public class ProjektSaldoControl extends BuchungsklasseSaldoControl
         }
         saveProjektSettings();
         ArrayList<PseudoDBObject> zeile = getList();
-        getSaldoList().removeAll();
+        getTablePart().removeAll();
         for (PseudoDBObject sz : zeile)
         {
-          getSaldoList().addItem(sz);
+          getTablePart().addItem(sz);
         }
       }
       catch (RemoteException e1)
       {
         Logger.error("Fehler", e1);
-      }
-      catch (ApplicationException e)
-      {
-        Logger.error("Fehler bei neu laden der Liste.");
       }
     }
   }

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -28,6 +28,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.control.SollbuchungControl.DIFFERENZ;
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.formatter.ZahlungswegFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
@@ -78,6 +79,7 @@ import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.PanelButton;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -158,8 +160,8 @@ public class RechnungControl extends DruckMailControl implements Savable
     settings.setStoreWhenRead(true);
   }
 
-  @SuppressWarnings("unchecked")
-  public BetragSummaryTablePart getRechnungList() throws RemoteException
+  @Override
+  public BetragSummaryTablePart getTablePart() throws RemoteException
   {
     if (rechnungList != null)
     {
@@ -256,7 +258,6 @@ public class RechnungControl extends DruckMailControl implements Savable
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void TabRefresh()
   {
     try
@@ -278,8 +279,8 @@ public class RechnungControl extends DruckMailControl implements Savable
     }
   }
 
-  @SuppressWarnings("rawtypes")
-  public GenericIterator getRechnungIterator() throws RemoteException
+  @SuppressWarnings("unchecked")
+  public GenericIterator<Rechnung> getRechnungIterator() throws RemoteException
   {
     DBIterator<Rechnung> rechnungenIt = Einstellungen.getDBService()
         .createList(Rechnung.class);
@@ -931,6 +932,27 @@ public class RechnungControl extends DruckMailControl implements Savable
       }
     }
     return map;
+  }
+
+  public PanelButton getDetailSpaltenPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+
+        new TabelleSpaltenAuswahlDialog(getSollbuchungPositionListPart())
+            .open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
   }
 
   public PanelButton exportButton(ExportArt art) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -34,6 +34,7 @@ import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.Queries.SollbuchungQuery;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
 import de.jost_net.JVerein.gui.menu.BuchungPartBearbeitenMenu;
 import de.jost_net.JVerein.gui.menu.MitgliedskontoMenu;
@@ -85,6 +86,7 @@ import de.willuhn.jameica.gui.util.SWTUtil;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -424,8 +426,15 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     return mitgliedskontoTree;
   }
 
-  public JVereinTablePart getSollbuchungenList(Action action, boolean umwandeln,
-      boolean multi) throws RemoteException, ApplicationException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
+  {
+    // TODO richtig so?
+    return getTablePart(null, false, false);
+  }
+
+  public JVereinTablePart getTablePart(Action action, boolean umwandeln,
+      boolean multi) throws RemoteException
   {
     if (sollbuchungenList != null)
     {
@@ -502,10 +511,6 @@ public class SollbuchungControl extends DruckMailControl implements Savable
       {
         Logger.error("Fehler beim Refresh der Tabelle", e);
       }
-      catch (ApplicationException e)
-      {
-        GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
-      }
     }
   }
 
@@ -551,7 +556,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     }
   }
 
-  public Part getSollbuchungPositionListPart() throws RemoteException
+  public JVereinTablePart getSollbuchungList() throws RemoteException
   {
     if (buchungList != null)
     {
@@ -581,7 +586,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     return buchungList;
   }
 
-  public Part getBuchungListPart() throws RemoteException
+  public JVereinTablePart getBuchungList() throws RemoteException
   {
     if (istbuchungList != null)
     {
@@ -655,10 +660,6 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     {
       Logger.error("Fehler", e);
     }
-    catch (ApplicationException e)
-    {
-      GUI.getStatusBar().setErrorText(e.getLocalizedMessage());
-    }
   }
 
   public Button getStartKontoauszugButton(final Object currentObject)
@@ -691,7 +692,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     return button;
   }
 
-  public static class MitgliedskontoTreeFormatter implements TreeFormatter
+  private static class MitgliedskontoTreeFormatter implements TreeFormatter
   {
     @Override
     public void format(TreeItem item)
@@ -1067,6 +1068,26 @@ public class SollbuchungControl extends DruckMailControl implements Savable
               "sollbuchungen", art);
           GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
+  }
+
+  public PanelButton getDetailSpaltenPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+        new TabelleSpaltenAuswahlDialog(getSollbuchungList(), getBuchungList())
+            .open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
   }
 
   public void deregisterSollbuchungConsumer()

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -429,8 +429,9 @@ public class SollbuchungControl extends DruckMailControl implements Savable
   @Override
   public JVereinTablePart getTablePart() throws RemoteException
   {
-    // TODO richtig so?
-    return getTablePart(null, false, false);
+    // dieser Aufruf wird nur für den Spalten-PanelButton gebraucht, da muss die
+    // Tabelle schon existieren
+    return sollbuchungenList;
   }
 
   public JVereinTablePart getTablePart(Action action, boolean umwandeln,

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -34,6 +34,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.input.MailAuswertungInput;
 import de.jost_net.JVerein.gui.input.MitgliedInput;
@@ -42,6 +43,7 @@ import de.jost_net.JVerein.gui.menu.SpendenbescheinigungMenu;
 import de.jost_net.JVerein.gui.parts.BetragSummaryTablePart;
 import de.jost_net.JVerein.gui.parts.BuchungListPart;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart.ExportArt;
 import de.jost_net.JVerein.gui.view.SpendenbescheinigungDetailView;
 import de.jost_net.JVerein.gui.view.SpendenbescheinigungMailView;
@@ -71,7 +73,6 @@ import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.AbstractInput;
@@ -85,6 +86,7 @@ import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.PanelButton;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -435,7 +437,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return versanddatum;
   }
 
-  public Part getBuchungListPart() throws RemoteException
+  public JVereinTablePart getBuchungListPart() throws RemoteException
   {
     return new BuchungListPart(getSpendenbescheinigung().getBuchungen(),
         new BuchungAction(false), new BuchungPartAnzeigenMenu());
@@ -514,7 +516,8 @@ public class SpendenbescheinigungControl extends DruckMailControl
     return b;
   }
 
-  public Part getSpendenbescheinigungList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (spbList != null)
     {
@@ -844,7 +847,7 @@ public class SpendenbescheinigungControl extends DruckMailControl
     }, null, true, "walking.png");
   }
 
-  public class MitgliedListener implements Listener
+  private class MitgliedListener implements Listener
   {
     @Override
     public void handleEvent(Event event)
@@ -1008,5 +1011,24 @@ public class SpendenbescheinigungControl extends DruckMailControl
               "spendenbescheinigungen", art);
           GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
+  }
+
+  public PanelButton getDetailSpaltenPanelButton()
+  {
+    return new PanelButton("document-properties.png", context -> {
+      try
+      {
+        new TabelleSpaltenAuswahlDialog(getBuchungListPart()).open();
+      }
+      catch (OperationCanceledException | ApplicationException e)
+      {
+        throw e;
+      }
+      catch (Exception e)
+      {
+        Logger.error("Fehler beim Spalten-Auswahl-Dialog", e);
+        throw new ApplicationException("Fehler beim Spalten-Auswahl-Dialog");
+      }
+    }, "Spalten auswählen");
   }
 }

--- a/src/de/jost_net/JVerein/gui/control/SteuerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SteuerControl.java
@@ -88,42 +88,35 @@ public class SteuerControl extends VorZurueckControl implements Savable
     return steuer;
   }
 
-  public JVereinTablePart getSteuerList() throws ApplicationException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
-    try
+    if (steuerList != null)
     {
-      if (steuerList != null)
-      {
-        return steuerList;
-      }
-      DBIterator<Steuer> steuern = Einstellungen.getDBService()
-          .createList(Steuer.class);
-
-      steuerList = new JVereinTablePart(steuern, null);
-      steuerList.addColumn("Name", "name");
-      steuerList.addColumn("Steuersatz", "satz", o -> {
-        return Einstellungen.DECIMALFORMAT.format(o) + "%";
-      }, false, Column.ALIGN_RIGHT);
-      steuerList.addColumn("Buchungsart", "buchungsart",
-          new BuchungsartFormatter());
-      if ((Boolean) Einstellungen
-          .getEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG))
-      {
-        steuerList.addColumn("Buchungsklasse", "buchungsklasse",
-            new BuchungsklasseFormatter());
-      }
-      steuerList.addColumn("Aktiv", "aktiv", new JaNeinFormatter());
-      steuerList.setContextMenu(new SteuerMenue(steuerList));
-      steuerList.setMulti(true);
-      steuerList.setCheckable(false);
-      steuerList.setAction(new EditAction(SteuerDetailView.class, steuerList));
       return steuerList;
     }
-    catch (RemoteException e)
+    DBIterator<Steuer> steuern = Einstellungen.getDBService()
+        .createList(Steuer.class);
+
+    steuerList = new JVereinTablePart(steuern, null);
+    steuerList.addColumn("Name", "name");
+    steuerList.addColumn("Steuersatz", "satz", o -> {
+      return Einstellungen.DECIMALFORMAT.format(o) + "%";
+    }, false, Column.ALIGN_RIGHT);
+    steuerList.addColumn("Buchungsart", "buchungsart",
+        new BuchungsartFormatter());
+    if ((Boolean) Einstellungen
+        .getEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG))
     {
-      throw new ApplicationException(
-          String.format("Fehler aufgetreten %s", e.getMessage()));
+      steuerList.addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
     }
+    steuerList.addColumn("Aktiv", "aktiv", new JaNeinFormatter());
+    steuerList.setContextMenu(new SteuerMenue(steuerList));
+    steuerList.setMulti(true);
+    steuerList.setCheckable(false);
+    steuerList.setAction(new EditAction(SteuerDetailView.class, steuerList));
+    return steuerList;
   }
 
   public TextInput getName() throws RemoteException

--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -62,39 +62,32 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
   }
 
   @Override
-  public SaldoListTablePart getSaldoList() throws ApplicationException
+  public SaldoListTablePart getTablePart() throws RemoteException
   {
-    try
+    if (saldoList != null)
     {
-      if (saldoList != null)
+      return saldoList;
+    }
+    saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
+    {
+      @Override
+      protected void orderBy(int index)
       {
-        return saldoList;
+        return;
       }
-      saldoList = new SaldoListTablePart(getList(), new SaldoDetailAction())
-      {
-        @Override
-        protected void orderBy(int index)
-        {
-          return;
-        }
-      };
-      saldoList.addColumn("Steuerart", GRUPPE, null, false, Column.ALIGN_RIGHT);
-      saldoList.addColumn("Steuer Name", STEUER);
-      saldoList.addColumn("Bemessungsgrundlage", BEMESSUNGSGRUNDLAGE,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Steuerbetrag", STEUERBETRAG,
-          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-          Column.ALIGN_RIGHT);
-      saldoList.addColumn("Anzahl", ANZAHL);
-      saldoList.setMulti(true);
-      saldoList.setFormatter(new SaldoFormatter());
-      saldoList.setContextMenu(new SaldoMenu(this));
-    }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException("Fehler aufgetreten " + e.getMessage());
-    }
+    };
+    saldoList.addColumn("Steuerart", GRUPPE, null, false, Column.ALIGN_RIGHT);
+    saldoList.addColumn("Steuer Name", STEUER);
+    saldoList.addColumn("Bemessungsgrundlage", BEMESSUNGSGRUNDLAGE,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Steuerbetrag", STEUERBETRAG,
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
+        Column.ALIGN_RIGHT);
+    saldoList.addColumn("Anzahl", ANZAHL);
+    saldoList.setMulti(true);
+    saldoList.setFormatter(new SaldoFormatter());
+    saldoList.setContextMenu(new SaldoMenu(this));
     return saldoList;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/VorZurueckControl.java
+++ b/src/de/jost_net/JVerein/gui/control/VorZurueckControl.java
@@ -24,11 +24,10 @@ import org.eclipse.swt.widgets.Composite;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
 import de.willuhn.datasource.rmi.DBObject;
-import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 
-public class VorZurueckControl extends AbstractControl
+public abstract class VorZurueckControl extends AbstractJVereinControl
 {
   static Class<? extends AbstractView> viewClass;
 

--- a/src/de/jost_net/JVerein/gui/control/VorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/VorlageControl.java
@@ -36,7 +36,6 @@ import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.jameica.gui.AbstractView;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.table.FeatureSummary;
@@ -143,7 +142,8 @@ public class VorlageControl extends FilterControl implements Savable
     }
   }
 
-  public Part getDateinamenList() throws RemoteException, ApplicationException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (namenList != null)
     {
@@ -178,14 +178,13 @@ public class VorlageControl extends FilterControl implements Savable
       }
       namenList.sort();
     }
-    catch (RemoteException | ApplicationException e1)
+    catch (RemoteException e1)
     {
       Logger.error("Fehler", e1);
     }
   }
 
-  private List<Vorlage> getVorlagenList()
-      throws RemoteException, ApplicationException
+  private List<Vorlage> getVorlagenList() throws RemoteException
   {
     String tmpSuchtext = ((String) getSuchtext().getValue()).toLowerCase();
     Vorlageart art = (Vorlageart) getVorlagenart().getValue();
@@ -211,7 +210,16 @@ public class VorlageControl extends FilterControl implements Savable
             null);
         vorlage.setAttribute(Vorlage.KEY, typ.getKey());
         vorlage.setMuster(typ.getDefault());
-        vorlage.store();
+        try
+        {
+          vorlage.store();
+        }
+        catch (ApplicationException e)
+        {
+          // kann nicht vorkommen, da es nur von insertCheck geworfen wird, und
+          // da ist bei VorlageImpl nichts implementiert
+          throw new RemoteException(e.getMessage());
+        }
       }
       // ggf. Filtern
       if (art != null && art.getKey() != typ.getArtkey())

--- a/src/de/jost_net/JVerein/gui/control/WiedervorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WiedervorlageControl.java
@@ -213,7 +213,8 @@ public class WiedervorlageControl extends FilterControl implements Savable
     }
   }
 
-  public AutoUpdateTablePart getWiedervorlageList() throws RemoteException
+  @Override
+  public AutoUpdateTablePart getTablePart() throws RemoteException
   {
     if (wiedervorlageList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -57,7 +57,6 @@ import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.input.SelectInput;
@@ -98,9 +97,6 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
   public WirtschaftsplanControl(AbstractView view) throws RemoteException
   {
     super(view);
-    de.willuhn.jameica.system.Settings settings = new de.willuhn.jameica.system.Settings(
-        this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   /**
@@ -110,7 +106,8 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
    * @throws RemoteException
    *           wenn ein Fehler beim Zugriff auf die Datenbank auftritt.
    */
-  public Part getWirtschaftsplanungList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (wirtschaftsplaene != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -56,7 +56,6 @@ import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
 import de.willuhn.jameica.gui.formatter.DateFormatter;
 import de.willuhn.jameica.gui.formatter.Formatter;
@@ -68,9 +67,6 @@ import de.willuhn.util.ApplicationException;
 
 public class ZusatzbetragControl extends VorZurueckControl implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private Zusatzbetrag zuab;
 
   private ZusatzbetragPart part;
@@ -90,8 +86,6 @@ public class ZusatzbetragControl extends VorZurueckControl implements Savable
   public ZusatzbetragControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public Zusatzbetrag getZusatzbetrag()
@@ -251,7 +245,8 @@ public class ZusatzbetragControl extends VorZurueckControl implements Savable
     }
   }
 
-  public Part getZusatzbetraegeList() throws RemoteException
+  @Override
+  public JVereinTablePart getTablePart() throws RemoteException
   {
     if (zusatzbetraegeList != null)
     {

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
@@ -66,9 +66,6 @@ import de.willuhn.util.ApplicationException;
 public class ZusatzbetragVorlageControl extends VorZurueckControl
     implements Savable
 {
-
-  private de.willuhn.jameica.system.Settings settings;
-
   private DateInput faelligkeit = null;
 
   private TextInput buchungstext;
@@ -100,8 +97,6 @@ public class ZusatzbetragVorlageControl extends VorZurueckControl
   public ZusatzbetragVorlageControl(AbstractView view)
   {
     super(view);
-    settings = new de.willuhn.jameica.system.Settings(this.getClass());
-    settings.setStoreWhenRead(true);
   }
 
   public ZusatzbetragVorlage getZusatzbetragVorlage()
@@ -126,18 +121,6 @@ public class ZusatzbetragVorlageControl extends VorZurueckControl
     this.faelligkeit = new DateInput(d, new JVDateFormatTTMMJJJJ());
     this.faelligkeit.setTitle("Fälligkeit");
     this.faelligkeit.setText("Bitte Fälligkeitsdatum wählen");
-    this.faelligkeit.addListener(new Listener()
-    {
-      @Override
-      public void handleEvent(Event event)
-      {
-        Date date = (Date) faelligkeit.getValue();
-        if (date == null)
-        {
-          return;
-        }
-      }
-    });
     return faelligkeit;
   }
 
@@ -223,8 +206,9 @@ public class ZusatzbetragVorlageControl extends VorZurueckControl
     {
       return buchungsart;
     }
-    buchungsart = new BuchungsartInput().getBuchungsartInput(getZusatzbetragVorlage().getBuchungsart(),
-        buchungsarttyp.BUCHUNGSART, (Integer) Einstellungen
+    buchungsart = new BuchungsartInput().getBuchungsartInput(
+        getZusatzbetragVorlage().getBuchungsart(), buchungsarttyp.BUCHUNGSART,
+        (Integer) Einstellungen
             .getEinstellung(Property.BUCHUNGBUCHUNGSARTAUSWAHL));
     buchungsart.addListener(new Listener()
     {
@@ -388,8 +372,8 @@ public class ZusatzbetragVorlageControl extends VorZurueckControl
     }
   }
 
-  public BetragSummaryTablePart getZusatzbetraegeVorlageList()
-      throws RemoteException
+  @Override
+  public BetragSummaryTablePart getTablePart() throws RemoteException
   {
     if (zusatzbetragVorlageList != null)
     {

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -22,6 +22,7 @@ import java.rmi.RemoteException;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.gui.control.MailVorlageControl;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
@@ -64,8 +65,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
       {
         try
         {
-          retval = (MailVorlage) control.getMailVorlageTable(null)
-              .getSelection();
+          retval = (MailVorlage) control.getTablePart().getSelection();
         }
         catch (RemoteException e)
         {
@@ -75,7 +75,9 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
         close();
       }
     };
-    control.getMailVorlageTable(action).paint(parent);
+    JVereinTablePart tablepart = control.getTablePart();
+    tablepart.setAction(action);
+    tablepart.paint(parent);
 
     ButtonArea b = new ButtonArea();
 

--- a/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/MailVorlagenAuswahlDialog.java
@@ -77,6 +77,7 @@ public class MailVorlagenAuswahlDialog extends AbstractDialog<MailVorlage>
     };
     JVereinTablePart tablepart = control.getTablePart();
     tablepart.setAction(action);
+    tablepart.setMulti(false);
     tablepart.paint(parent);
 
     ButtonArea b = new ButtonArea();

--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
@@ -145,7 +145,7 @@ public class SollbuchungAuswahlDialog extends AbstractDialog<Object>
         close();
       }
     };
-    sollbuchunglist = control.getSollbuchungenList(action, true, multi);
+    sollbuchunglist = control.getTablePart(action, true, multi);
     sollbuchunglist.paint(tabNurIst.getComposite());
 
     TabGroup tabSollIst = new TabGroup(folder,

--- a/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
+++ b/src/de/jost_net/JVerein/gui/menu/BuchungMenu.java
@@ -65,7 +65,7 @@ public class BuchungMenu extends ContextMenu
   {
     boolean geldkonto = control.getGeldkonto();
     addItem(new CheckedSingleContextMenuItem("Bearbeiten",
-        new BuchungAction(false, control.getBuchungsList()),
+        new BuchungAction(false, control.getTablePart()),
         "text-x-generic.png"));
     addItem(new GeprueftBuchungItem("Als \"geprüft\" markieren",
         new BuchungGeprueftAction(true), "emblem-default.png", false));

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
@@ -122,11 +122,11 @@ public class AbrechnungslaufDetailView extends AbstractDetailView
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
 
-    GUI.getView().addPanelButton(control.getDetailPanelButton());
     GUI.getView()
         .addPanelButton(control.exportAbrechnungslaufTabsButton(ExportArt.PDF));
     GUI.getView()
         .addPanelButton(control.exportAbrechnungslaufTabsButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getDetailPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
@@ -122,7 +122,7 @@ public class AbrechnungslaufDetailView extends AbstractDetailView
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
 
-    GUI.getView().addPanelButton(control.getPanelButton());
+    GUI.getView().addPanelButton(control.getDetailPanelButton());
     GUI.getView()
         .addPanelButton(control.exportAbrechnungslaufTabsButton(ExportArt.PDF));
     GUI.getView()

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListeView.java
@@ -60,7 +60,7 @@ public class AbrechnungslaufListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getAbrechnungslaeufeList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -71,5 +71,6 @@ public class AbrechnungslaufListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
@@ -117,14 +117,6 @@ public abstract class AbstractMitgliedListeView extends AbstractView
     GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
-  // TODO Warum ist das hier???
-  @Override
-  public void unbind()
-  {
-    if (p != null)
-      p.removeAll();
-  }
-
   public abstract String getTitle();
 
   public abstract void getFilter() throws RemoteException;

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
@@ -24,6 +24,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.MitgliederImportAction;
 import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart.ExportArt;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
@@ -35,13 +36,12 @@ import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.LabelInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
-import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.logging.Logger;
 
 public abstract class AbstractMitgliedListeView extends AbstractView
 {
 
-  private TablePart p;
+  private JVereinTablePart p;
 
   final MitgliedControl control = new MitgliedControl(this);
 
@@ -92,12 +92,12 @@ public abstract class AbstractMitgliedListeView extends AbstractView
       if (mt != null)
       {
         Logger.debug(mt.getID() + ": " + mt.getBezeichnung());
-        p = control.getMitgliedTable(Integer.parseInt(mt.getID()),
+        p = control.getTablePart(Integer.parseInt(mt.getID()),
             getDetailAction());
       }
       else
       {
-        p = control.getMitgliedTable(0, getDetailAction());
+        p = control.getTablePart(0, getDetailAction());
       }
       p.paint(getParent());
     }
@@ -114,8 +114,10 @@ public abstract class AbstractMitgliedListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
+  // TODO Warum ist das hier???
   @Override
   public void unbind()
   {

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandListeView.java
@@ -62,7 +62,7 @@ public class AnfangsbestandListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getAnfangsbestandList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -73,5 +73,6 @@ public class AnfangsbestandListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
@@ -123,7 +123,7 @@ public class AnlagenbuchungListeView extends AbstractView
     left2.addLabelPair("Saldo:", headerControl.getAktJahrSaldoInput());
     right2.addLabelPair("Saldo:", headerControl.getVorJahrSaldoInput());
 
-    control.getBuchungsList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/AnlagenverzeichnisView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenverzeichnisView.java
@@ -41,7 +41,7 @@ public class AnlagenverzeichnisView extends AbstractView
     qpart.paint(this.getParent());
 
     LabelGroup group = new LabelGroup(getParent(), "Liste", true);
-    group.addPart(control.getSaldoList());
+    group.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
@@ -66,7 +66,7 @@ public class ArbeitseinsatzListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getArbeitseinsatzTable().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -85,5 +85,6 @@ public class ArbeitseinsatzListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeListeView.java
@@ -35,7 +35,7 @@ public class BeitragsgruppeListeView extends AbstractView
 
     BeitragsgruppeControl control = new BeitragsgruppeControl(this);
 
-    control.getBeitragsgruppeTable().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -45,8 +45,8 @@ public class BeitragsgruppeListeView extends AbstractView
         null, false, "document-new.png");
     buttons.paint(this.getParent());
 
-    GUI.getView().addPanelButton(control.getPanelButton());
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
@@ -135,7 +135,7 @@ public class BuchungListeView extends AbstractView
     left2.addLabelPair("Saldo:", headerControl.getAktJahrSaldoInput());
     right2.addLabelPair("Saldo:", headerControl.getVorJahrSaldoInput());
 
-    control.getBuchungsList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartListeView.java
@@ -55,7 +55,7 @@ public class BuchungsartListeView extends AbstractView
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
 
-    control.getBuchungsartList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -67,5 +67,6 @@ public class BuchungsartListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseListeView.java
@@ -35,7 +35,7 @@ public class BuchungsklasseListeView extends AbstractView
 
     BuchungsklasseControl control = new BuchungsklasseControl(this);
 
-    control.getBuchungsklasseList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class BuchungsklasseListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -42,7 +42,7 @@ public class BuchungsklasseSaldoView extends AbstractView
     qpart.paint(this.getParent());
 
     LabelGroup group = new LabelGroup(getParent(), "Saldo", true);
-    group.addPart(control.getSaldoList());
+    group.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
@@ -35,7 +35,7 @@ public class EigenschaftGruppeListeView extends AbstractView
 
     EigenschaftGruppeControl control = new EigenschaftGruppeControl(this);
 
-    control.getEigenschaftGruppeList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -46,5 +46,6 @@ public class EigenschaftGruppeListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
@@ -35,7 +35,7 @@ public class EigenschaftListeView extends AbstractView
 
     EigenschaftControl control = new EigenschaftControl(this);
 
-    control.getEigenschaftList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class EigenschaftListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenVorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenVorlageListeView.java
@@ -42,7 +42,7 @@ public class EinstellungenVorlageListeView extends AbstractView
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
 
-    control.getDateinamenList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
@@ -92,6 +92,7 @@ public class FormularDetailView extends AbstractDetailView
         .addPanelButton(control.exportFormularFelderButton(ExportArt.PDF));
     GUI.getView()
         .addPanelButton(control.exportFormularFelderButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getDetailSpaltenPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/FormularListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularListeView.java
@@ -36,7 +36,7 @@ public class FormularListeView extends AbstractView
 
     FormularControl control = new FormularControl(this, null);
 
-    control.getFormularList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -50,5 +50,6 @@ public class FormularListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
@@ -83,8 +83,7 @@ public class JahresabschlussDetailView extends AbstractView
       right.addLabelPair("Zwanghafte satzungsgemäße\nWeitergabe von Mitteln",
           control.getZwanghafteWeitergabe());
     }
-
-    control.getTablePart().paint(this.getParent());
+    control.getSaldoList().paint(this.getParent());
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -104,7 +103,10 @@ public class JahresabschlussDetailView extends AbstractView
     buttons.addButton(save);
     buttons.paint(this.getParent());
 
-    GUI.getView().addPanelButton(control.exportJahresabschlussButton(ExportArt.PDF));
-    GUI.getView().addPanelButton(control.exportJahresabschlussButton(ExportArt.CSV));
+    GUI.getView()
+        .addPanelButton(control.exportJahresabschlussButton(ExportArt.PDF));
+    GUI.getView()
+        .addPanelButton(control.exportJahresabschlussButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenDetailPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
@@ -84,7 +84,7 @@ public class JahresabschlussDetailView extends AbstractView
           control.getZwanghafteWeitergabe());
     }
 
-    control.getSaldoList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussListeView.java
@@ -35,7 +35,7 @@ public class JahresabschlussListeView extends AbstractView
 
     JahresabschlussControl control = new JahresabschlussControl(this);
 
-    control.getJahresabschlussList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class JahresabschlussListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/KontoListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoListeView.java
@@ -55,7 +55,7 @@ public class KontoListeView extends AbstractView
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
 
-    control.getKontenList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -68,5 +68,6 @@ public class KontoListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/KontoSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoSaldoView.java
@@ -42,7 +42,7 @@ public class KontoSaldoView extends AbstractView
     part.paint(this.getParent());
 
     LabelGroup group2 = new LabelGroup(getParent(), "Saldo", true);
-    group2.addPart(control.getSaldoList());
+    group2.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerListeView.java
@@ -75,7 +75,7 @@ public class KursteilnehmerListeView extends AbstractView
     zurueck2.setToolTipText("Abbuchung Datumsbereich zurück");
     vor2.setToolTipText("Abbuchung Datumsbereich vowärts");
 
-    control.getKursteilnehmerTable().paint(getParent());
+    control.getTablePart().paint(getParent());
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.KURSTEILNEHMER, false, "question-circle.png");
@@ -86,5 +86,6 @@ public class KursteilnehmerListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -66,7 +66,7 @@ public class LastschriftListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getLastschriftList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -75,5 +75,6 @@ public class LastschriftListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangListeView.java
@@ -67,7 +67,7 @@ public class LehrgangListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getLehrgaengeList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.LEHRGANG, false, "question-circle.png");
@@ -78,5 +78,6 @@ public class LehrgangListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
@@ -35,7 +35,7 @@ public class LehrgangsartListeView extends AbstractView
 
     LehrgangsartControl control = new LehrgangsartControl(this);
 
-    control.getLehrgangsartList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class LehrgangsartListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/LesefeldListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldListeView.java
@@ -39,7 +39,7 @@ public class LesefeldListeView extends AbstractView
     LabelGroup group = new LabelGroup(getParent(), "Parameter");
     group.addLabelPair("Mitglied", control.getSuchMitglied());
 
-    control.getLesefelderList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -51,5 +51,6 @@ public class LesefeldListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MailListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailListeView.java
@@ -57,7 +57,7 @@ public class MailListeView extends AbstractView
     fbuttons.addButton(control.getSuchenButton());
     group.addButtonArea(fbuttons);
 
-    control.getMailList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -68,5 +68,6 @@ public class MailListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MailVorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlageListeView.java
@@ -35,7 +35,7 @@ public class MailVorlageListeView extends AbstractView
 
     MailVorlageControl control = new MailVorlageControl(this);
 
-    control.getMailVorlageTable(null).paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class MailVorlageListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
@@ -38,7 +38,7 @@ public class MitgliedstypListeView extends AbstractView
 
     MitgliedstypControl control = new MitgliedstypControl(this);
 
-    control.getMitgliedstypList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -60,5 +60,6 @@ public class MitgliedstypListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
@@ -42,7 +42,7 @@ public class MittelverwendungSaldoView extends AbstractView
     qpart.paint(this.getParent());
 
     LabelGroup group = new LabelGroup(getParent(), "Saldo", true);
-    group.addPart(control.getSaldoList());
+    group.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/ProjektListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektListeView.java
@@ -74,7 +74,7 @@ public class ProjektListeView extends AbstractView
     zurueck2.setToolTipText("Ende Datumsbereich zurück");
     vor2.setToolTipText("Ende Datumsbereich vowärts");
 
-    control.getProjektList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -86,5 +86,6 @@ public class ProjektListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -45,7 +45,7 @@ public class ProjektSaldoView extends AbstractView
     projekt.addLabelPair("Projekt", control.getProjekt());
 
     LabelGroup group = new LabelGroup(getParent(), "Saldo", true);
-    group.addPart(control.getSaldoList());
+    group.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/RechnungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungDetailView.java
@@ -88,6 +88,8 @@ public class RechnungDetailView extends AbstractDetailView
     buttons.addButton(control.getMahnungDruckUndMailButton());
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.getDetailSpaltenPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
@@ -68,7 +68,7 @@ public class RechnungListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getRechnungList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -77,6 +77,7 @@ public class RechnungListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungDetailView.java
@@ -78,11 +78,11 @@ public class SollbuchungDetailView extends AbstractDetailView
     comp.setLayoutData(new GridData(GridData.END));
 
     buttons1.paint(cont.getComposite());
-    cont.addPart(control.getSollbuchungPositionListPart());
+    cont.addPart(control.getSollbuchungList());
 
     LabelGroup buch = new LabelGroup(scrolled.getComposite(),
         "Zugeordnete Buchungen");
-    buch.addPart(control.getBuchungListPart());
+    buch.addPart(control.getBuchungList());
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -96,6 +96,8 @@ public class SollbuchungDetailView extends AbstractDetailView
     buttons.addButton(save);
 
     buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.getDetailSpaltenPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -71,7 +71,7 @@ public class SollbuchungListeView extends AbstractView
     zurueck.setToolTipText("Datumsbereich zurück");
     vor.setToolTipText("Datumsbereich vowärts");
 
-    control.getSollbuchungenList(null, false, true).paint(this.getParent());
+    control.getTablePart(null, false, true).paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -85,5 +85,6 @@ public class SollbuchungListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungDetailView.java
@@ -93,6 +93,9 @@ public class SpendenbescheinigungDetailView extends AbstractDetailView
     buttons.addButton(control.getDruckUndMailButton());
     buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.getDetailSpaltenPanelButton());
+
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -77,7 +77,7 @@ public class SpendenbescheinigungListeView extends AbstractView
     zurueck2.setToolTipText("Spende Datumsbereich zurück");
     vor2.setToolTipText("Spende Datumsbereich vowärts");
 
-    control.getSpendenbescheinigungList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -89,5 +89,6 @@ public class SpendenbescheinigungListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/SteuerListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SteuerListeView.java
@@ -35,7 +35,7 @@ public class SteuerListeView extends AbstractView
 
     final SteuerControl control = new SteuerControl(this);
 
-    control.getSteuerList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.STEUER, false, "question-circle.png");
@@ -46,6 +46,7 @@ public class SteuerListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
@@ -42,7 +42,7 @@ public class UmsatzsteuerSaldoView extends AbstractView
     part.paint(this.getParent());
 
     LabelGroup group2 = new LabelGroup(getParent(), "Saldo", true);
-    group2.addPart(control.getSaldoList());
+    group2.addPart(control.getTablePart());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlageListeView.java
@@ -76,7 +76,7 @@ public class WiedervorlageListeView extends AbstractView
     zurueck2.setToolTipText("Erledigung Datumsbereich zurück");
     vor2.setToolTipText("Erledigung Datumsbereich vowärts");
 
-    control.getWiedervorlageList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.WIEDERVORLAGE, false, "question-circle.png");
@@ -87,5 +87,6 @@ public class WiedervorlageListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/WirtschaftsplanListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/WirtschaftsplanListeView.java
@@ -34,7 +34,7 @@ public class WirtschaftsplanListeView extends AbstractView
 
     WirtschaftsplanControl control = new WirtschaftsplanControl(this);
 
-    control.getWirtschaftsplanungList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -46,5 +46,6 @@ public class WirtschaftsplanListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragListeView.java
@@ -41,7 +41,7 @@ public class ZusatzbetragListeView extends AbstractView
     LabelGroup group = new LabelGroup(getParent(), "Ausführungstag");
     group.addLabelPair("Ausführungstag", control.getAusfuehrungSuch());
 
-    control.getZusatzbetraegeList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -58,5 +58,6 @@ public class ZusatzbetragListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageListeView.java
@@ -36,7 +36,7 @@ public class ZusatzbetragVorlageListeView extends AbstractView
     final ZusatzbetragVorlageControl control = new ZusatzbetragVorlageControl(
         this);
 
-    control.getZusatzbetraegeVorlageList().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class ZusatzbetragVorlageListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }

--- a/src/de/jost_net/JVerein/gui/view/ZusatzfeldListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzfeldListeView.java
@@ -35,7 +35,7 @@ public class ZusatzfeldListeView extends AbstractView
 
     FelddefinitionControl control = new FelddefinitionControl(this);
 
-    control.getFelddefinitionTable().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
@@ -47,5 +47,6 @@ public class ZusatzfeldListeView extends AbstractView
 
     GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
     GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 }


### PR DESCRIPTION
Ich hab jetzt einen AbstractJVereinControl erstellt in dem der SpaltenPanelButton implementiert ist. Auch ist hier abstract getTablePart definiert. So kann leicht von überall auf den TablePart zugegriffen werden.
In Allen Views hab ich den PanelButton hinzugefügt.
Bei einigen DetailViews mit Liste existiert der Button auch.
Jetzt sind nur noch folgende Listen ohne Button:
- BuchungenDialog (Salden)
- SollbuchungZuordnungDialog
- Zusatzbetrag-Vorlage-Dialog
- Mitglied-Detail (Zusatzbetrag, Wiedervorlage, Mail, Lehrgänge, Lesefeld, Arbeitseinsatz, Dokument)
- Alle Salden

Auch den ExportButton könnte man in den AbsractJVereinContrrol verschieben und dann, so ähnlich wie jetzt bei den Salden, abstracte funktionen üf getDateiname, getTitel und getUnterTitel definieren. Dann gibt es nicht so viel doppelten Code. Ist aber was für einen extra PR.