### PR TITLE
Leere Spalte bei Tabellen

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -232,6 +232,8 @@ public class Einstellungen
     EXTERNEMITGLIEDSNUMMER("externemitgliedsnummer", Boolean.class, "0"),
     MITGLIEDSNUMMERANZEIGEN("nummeranzeigen", Boolean.class, "0"),
     SUMMENANLAGENKONTO("summenanlagenkonto", Boolean.class, "0"),
+    LEERESPALTE("leerespalte", Boolean.class, "0"),
+    // Felder unten
     ALTERSMODEL("altermodel", Integer.class,
         ((Integer) Altermodel.AKTUELLES_DATUM).toString()),
     BUCHUNGBUCHUNGSARTAUSWAHL("buchungbuchungsartauswahl", Integer.class,

--- a/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
+++ b/src/de/jost_net/JVerein/gui/boxes/MitgliedNextBGruppeChecker.java
@@ -24,6 +24,7 @@ import de.willuhn.jameica.gui.parts.ButtonArea;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
@@ -153,7 +154,10 @@ public class MitgliedNextBGruppeChecker extends AbstractBox
           MitgliedNextBGruppe.VIEW_AKT_BEITRAGSGRUPPE);
       aenderungsListenPart.addColumn("Nach Beitragsgruppe",
           MitgliedNextBGruppe.VIEW_BEITRAGSGRUPPE);
-
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        aenderungsListenPart.addColumn(" ", " ");
+      }
       aenderungsListenPart.setContextMenu(new ListenContextMenu());
     }
     listeAktuallisieren();

--- a/src/de/jost_net/JVerein/gui/boxes/WiedervorlagenCheck.java
+++ b/src/de/jost_net/JVerein/gui/boxes/WiedervorlagenCheck.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.control.VorZurueckControl;
 import de.jost_net.JVerein.gui.menu.WiedervorlageMenu;
@@ -97,6 +98,10 @@ public class WiedervorlagenCheck extends AbstractBox
     wiedervorlageList.addColumn("Vermerk", "vermerk");
     wiedervorlageList.addColumn("Erledigung", "erledigung",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      wiedervorlageList.addColumn(" ", " ");
+    }
     wiedervorlageList.setContextMenu(new WiedervorlageMenu(wiedervorlageList));
 
     wiedervorlageList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -330,6 +330,10 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
       abrechnungslaufList.addColumn("Kursteilnehmer", "kursteilnehmer",
           new JaNeinFormatter());
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      abrechnungslaufList.addColumn(" ", " ");
+    }
     abrechnungslaufList
         .setContextMenu(new AbrechnungslaufMenu(abrechnungslaufList));
     abrechnungslaufList.setAction(
@@ -459,6 +463,11 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     buchungList.addColumn(new Column(Buchung.SOLLBUCHUNG,
         "Mitglied - Sollbuchung", new SollbuchungFormatter(), false,
         Column.ALIGN_AUTO, Column.SORT_BY_DISPLAY));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      buchungList.addColumn(" ", " ");
+    }
+
     buchungList.setMulti(true);
 
     buchungList.setContextMenu(new BuchungAbrechnugslaufMenu());
@@ -496,6 +505,10 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     {
       sollbuchungList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      sollbuchungList.addColumn(" ", " ");
+    }
     sollbuchungList.setContextMenu(new SollbuchungMenu(null));
     sollbuchungList.setMulti(true);
 
@@ -530,6 +543,10 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     lastschriftList.addColumn("Mandat", "mandatid");
     lastschriftList.addColumn("Mandatdatum", "mandatdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lastschriftList.addColumn(" ", " ");
+    }
     lastschriftList.setContextMenu(new LastschriftMenu(lastschriftList));
     lastschriftList.setMulti(true);
     return lastschriftList;
@@ -599,6 +616,10 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     }
     zusatzbetraegeList.addColumn("Zahlt selbst", "mitgliedzahltselbst",
         new JaNeinFormatter(), false, Column.ALIGN_LEFT);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zusatzbetraegeList.addColumn(" ", " ");
+    }
     zusatzbetraegeList
         .setContextMenu(new ZusatzbetraegeMenu(zusatzbetraegeList));
     zusatzbetraegeList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/AbstractAbrechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractAbrechnungControl.java
@@ -622,7 +622,7 @@ public abstract class AbstractAbrechnungControl
     return b;
   }
 
-  public JVereinTablePart getBugsList()
+  public JVereinTablePart getBugsList() throws RemoteException
   {
     if (bugsList != null)
     {
@@ -633,6 +633,10 @@ public abstract class AbstractAbrechnungControl
     bugsList.addColumn("Name", "name");
     bugsList.addColumn("Meldung", "meldung");
     bugsList.addColumn("Klassifikation", "klassifikationText");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      bugsList.addColumn(" ", " ");
+    }
     bugsList.setContextMenu(new BugListMenu());
     return bugsList;
   }

--- a/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnfangsbestandControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.AnfangsbestandMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -170,6 +171,10 @@ public class AnfangsbestandControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     anfangsbestandList.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      anfangsbestandList.addColumn(" ", " ");
+    }
     anfangsbestandList
         .setContextMenu(new AnfangsbestandMenu(anfangsbestandList));
     anfangsbestandList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -112,10 +112,10 @@ public class AnlagenlisteControl extends AbstractSaldoControl
     saldoList.addColumn("Buchwert Ende GJ", ENDWERT,
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
-    // Dummy Spalte, damit endwert nicht am rechten Rand klebt
-    saldoList.addColumn(" ", " ",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-        Column.ALIGN_LEFT);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      saldoList.addColumn(" ", " ");
+    }
     saldoList.setFormatter(new SaldoFormatter());
     saldoList.setMulti(true);
     saldoList.setContextMenu(new SaldoMenu(this));

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzAbrechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzAbrechnungControl.java
@@ -258,6 +258,10 @@ public class ArbeitseinsatzAbrechnungControl extends AbstractAbrechnungControl
       arbeitseinsatzueberpruefungList.addColumn("Gesamtbetrag", GESAMTBETRAG,
           new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
           Column.ALIGN_RIGHT);
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        arbeitseinsatzueberpruefungList.addColumn(" ", " ");
+      }
       return arbeitseinsatzueberpruefungList;
     }
   }

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.ArbeitseinsatzMenu;
 import de.jost_net.JVerein.gui.parts.ArbeitseinsatzPart;
