### PR TITLE
Leere Spalte bei Tabellen

### DIFF
--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -44,7 +44,6 @@ import de.willuhn.jameica.hbci.rmi.HBCIDBService;
 import de.willuhn.jameica.messaging.QueryMessage;
 import de.willuhn.jameica.security.Wallet;
 import de.willuhn.jameica.system.Application;
-import de.willuhn.jameica.system.Platform;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -234,10 +233,7 @@ public class Einstellungen
     MITGLIEDSNUMMERANZEIGEN("nummeranzeigen", Boolean.class, "0"),
     SUMMENANLAGENKONTO("summenanlagenkonto", Boolean.class, "0"),
     LEERESPALTE("leerespalte", Boolean.class,
-        (Application.getPlatform().getOS() == Platform.OS_WINDOWS
-            || Application.getPlatform().getOS() == Platform.OS_WINDOWS_64)
-                ? "0"
-                : "1"),
+        System.getProperty("os.name").indexOf("windows") != -1 ? "0" : "1"),
 
     // Felder unten
     ALTERSMODEL("altermodel", Integer.class,

--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -232,6 +232,8 @@ public class Einstellungen
     EXTERNEMITGLIEDSNUMMER("externemitgliedsnummer", Boolean.class, "0"),
     MITGLIEDSNUMMERANZEIGEN("nummeranzeigen", Boolean.class, "0"),
     SUMMENANLAGENKONTO("summenanlagenkonto", Boolean.class, "0"),
+    LEERESPALTE("leerespalte", Boolean.class, "0"),
+    // Felder unten
     ALTERSMODEL("altermodel", Integer.class,
         ((Integer) Altermodel.AKTUELLES_DATUM).toString()),
     BUCHUNGBUCHUNGSARTAUSWAHL("buchungbuchungsartauswahl", Integer.class,

--- a/src/de/jost_net/JVerein/Einstellungen.java
+++ b/src/de/jost_net/JVerein/Einstellungen.java
@@ -44,6 +44,7 @@ import de.willuhn.jameica.hbci.rmi.HBCIDBService;
 import de.willuhn.jameica.messaging.QueryMessage;
 import de.willuhn.jameica.security.Wallet;
 import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.Platform;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -232,7 +233,12 @@ public class Einstellungen
     EXTERNEMITGLIEDSNUMMER("externemitgliedsnummer", Boolean.class, "0"),
     MITGLIEDSNUMMERANZEIGEN("nummeranzeigen", Boolean.class, "0"),
     SUMMENANLAGENKONTO("summenanlagenkonto", Boolean.class, "0"),
-    LEERESPALTE("leerespalte", Boolean.class, "0"),
+    LEERESPALTE("leerespalte", Boolean.class,
+        (Application.getPlatform().getOS() == Platform.OS_WINDOWS
+            || Application.getPlatform().getOS() == Platform.OS_WINDOWS_64)
+                ? "0"
+                : "1"),
+
     // Felder unten
     ALTERSMODEL("altermodel", Integer.class,
         ((Integer) Altermodel.AKTUELLES_DATUM).toString()),

--- a/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AnlagenlisteControl.java
@@ -112,10 +112,6 @@ public class AnlagenlisteControl extends AbstractSaldoControl
     saldoList.addColumn("Buchwert Ende GJ", ENDWERT,
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
-    // Dummy Spalte, damit endwert nicht am rechten Rand klebt
-    saldoList.addColumn(" ", " ",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-        Column.ALIGN_LEFT);
     saldoList.setFormatter(new SaldoFormatter());
     saldoList.setMulti(true);
     saldoList.setContextMenu(new SaldoMenu(this));

--- a/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -346,6 +346,8 @@ public class EinstellungControl extends AbstractControl
 
   private CheckboxInput summenAnlagenkonto;
 
+  private CheckboxInput leerespalte;
+
   private IntegerInput qrcodesize;
 
   private CheckboxInput qrcodeptext;
@@ -2164,6 +2166,17 @@ public class EinstellungControl extends AbstractControl
     return summenAnlagenkonto;
   }
 
+  public CheckboxInput getLeereSpalte() throws RemoteException
+  {
+    if (leerespalte != null)
+    {
+      return leerespalte;
+    }
+    leerespalte = new CheckboxInput(
+        (Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE));
+    return leerespalte;
+  }
+
   public DecimalInput getAfaRestwert() throws RemoteException
   {
     if (afarestwert != null)
@@ -2486,6 +2499,8 @@ public class EinstellungControl extends AbstractControl
           (Boolean) externemitgliedsnummer.getValue());
       Einstellungen.setEinstellung(Property.SUMMENANLAGENKONTO,
           (Boolean) summenAnlagenkonto.getValue());
+      Einstellungen.setEinstellung(Property.LEERESPALTE,
+          (Boolean) leerespalte.getValue());
       Altermodel amValue = (Altermodel) altersmodel.getValue();
       Einstellungen.setEinstellung(Property.ALTERSMODEL, amValue.getKey());
       AbstractInputAuswahl bbaAuswahl = (AbstractInputAuswahl) buchungBuchungsartAuswahl

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -2774,6 +2774,10 @@ public class MitgliedControl extends FilterControl implements Savable
     familienbeitragtree.addColumn("Zahlungsweg", "zahlungsweg");
     familienbeitragtree.addColumn("IBAN", "iban", new IBANFormatter());
     familienbeitragtree.addColumn("Austritt", "austritt", new DateFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      familienbeitragtree.addColumn(new Column("leer", ""));
+    }
     familienbeitragtree.setRememberColWidths(true);
 
     familienbeitragtree.setContextMenu(new FamilienbeitragMenu());
@@ -2820,6 +2824,10 @@ public class MitgliedControl extends FilterControl implements Savable
     abweichenderzahlertree.addColumn("Name", "name");
     abweichenderzahlertree.addColumn("Zahlungsweg", "zahlungsweg");
     abweichenderzahlertree.addColumn("IBAN", "iban", new IBANFormatter());
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      abweichenderzahlertree.addColumn(new Column("leer", ""));
+    }
     abweichenderzahlertree.setRememberColWidths(true);
 
     abweichenderzahlertree.setContextMenu(new AbweichenderZahlerMenu());

--- a/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MittelverwendungControl.java
@@ -355,10 +355,6 @@ public class MittelverwendungControl extends AbstractSaldoControl
     zuflussList.addColumn("Summe", SUMME,
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
         Column.ALIGN_RIGHT);
-    // Dummy Spalte, damit Summe nicht am rechten Rand klebt
-    zuflussList.addColumn(" ", " ",
-        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT), false,
-        Column.ALIGN_LEFT);
     zuflussList.removeFeature(FeatureSummary.class);
     return zuflussList;
   }