@@ -136,6 +137,10 @@ public class ArbeitseinsatzControl extends FilterControl implements Savable
     arbeitseinsatzList.addColumn("Stunden", "stunden",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     arbeitseinsatzList.addColumn("Bemerkung", "bemerkung");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      arbeitseinsatzList.addColumn(" ", " ");
+    }
     arbeitseinsatzList.setAction(
         new EditAction(ArbeitseinsatzDetailView.class, arbeitseinsatzList));
     VorZurueckControl.setObjektListe(null, null);
@@ -217,12 +222,12 @@ public class ArbeitseinsatzControl extends FilterControl implements Savable
     }
     return new PanelButton(
         art.equals(ExportArt.PDF) ? "file-pdf.png" : "xsd.png", context -> {
-      arbeitseinsatzList.export(
-          VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_TITEL, this),
-          VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_SUBTITEL, this),
-          VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_DATEINAME, this),
-          "arbeitseinsaetze", art);
-      GUI.getStatusBar().setSuccessText("Auswertung fertig.");
+          arbeitseinsatzList.export(
+              VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_TITEL, this),
+              VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_SUBTITEL, this),
+              VorlageUtil.getName(VorlageTyp.ARBEITSEINSAETZE_DATEINAME, this),
+              "arbeitseinsaetze", art);
+          GUI.getStatusBar().setSuccessText("Auswertung fertig.");
         }, art.equals(ExportArt.PDF) ? "PDF" : "CSV");
   }
 

--- a/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BeitragsgruppeControl.java
@@ -652,6 +652,10 @@ public class BeitragsgruppeControl extends VorZurueckControl implements Savable
       });
     }
     beitragsgruppeList.addColumn("Notiz", "notiz", new NotizFormatter(40));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      beitragsgruppeList.addColumn(" ", " ");
+    }
     beitragsgruppeList
         .setContextMenu(new BeitragsgruppeMenu(beitragsgruppeList));
     beitragsgruppeList.setFormatter(new TableFormatter()

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1565,6 +1565,10 @@ public class BuchungsControl extends VorZurueckControl implements Savable
     {
       buchungsList.addColumn("Spendenbescheinigung", "spendenbescheinigung");
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      buchungsList.addColumn(" ", " ");
+    }
     buchungsList.setMulti(true);
     buchungsList.setContextMenu(new BuchungMenu(this));
     buchungsList.setRememberState(true);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsTextKorrekturControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsTextKorrekturControl.java
@@ -18,7 +18,9 @@ package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
 
+import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.Queries.BuchungsKorrekturQuery;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -91,6 +93,10 @@ public class BuchungsTextKorrekturControl extends AbstractControl
           return s;
         }
       });
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        buchungsList.addColumn(" ", " ");
+      }
       buchungsList.setMulti(true);
       buchungsList.setRememberState(true);
     }

--- a/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -406,6 +406,10 @@ public class BuchungsartControl extends FilterControl implements Savable
       }
     }, false, Column.ALIGN_LEFT);
     buchungsartList.addColumn("Suchtext", "suchbegriff");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      buchungsartList.addColumn(" ", " ");
+    }
     buchungsartList.setContextMenu(new BuchungsartMenu(buchungsartList));
     buchungsartList.setMulti(true);
     buchungsartList.setRememberState(true);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.BuchungsklasseMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -136,6 +137,10 @@ public class BuchungsklasseControl extends VorZurueckControl implements Savable
     buchungsklassenList = new JVereinTablePart(buchungsklassen, null);
     buchungsklassenList.addColumn("Nummer", "nummer");
     buchungsklassenList.addColumn("Bezeichnung", "bezeichnung");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      buchungsklassenList.addColumn(" ", " ");
+    }
     buchungsklassenList
         .setContextMenu(new BuchungsklasseMenu(buchungsklassenList));
     buchungsklassenList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsklasseSaldoControl.java
@@ -139,6 +139,10 @@ public class BuchungsklasseSaldoControl extends AbstractSaldoControl
           Column.ALIGN_RIGHT);
     }
     saldoList.addColumn("Anzahl", ANZAHL);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      saldoList.addColumn(" ", " ");
+    }
     saldoList.setMulti(true);
     saldoList.setRememberState(true);
     saldoList.setContextMenu(new SaldoMenu(this));

--- a/src/de/jost_net/JVerein/gui/control/BuchungsuebernahmeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsuebernahmeControl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.Konto;
 import de.willuhn.datasource.rmi.DBIterator;
@@ -130,7 +131,10 @@ public class BuchungsuebernahmeControl
     kontenlist.addColumn("Hibiscus max. Buchungsnummer",
         "hibiscusMaxBuchungID");
     kontenlist.addColumn("Bemerkung", "bemerkung");
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      kontenlist.addColumn(" ", " ");
+    }
     return kontenlist;
   }
 

--- a/src/de/jost_net/JVerein/gui/control/DokumentControl.java
+++ b/src/de/jost_net/JVerein/gui/control/DokumentControl.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.Messaging.DokumentMessage;
 import de.jost_net.JVerein.gui.action.DokumentShowAction;
 import de.jost_net.JVerein.gui.menu.DokumentMenu;
@@ -251,6 +252,10 @@ public class DokumentControl extends AbstractControl
     docsList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     docsList.addColumn("Bemerkung", "bemerkung");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      docsList.addColumn(" ", " ");
+    }
     docsList.setContextMenu(new DokumentMenu(enabled));
     docsList.setMulti(true);
     this.mc = new DokumentMessageConsumer();

--- a/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EigenschaftControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.EigenschaftMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -165,6 +166,10 @@ public class EigenschaftControl extends VorZurueckControl implements Savable
     eigenschaftList.addColumn("Name", "name");
     eigenschaftList.addColumn("Bezeichnung", "bezeichnung");
     eigenschaftList.addColumn("Gruppe", "eigenschaftgruppe");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      eigenschaftList.addColumn(" ", " ");
+    }
     eigenschaftList.setContextMenu(new EigenschaftMenu(eigenschaftList));
     eigenschaftList.setRememberState(true);
     eigenschaftList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/EigenschaftGruppeControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EigenschaftGruppeControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.formatter.JaNeinFormatter;
 import de.jost_net.JVerein.gui.menu.EigenschaftGruppeMenu;
@@ -163,6 +164,10 @@ public class EigenschaftGruppeControl extends VorZurueckControl
         new JaNeinFormatter());
     eigenschaftgruppeList.addColumn("Max. 1 Eigenschaft", "max1",
         new JaNeinFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      eigenschaftgruppeList.addColumn(" ", " ");
+    }
     eigenschaftgruppeList
         .setContextMenu(new EigenschaftGruppeMenu(eigenschaftgruppeList));
     eigenschaftgruppeList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -346,6 +346,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput summenAnlagenkonto;
 
+  private CheckboxInput leerespalte;
+
   private IntegerInput qrcodesize;
 
   private CheckboxInput qrcodeptext;
@@ -2164,6 +2166,17 @@ public class EinstellungControl extends AbstractControl
     return summenAnlagenkonto;
   }
 
+  public CheckboxInput getLeereSpalte() throws RemoteException
+  {
+    if (leerespalte != null)
+    {
+      return leerespalte;
+    }
+    leerespalte = new CheckboxInput(
+        (Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE));
+    return leerespalte;
+  }
+
   public DecimalInput getAfaRestwert() throws RemoteException
   {
     if (afarestwert != null)
@@ -2486,6 +2499,8 @@ public class EinstellungControl extends AbstractControl
           (Boolean) externemitgliedsnummer.getValue());
       Einstellungen.setEinstellung(Property.SUMMENANLAGENKONTO,
           (Boolean) summenAnlagenkonto.getValue());
+      Einstellungen.setEinstellung(Property.LEERESPALTE,
+          (Boolean) leerespalte.getValue());
       Altermodel amValue = (Altermodel) altersmodel.getValue();
       Einstellungen.setEinstellung(Property.ALTERSMODEL, amValue.getKey());
       AbstractInputAuswahl bbaAuswahl = (AbstractInputAuswahl) buchungBuchungsartAuswahl

--- a/src/de/jost_net/JVerein/gui/control/FelddefinitionControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FelddefinitionControl.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.formatter.DatentypFormatter;
 import de.jost_net.JVerein.gui.menu.FelddefinitionMenu;
@@ -173,6 +174,10 @@ public class FelddefinitionControl extends VorZurueckControl implements Savable
     felddefinitionList.addColumn("Datentyp", "datentyp",
         new DatentypFormatter(), false, Column.ALIGN_LEFT);
     felddefinitionList.addColumn("Länge", "laenge");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      felddefinitionList.addColumn(" ", " ");
+    }
     felddefinitionList
         .setContextMenu(new FelddefinitionMenu(felddefinitionList));
     felddefinitionList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -364,6 +364,10 @@ public class FormularControl extends FormularPartControl implements Savable
     formularList.addColumn("Fortlaufende Nr.", "zaehler");
     formularList.addColumn("Verknüpft mit", "formlink",
         new FormularLinkFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      formularList.addColumn(" ", " ");
+    }
     formularList.setContextMenu(new FormularMenu(this, formularList));
     formularList.setMulti(true);
     formularList

--- a/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularPartControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.FormularfeldMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -73,7 +74,10 @@ public abstract class FormularPartControl extends VorZurueckControl
     formularfelderList.addColumn("Schriftart", "font");
     formularfelderList.addColumn("Schriftgröße", "fontsize");
     formularfelderList.addColumn("Ausrichtung", "ausrichtung");
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      formularfelderList.addColumn(" ", " ");
+    }
     formularfelderList.setContextMenu(new FormularfeldMenu());
     formularfelderList.removeFeature(FeatureSummary.class);
     formularfelderList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/GutschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/GutschriftControl.java
@@ -164,8 +164,8 @@ public class GutschriftControl extends AbstractAbrechnungControl
         // Dann erste aus der Liste
       }
     }
-    buchungsartInput = new BuchungsartInput().getBuchungsartInput(
-        ba, buchungsarttyp.BUCHUNGSART, (Integer) Einstellungen
+    buchungsartInput = new BuchungsartInput().getBuchungsartInput(ba,
+        buchungsarttyp.BUCHUNGSART, (Integer) Einstellungen
             .getEinstellung(Property.BUCHUNGBUCHUNGSARTAUSWAHL));
     buchungsartInput.addListener(e -> {
       try
@@ -538,7 +538,7 @@ public class GutschriftControl extends AbstractAbrechnungControl
   }
 
   @Override
-  public JVereinTablePart getBugsList()
+  public JVereinTablePart getBugsList() throws RemoteException
   {
     if (bugsList != null)
     {
@@ -551,6 +551,10 @@ public class GutschriftControl extends AbstractAbrechnungControl
     bugsList.addColumn("Zahler", "zahlerName");
     bugsList.addColumn("Meldung", "meldung");
     bugsList.addColumn("Klassifikation", "klassifikationText");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      bugsList.addColumn(" ", " ");
+    }
     bugsList.setContextMenu(new BugListMenu());
     return bugsList;
   }

--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -390,6 +390,10 @@ public class JahresabschlussControl extends KontensaldoControl
     jahresabschlussList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     jahresabschlussList.addColumn("Name", "name");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      jahresabschlussList.addColumn(" ", " ");
+    }
     jahresabschlussList
         .setContextMenu(new JahresabschlussMenu(jahresabschlussList));
     jahresabschlussList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontensaldoControl.java
@@ -96,6 +96,10 @@ public class KontensaldoControl extends AbstractSaldoControl
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
     saldoList.addColumn("Bemerkung", BEMERKUNG);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      saldoList.addColumn(" ", " ");
+    }
     saldoList.setMulti(true);
     saldoList.setFormatter(new SaldoFormatter());
     saldoList.setContextMenu(new SaldoMenu(this));