--- a/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -79,6 +79,7 @@ import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.ContextMenu;
 import de.willuhn.jameica.gui.parts.PanelButton;
 import de.willuhn.jameica.gui.parts.TreePart;
@@ -417,6 +418,10 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     mitgliedskontoTree.addColumn("Differenz", "differenz",
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      mitgliedskontoTree.addColumn(new Column("leer", ""));
+    }
     mitgliedskontoTree.setContextMenu(new MitgliedskontoMenu());
     mitgliedskontoTree.setFormatter(new MitgliedskontoTreeFormatter());
     mitgliedskontoTree.setRememberColWidths(true);

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Table;
@@ -42,6 +43,8 @@ import org.supercsv.prefs.CsvPreference;
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.Element;
 
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.dialogs.SpaltenAuswahlDialog;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
@@ -115,6 +118,16 @@ public class JVereinTablePart extends TablePart
   public void setAction(Action action)
   {
     this.action = action;
+  }
+
+  @Override
+  public synchronized void paint(Composite parent) throws RemoteException
+  {
+    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
+    {
+      addColumn(new Column("leer", ""));
+    }
+    super.paint(parent);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EinstellungenAnzeigeView.java
@@ -97,6 +97,8 @@ public class EinstellungenAnzeigeView extends AbstractView
         control.getUnterdrueckungOhneBuchung());
     cont4.addLabelPair("Summen Anlagenkonto in Kontensaldo",
         control.getSummenAnlagenkonto());
+    cont4.addLabelPair("Leere letzte Spalte in Tabellen",
+        control.getLeereSpalte());
 
     cont.addSeparator();
     ColumnLayout cols2 = new ColumnLayout(cont.getComposite(), 2);


### PR DESCRIPTION
Ich habe jetzt bei allen Tabellen und manchen Trees eine leere Spalte angefügt. Es lässt sich über die Einstellungen auswählen, ob diese Spalte angezeigt werden soll. So können Linux User vermeiden, dass die letzte Spalte ganz nach rechts gezogen wird, was speziell bei rechtem Alignment des Inhalts unschön ausschaut.

Schalter in Administration->Einstellungen->Anzeige
<img width="294" height="125" alt="Bildschirmfoto_20260524_102934" src="https://github.com/user-attachments/assets/53300a3d-983e-4da4-9abe-01d712d56d80" />