--- a/src/de/jost_net/JVerein/gui/control/KontoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KontoControl.java
@@ -384,6 +384,10 @@ public class KontoControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     kontenList.addColumn("Gegenbuchung-Buchungsart", "buchungsart",
         new BuchungsartFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      kontenList.addColumn(" ", " ");
+    }
     kontenList.setContextMenu(new KontoMenu(kontenList));
     kontenList.setMulti(true);
     kontenList.setAction(new EditAction(KontoDetailView.class, kontenList));

--- a/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/KursteilnehmerControl.java
@@ -417,6 +417,10 @@ public class KursteilnehmerControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     kursteilnehmerList.addColumn("Abbuchungsdatum", "abbudatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      kursteilnehmerList.addColumn(" ", " ");
+    }
     kursteilnehmerList
         .setContextMenu(new KursteilnehmerMenu(kursteilnehmerList));
     kursteilnehmerList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LastschriftControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.input.BICInput;
@@ -135,6 +136,10 @@ public class LastschriftControl extends FilterControl implements Savable
     lastschriftList.addColumn("Mandat", "mandatid");
     lastschriftList.addColumn("Mandatdatum", "mandatdatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lastschriftList.addColumn(" ", " ");
+    }
     lastschriftList.setContextMenu(new LastschriftMenu(lastschriftList));
     lastschriftList.setMulti(true);
     lastschriftList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangControl.java
@@ -338,6 +338,10 @@ public class LehrgangControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     lehrgaengeList.addColumn("Veranstalter", "veranstalter");
     lehrgaengeList.addColumn("Ergebnis", "ergebnis");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lehrgaengeList.addColumn(" ", " ");
+    }
     lehrgaengeList.setContextMenu(new LehrgangMenu(lehrgaengeList));
     lehrgaengeList.setMulti(true);
     lehrgaengeList

--- a/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LehrgangsartControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.LehrgangsartMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -180,6 +181,10 @@ public class LehrgangsartControl extends VorZurueckControl implements Savable
     lehrgangsartList.addColumn("Bis", "bis",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     lehrgangsartList.addColumn("Veranstalter", "veranstalter");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lehrgangsartList.addColumn(" ", " ");
+    }
     lehrgangsartList.setContextMenu(new LehrgangsartMenu(lehrgangsartList));
     lehrgangsartList.setMulti(true);
     lehrgangsartList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/LesefeldControl.java
+++ b/src/de/jost_net/JVerein/gui/control/LesefeldControl.java
@@ -429,6 +429,10 @@ public class LesefeldControl extends VorZurueckControl implements Savable
         null);
     lesefeldList.addColumn("Skript-Name", "bezeichnung");
     lesefeldList.addColumn("Erste Zeile der Script-Ausgabe", "ausgabe");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lesefeldList.addColumn(" ", " ");
+    }
     lesefeldList.setContextMenu(new LesefeldMenu(lesefeldList));
     lesefeldList.setMulti(true);
     lesefeldList
@@ -482,6 +486,10 @@ public class LesefeldControl extends VorZurueckControl implements Savable
         new EditAction(LesefeldDetailView.class));
     lesefeldMitgliedList.addColumn("Skript-Name", "bezeichnung");
     lesefeldMitgliedList.addColumn("Erste Zeile der Script-Ausgabe", "ausgabe");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lesefeldMitgliedList.addColumn(" ", " ");
+    }
     lesefeldMitgliedList.setContextMenu(new LesefeldMenu(null));
     lesefeldMitgliedList.setMulti(true);
     return lesefeldMitgliedList;

--- a/src/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailControl.java
@@ -154,6 +154,10 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     empfaenger.addColumn("Name", "name");
     empfaenger.addColumn("Versand", "versand",
         new DateFormatter(new JVDateFormatDATETIME()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      empfaenger.addColumn(" ", " ");
+    }
     empfaenger.setContextMenu(new MailEmpfaengerMenu(this));
     empfaenger.setMulti(true);
     return empfaenger;
@@ -213,6 +217,10 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     mitgliedmitmail.addColumn("Name", "name");
     mitgliedmitmail.addColumn("Vorname", "vorname");
     mitgliedmitmail.addColumn("Mitgliedstyp", Mitglied.MITGLIEDSTYP);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mitgliedmitmail.addColumn(" ", " ");
+    }
     mitgliedmitmail.setCheckable(true);
     mitgliedmitmail.removeFeature(FeatureSummary.class);
     return mitgliedmitmail;
@@ -258,6 +266,10 @@ public class MailControl extends FilterControl implements IMailControl, Savable
         .registerMessageConsumer(this.mailDeleteConsumer);
     anhang = new JVereinTablePart(anhang2, new MailAnhangAnzeigeAction());
     anhang.addColumn("Dateiname", "dateiname");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      anhang.addColumn(" ", " ");
+    }
     anhang.setContextMenu(new MailAnhangMenu(this));
     anhang.setMulti(true);
     return anhang;
@@ -680,6 +692,10 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     mailsList.addColumn("Versand", "versand",
         new DateFormatter(new JVDateFormatDATETIME()));
     mailsList.addColumn("Anhänge", "anhaenge");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mailsList.addColumn(" ", " ");
+    }
     mailsList.setContextMenu(new MailMenu(mailsList));
     mailsList.setMulti(true);
     mailsList.setAction(new EditAction(MailDetailView.class, mailsList));

--- a/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MailVorlageControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.MailVorlageMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -141,6 +142,10 @@ public class MailVorlageControl extends VorZurueckControl
     DBIterator<MailVorlage> fdef = service.createList(MailVorlage.class);
     mailvorlageList = new JVereinTablePart(fdef, null);
     mailvorlageList.addColumn("Betreff", "betreff");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mailvorlageList.addColumn(" ", " ");
+    }
     mailvorlageList.setContextMenu(new MailVorlageMenu(mailvorlageList));
     mailvorlageList.setMulti(true);
     mailvorlageList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -1562,7 +1562,10 @@ public class MitgliedControl extends FilterControl implements Savable
           return "Familienmitglied";
       }
     });
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      familienangehoerige.addColumn(" ", " ");
+    }
     return familienangehoerige;
   }
 
@@ -1587,7 +1590,10 @@ public class MitgliedControl extends FilterControl implements Savable
     zahtlFuer = new JVereinTablePart(mitglieder, new MitgliedDetailAction());
     zahtlFuer.addColumn("Name", "name");
     zahtlFuer.addColumn("Vorname", "vorname");
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zahtlFuer.addColumn(" ", " ");
+    }
     return zahtlFuer;
   }
 
@@ -1644,6 +1650,10 @@ public class MitgliedControl extends FilterControl implements Savable
         return "";
       }, false, Column.ALIGN_RIGHT);
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zusatzbetraegeList.addColumn(" ", " ");
+    }
     zusatzbetraegeList.setContextMenu(new ZusatzbetraegeMenu(null));
     return zusatzbetraegeList;
   }
@@ -1666,6 +1676,10 @@ public class MitgliedControl extends FilterControl implements Savable
     wiedervorlageList.addColumn("Vermerk", "vermerk");
     wiedervorlageList.addColumn("Erledigung", "erledigung",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      wiedervorlageList.addColumn(" ", " ");
+    }
     wiedervorlageList.setContextMenu(new WiedervorlageMenu(null));
     wiedervorlageList.setMulti(true);
     return wiedervorlageList;
@@ -1690,6 +1704,10 @@ public class MitgliedControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTIMESTAMP()));
     mailList.addColumn("Betreff", "betreff");
     mailList.addColumn("Anhänge", "anhaenge");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mailList.addColumn(" ", " ");
+    }
     mailList.setContextMenu(new MailMenu(null));
     return mailList;
   }
@@ -1714,6 +1732,10 @@ public class MitgliedControl extends FilterControl implements Savable
     arbeitseinsatzList.addColumn("Stunden", "stunden",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     arbeitseinsatzList.addColumn("Bemerkung", "bemerkung");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      arbeitseinsatzList.addColumn(" ", " ");
+    }
     // wiedervorlageList.setContextMenu(new
     // WiedervorlageMenu(wiedervorlageList));
     return arbeitseinsatzList;
@@ -1739,6 +1761,10 @@ public class MitgliedControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     lehrgaengeList.addColumn("Veranstalter", "veranstalter");
     lehrgaengeList.addColumn("Ergebnis", "ergebnis");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      lehrgaengeList.addColumn(" ", " ");
+    }
     lehrgaengeList.setContextMenu(new LehrgangMenu(null));
     return lehrgaengeList;
   }
@@ -2348,6 +2374,10 @@ public class MitgliedControl extends FilterControl implements Savable
 
         add(eg.getBezeichnung(), "eigenschaften_" + eg.getName(), false, true);
       }
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        add(" ", " ", true, true);
+      }
     }
     catch (RemoteException e)
     {
@@ -2372,10 +2402,10 @@ public class MitgliedControl extends FilterControl implements Savable
   }
 
   private void add(String spaltenbezeichnung, String spaltenname,
-      boolean defaultvalue, boolean auchNichtMitglied)
+      boolean defaultVisible, boolean auchNichtMitglied)
   {
-    add(spaltenbezeichnung, spaltenname, defaultvalue, null, Column.ALIGN_AUTO,
-        auchNichtMitglied);
+    add(spaltenbezeichnung, spaltenname, defaultVisible, null,
+        Column.ALIGN_AUTO, auchNichtMitglied);
   }
 
   private void add(String spaltenbezeichnung, String spaltenname,
@@ -2774,6 +2804,10 @@ public class MitgliedControl extends FilterControl implements Savable
     familienbeitragtree.addColumn("Zahlungsweg", "zahlungsweg");
     familienbeitragtree.addColumn("IBAN", "iban", new IBANFormatter());
     familienbeitragtree.addColumn("Austritt", "austritt", new DateFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      familienbeitragtree.addColumn(" ", " ");
+    }
     familienbeitragtree.setRememberColWidths(true);
 
     familienbeitragtree.setContextMenu(new FamilienbeitragMenu());
@@ -2820,6 +2854,10 @@ public class MitgliedControl extends FilterControl implements Savable
     abweichenderzahlertree.addColumn("Name", "name");
     abweichenderzahlertree.addColumn("Zahlungsweg", "zahlungsweg");
     abweichenderzahlertree.addColumn("IBAN", "iban", new IBANFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      abweichenderzahlertree.addColumn(" ", " ");
+    }
     abweichenderzahlertree.setRememberColWidths(true);
 
     abweichenderzahlertree.setContextMenu(new AbweichenderZahlerMenu());
@@ -3245,6 +3283,10 @@ public class MitgliedControl extends FilterControl implements Savable
     beitragsTabelle.addColumn("Beitragsgruppe",
         MitgliedNextBGruppe.VIEW_BEITRAGSGRUPPE);
     beitragsTabelle.addColumn("Bemerkung", MitgliedNextBGruppe.COL_BEMERKUNG);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      beitragsTabelle.addColumn(" ", " ");
+    }
     refreshMitgliedBeitraegeTabelle();
     return beitragsTabelle;
   }

--- a/src/de/jost_net/JVerein/gui/control/MitgliedSuchProfilControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedSuchProfilControl.java
@@ -22,6 +22,7 @@ import java.rmi.RemoteException;
 import java.util.Properties;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.Messaging.SuchprofilMessage;
 import de.jost_net.JVerein.gui.action.SuchprofilLadenAction;
 import de.jost_net.JVerein.gui.menu.SuchprofilMenu;
@@ -82,6 +83,10 @@ public class MitgliedSuchProfilControl extends AbstractControl
 
     profillist = new JVereinTablePart(profile, new SuchprofilLadenAction());
     profillist.addColumn("Bezeichnung", "bezeichnung");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      profillist.addColumn(" ", " ");
+    }
     profillist.setContextMenu(new SuchprofilMenu(this));
     profillist.setMulti(true);
     this.mc = new SuchprofilMessageConsumer();

--- a/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedstypControl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.MitgliedstypMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -146,6 +147,10 @@ public class MitgliedstypControl extends VorZurueckControl implements Savable
     mitgliedstypList.addColumn("Bezeichnung Plural",
         Mitgliedstyp.BEZEICHNUNG_PLURAL);
     mitgliedstypList.addColumn("ID", "id");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mitgliedstypList.addColumn(" ", " ");
+    }
     mitgliedstypList.setContextMenu(new MitgliedstypMenu(mitgliedstypList));
     mitgliedstypList.setMulti(true);
     mitgliedstypList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -320,6 +320,10 @@ public class MittelverwendungControl extends AbstractSaldoControl
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
     saldoList.addColumn("Kommentar", KOMMENTAR);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      saldoList.addColumn(" ", " ");
+    }
     saldoList.removeFeature(FeatureSummary.class);
     saldoList.setFormatter(new SaldoFormatter());
     return saldoList;
@@ -355,10 +359,10 @@ public class MittelverwendungControl extends AbstractSaldoControl
     zuflussList.addColumn("Summe", SUMME,
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
-    // Dummy Spalte, damit Summe nicht am rechten Rand klebt
-    zuflussList.addColumn(" ", " ",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-        Column.ALIGN_LEFT);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zuflussList.addColumn(" ", " ");
+    }
     zuflussList.removeFeature(FeatureSummary.class);
     return zuflussList;
   }

--- a/src/de/jost_net/JVerein/gui/control/ProjektControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ProjektControl.java
@@ -20,6 +20,7 @@ import java.rmi.RemoteException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.ProjektMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -160,6 +161,10 @@ public class ProjektControl extends FilterControl implements Savable
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     projektList.addColumn("Endedatum", "endedatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      projektList.addColumn(" ", " ");
+    }
     projektList.setContextMenu(new ProjektMenu(projektList));
     projektList.setMulti(true);
     projektList.setAction(new EditAction(ProjektDetailView.class, projektList));

--- a/src/de/jost_net/JVerein/gui/control/QIFBuchungsImportControl.java
+++ b/src/de/jost_net/JVerein/gui/control/QIFBuchungsImportControl.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.TableItem;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.Messaging.QIFImportHeaderMessage;
 import de.jost_net.JVerein.gui.input.JVereinKontoInput;
 import de.jost_net.JVerein.gui.input.QIFExternKontenInput;
@@ -286,7 +287,10 @@ public class QIFBuchungsImportControl extends AbstractControl
     qifImportPosList.addColumn("Gesperrt", QIFImportPos.COL_SPERRE,
         new PosStatusFormater());
     qifImportPosList.addColumn("Mitglied", QIFImportPos.VIEW_MITGLIEDS_NAME);
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      qifImportPosList.addColumn(" ", " ");
+    }
     qifImportPosList.setFormatter(new QIFImportPosListTableFormater());
     return qifImportPosList;
 

--- a/src/de/jost_net/JVerein/gui/control/QIFBuchungsartZuordnenControl.java
+++ b/src/de/jost_net/JVerein/gui/control/QIFBuchungsartZuordnenControl.java
@@ -26,6 +26,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.TableItem;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.QIFImportPos;
@@ -176,7 +177,10 @@ public class QIFBuchungsartZuordnenControl extends AbstractControl
       posBeispielListTable.addColumn("Name", QIFImportPos.COL_NAME);
       posBeispielListTable.addColumn("Zweck", QIFImportPos.COL_ZWECK);
       posBeispielListTable.addColumn("Konto", QIFImportPos.VIEW_QIFKONTO_NAME);
-
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        posBeispielListTable.addColumn(" ", " ");
+      }
     }
     else
     {
@@ -381,7 +385,10 @@ public class QIFBuchungsartZuordnenControl extends AbstractControl
           QIFImportPos.VIEW_BUCHART_BEZEICHNER);
       distinctBuchartListTable.addColumn("Mitgliedskonto",
           QIFImportPos.VIEW_MITGLIED_BAR);
-
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        distinctBuchartListTable.addColumn(" ", " ");
+      }
       distinctBuchartListTable.setFormatter(new BuchartListTableFormater());
       distinctBuchartListTable
           .addSelectionListener(new BuchartListSelectionListener());

--- a/src/de/jost_net/JVerein/gui/control/QIFMitgliedZuordnenControl.java
+++ b/src/de/jost_net/JVerein/gui/control/QIFMitgliedZuordnenControl.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.TableItem;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.QIFImportPos;
@@ -172,6 +173,10 @@ public class QIFMitgliedZuordnenControl extends AbstractControl
       posBeispielListTable.addColumn("Name", QIFImportPos.COL_NAME);
       posBeispielListTable.addColumn("Zweck", QIFImportPos.COL_ZWECK);
       posBeispielListTable.addColumn("Konto", QIFImportPos.VIEW_QIFKONTO_NAME);
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        posBeispielListTable.addColumn(" ", " ");
+      }
     }
     else
     {
@@ -394,7 +399,10 @@ public class QIFMitgliedZuordnenControl extends AbstractControl
       distinctExternNameListTable.addColumn("Status", "Status");
       distinctExternNameListTable.addColumn("JVerein Mitglied",
           QIFImportPos.VIEW_MITGLIEDS_NAME);
-
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        distinctExternNameListTable.addColumn(" ", " ");
+      }
       distinctExternNameListTable.setFormatter(new NamensListTableFormater());
       distinctExternNameListTable
           .addSelectionListener(new ExterneNamensListSelectionListener());

--- a/src/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -187,7 +187,10 @@ public class RechnungControl extends DruckMailControl implements Savable
     rechnungList.addColumn("Referenz Rechnung", "refrechnung");
     rechnungList.addColumn("Erstattungsbetrag", "erstattungsbetrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      rechnungList.addColumn(" ", " ");
+    }
     rechnungList.setContextMenu(new RechnungMenu(rechnungList));
     rechnungList.setMulti(true);
     rechnungList

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -417,6 +417,10 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     mitgliedskontoTree.addColumn("Differenz", "differenz",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mitgliedskontoTree.addColumn(" ", " ");
+    }
     mitgliedskontoTree.setContextMenu(new MitgliedskontoMenu());
     mitgliedskontoTree.setFormatter(new MitgliedskontoTreeFormatter());
     mitgliedskontoTree.setRememberColWidths(true);
@@ -471,6 +475,10 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     {
       sollbuchungenList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      sollbuchungenList.addColumn(" ", " ");
+    }
     sollbuchungenList.setMulti(multi);
     if (action == null)
     {
@@ -524,6 +532,10 @@ public class SollbuchungControl extends DruckMailControl implements Savable
       mitgliederList = new JVereinTablePart(mitglieder, action);
       mitgliederList.addColumn("Name", "name");
       mitgliederList.addColumn("Vorname", "vorname");
+      if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+      {
+        mitgliederList.addColumn(" ", " ");
+      }
       mitgliederList.setContextMenu(menu);
       mitgliederList.setMulti(true);
     }

--- a/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SpendenbescheinigungControl.java
@@ -543,7 +543,10 @@ public class SpendenbescheinigungControl extends DruckMailControl
     spbList.addColumn("Zeile 5", "zeile5");
     spbList.addColumn("Zeile 6", "zeile6");
     spbList.addColumn("Zeile 7", "zeile7");
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      spbList.addColumn(" ", " ");
+    }
     spbList.setContextMenu(new SpendenbescheinigungMenu(spbList));
     spbList.setMulti(true);
     spbList.setAction(

--- a/src/de/jost_net/JVerein/gui/control/SteuerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SteuerControl.java
@@ -112,6 +112,10 @@ public class SteuerControl extends VorZurueckControl implements Savable
           new BuchungsklasseFormatter());
     }
     steuerList.addColumn("Aktiv", "aktiv", new JaNeinFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      steuerList.addColumn(" ", " ");
+    }
     steuerList.setContextMenu(new SteuerMenue(steuerList));
     steuerList.setMulti(true);
     steuerList.setCheckable(false);

--- a/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/UmsatzsteuerSaldoControl.java
@@ -84,6 +84,10 @@ public class UmsatzsteuerSaldoControl extends AbstractSaldoControl
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
     saldoList.addColumn("Anzahl", ANZAHL);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      saldoList.addColumn(" ", " ");
+    }
     saldoList.setMulti(true);
     saldoList.setFormatter(new SaldoFormatter());
     saldoList.setContextMenu(new SaldoMenu(this));

--- a/src/de/jost_net/JVerein/gui/control/VorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/VorlageControl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.menu.VorlageMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -152,6 +153,10 @@ public class VorlageControl extends FilterControl implements Savable
     namenList = new JVereinTablePart(getVorlagenList(), null);
     namenList.addColumn("Vorlage Art", "art");
     namenList.addColumn("Vorlagenmuster", Vorlage.MUSTER);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      namenList.addColumn(" ", " ");
+    }
     namenList.setContextMenu(new VorlageMenu(namenList));
     namenList.setRememberState(true);
     namenList.removeFeature(FeatureSummary.class);

--- a/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
+++ b/src/de/jost_net/JVerein/gui/control/WirtschaftsplanControl.java
@@ -134,7 +134,10 @@ public class WirtschaftsplanControl extends VorZurueckControl implements Savable
     wirtschaftsplaene.addColumn("Ausgaben Ist", "istMinus", formatter);
     wirtschaftsplaene.addColumn("Saldo Ist", "istSaldo", formatter);
     wirtschaftsplaene.addColumn("Saldo Differenz", "differenz", formatter);
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      wirtschaftsplaene.addColumn(" ", " ");
+    }
     wirtschaftsplaene
         .setContextMenu(new WirtschaftsplanListMenu(wirtschaftsplaene));
     wirtschaftsplaene.setAction(

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragControl.java
@@ -306,6 +306,10 @@ public class ZusatzbetragControl extends VorZurueckControl implements Savable
     }
     zusatzbetraegeList.addColumn("Zahlt selbst", "mitgliedzahltselbst",
         new JaNeinFormatter(), false, Column.ALIGN_LEFT);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zusatzbetraegeList.addColumn(" ", " ");
+    }
     zusatzbetraegeList
         .setContextMenu(new ZusatzbetraegeMenu(zusatzbetraegeList));
     zusatzbetraegeList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ZusatzbetragVorlageControl.java
@@ -426,6 +426,10 @@ public class ZusatzbetragVorlageControl extends VorZurueckControl
     }
     zusatzbetragVorlageList.addColumn("Zahlt selbst", "mitgliedzahltselbst",
         new JaNeinFormatter(), false, Column.ALIGN_LEFT);
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      zusatzbetragVorlageList.addColumn(" ", " ");
+    }
     zusatzbetragVorlageList
         .setContextMenu(new ZusatzbetragVorlageMenu(zusatzbetragVorlageList));
     zusatzbetragVorlageList.setMulti(true);

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungUebernahmeProtokollDialog.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -92,6 +93,10 @@ public class BuchungUebernahmeProtokollDialog extends AbstractDialog<Buchung>
     bu.addColumn("Betrag", "betrag",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     bu.addColumn("Buchungsart", "buchungsart", new BuchungsartFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      bu.addColumn(" ", " ");
+    }
     bu.paint(parent);
 
     if (exception != null)

--- a/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungVorschauDialog.java
@@ -148,9 +148,11 @@ public class BuchungenSollbuchungZuordnungVorschauDialog
                 .replaceAll("\n", " "));
     buchungList.addColumn("Sollbuchung Datum", "sollbuchung_datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
-
     buchungList.addColumn("Zuordnungsart", "art");
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      buchungList.addColumn(" ", " ");
+    }
     buchungList.setCheckable(true);
     buchungList.setChecked(list.toArray(), true);
     buchungList.paint(parent);

--- a/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/DruckMailMitgliedDialog.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.eclipse.swt.widgets.Composite;
 
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.control.DruckMailControl.DruckMailEmpfaengerEntry;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
@@ -60,6 +62,10 @@ public class DruckMailMitgliedDialog extends AbstractDialog<Object>
     empfaenger.addColumn("Name", "name");
     empfaenger.addColumn("Vorname", "vorname");
     empfaenger.addColumn("Mitgliedstyp", "mitgliedstyp");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      empfaenger.addColumn(" ", " ");
+    }
     empfaenger.setMulti(true);
     empfaenger.paint(parent);
 

--- a/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SammelueberweisungAuswahlDialog.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -118,6 +119,10 @@ public class SammelueberweisungAuswahlDialog
     this.sammelueberweisung.addColumn("Bezeichnung", "bezeichnung");
     this.sammelueberweisung.addColumn("Summe", "summe",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      this.sammelueberweisung.addColumn(" ", " ");
+    }
     return this.sammelueberweisung;
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/ShowVariablesDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ShowVariablesDialog.java
@@ -26,6 +26,9 @@ import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.jameica.gui.Action;
@@ -92,6 +95,10 @@ public class ShowVariablesDialog extends AbstractJVereinDialog<Object>
     tab = new JVereinTablePart(list, getCopyAction());
     tab.addColumn("Name", "name");
     tab.addColumn("Wert", "wert");
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      tab.addColumn(" ", " ");
+    }
     tab.paint(parent);
 
     ButtonArea buttons = new ButtonArea();

--- a/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ZusatzbetragVorlageDialog.java
@@ -159,7 +159,10 @@ public class ZusatzbetragVorlageDialog
     }
     tab.addColumn("Zahlt selbst", "mitgliedzahltselbst", new JaNeinFormatter(),
         false, Column.ALIGN_LEFT);
-
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      tab.addColumn(" ", " ");
+    }
     return this.tab;
   }
 }

--- a/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/BuchungListPart.java
@@ -107,6 +107,10 @@ public class BuchungListPart extends BuchungListTablePart
     addColumn("Mitglied - Sollbuchung", Buchung.SOLLBUCHUNG,
         new SollbuchungFormatter());
     addColumn("Ersatz für Aufwendungen", "verzicht", new JaNeinFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      addColumn(" ", " ");
+    }
     setContextMenu(menu);
     setRememberState(true);
     setMulti(true);

--- a/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
@@ -78,6 +78,10 @@ public class SollbuchungPositionListPart extends BetragSummaryTablePart
       addColumn("Buchungsklasse", "buchungsklasse",
           new BuchungsklasseFormatter());
     }
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      addColumn(" ", " ");
+    }
     setMulti(true);
   }
 }

--- a/src/de/jost_net/JVerein/gui/parts/WiedervorlageList.java
+++ b/src/de/jost_net/JVerein/gui/parts/WiedervorlageList.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.control.FilterControl;
 import de.jost_net.JVerein.gui.control.VorZurueckControl;
@@ -64,6 +65,10 @@ public class WiedervorlageList extends JVereinTablePart
     wiedervorlageList.addColumn("Vermerk", "vermerk");
     wiedervorlageList.addColumn("Erledigung", "erledigung",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      wiedervorlageList.addColumn(" ", " ");
+    }
     wiedervorlageList.setContextMenu(new WiedervorlageMenu(wiedervorlageList));
     wiedervorlageList.setMulti(true);
     wiedervorlageList.setAction(

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -97,6 +97,8 @@ public class EinstellungenAnzeigeView extends AbstractView
         control.getUnterdrueckungOhneBuchung());
     cont4.addLabelPair("Summen Anlagenkonto in Kontensaldo",
         control.getSummenAnlagenkonto());
+    cont4.addLabelPair("Leere letzte Spalte in Tabellen",
+        control.getLeereSpalte());
 
     cont.addSeparator();
     ColumnLayout cols2 = new ColumnLayout(cont.getComposite(), 2);


### PR DESCRIPTION
Ich habe jetzt bei allen Tabellen und manchen Trees eine leere Spalte angefügt. Es lässt sich über die Einstellungen auswählen, ob diese Spalte angezeigt werden soll. So können Linux User vermeiden, dass die letzte Spalte ganz nach rechts gezogen wird, was speziell bei rechtem Alignment des Inhalts unschön ausschaut.

Schalter in Administration->Einstellungen->Anzeige
<img width="294" height="125" alt="Bildschirmfoto_20260524_102934" src="https://github.com/user-attachments/assets/53300a3d-983e-4da4-9abe-01d712d56d80" />
