### PR TITLE
Seitennummern bei Kontoauszug

### DIFF
--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -39,9 +39,9 @@ import de.willuhn.datasource.rmi.DBObject;
 
 public class Kontoauszug extends AbstractAusgabe
 {
-  private Reporter rpt;
+  private FileOutputStream fos;
 
-  private boolean first = true;
+  private Reporter rpt;
 
   private SollbuchungControl control;
 
@@ -50,18 +50,27 @@ public class Kontoauszug extends AbstractAusgabe
     this.control = control;
   }
 
-  private void generiereMitglied(Mitglied m)
-      throws RemoteException, DocumentException
+  private void generiereMitglied(File file, Mitglied m)
+      throws DocumentException, IOException
   {
     MitgliedskontoNode node = new MitgliedskontoNode(m,
         (Date) control.getDatumvon().getValue(),
         (Date) control.getDatumbis().getValue());
 
-    if (!first)
+    if (fos == null)
+    {
+      fos = new FileOutputStream(file);
+    }
+
+    if (rpt == null)
+    {
+      rpt = new Reporter(fos, "", "", 60, 30, 20, 20, false);
+    }
+    else
     {
       rpt.newPage();
     }
-    first = false;
+
     String title = VorlageUtil.getName(VorlageTyp.KONTOAUSZUG_TITEL, null, m);
     String subtitle = VorlageUtil.getName(VorlageTyp.KONTOAUSZUG_SUBTITEL, null,
         m);
@@ -72,7 +81,7 @@ public class Kontoauszug extends AbstractAusgabe
     psubTitle.setAlignment(Element.ALIGN_CENTER);
     rpt.add(psubTitle);
 
-    rpt.addHeaderColumn(" ", Element.ALIGN_CENTER, 20, BaseColor.LIGHT_GRAY);
+    rpt.addHeaderColumn(" ", Element.ALIGN_CENTER, 15, BaseColor.LIGHT_GRAY);
     rpt.addHeaderColumn("Datum", Element.ALIGN_CENTER, 20,
         BaseColor.LIGHT_GRAY);
     rpt.addHeaderColumn("Zweck", Element.ALIGN_LEFT, 50, BaseColor.LIGHT_GRAY);
@@ -136,12 +145,7 @@ public class Kontoauszug extends AbstractAusgabe
   protected void createPDF(Formular formular, FormularAufbereitung aufbereitung,
       File file, DBObject object) throws IOException, DocumentException
   {
-    if (rpt == null)
-    {
-      rpt = new Reporter(new FileOutputStream(file, true), 40, 20, 20, 40,
-          false);
-    }
-    generiereMitglied((Mitglied) object);
+    generiereMitglied(file, (Mitglied) object);
   }
 
   @Override
@@ -149,9 +153,9 @@ public class Kontoauszug extends AbstractAusgabe
       DBObject object) throws IOException, DocumentException
   {
     rpt.close();
-    // auf null setzen, damit beim nächsten createPDF ein neues Dokument erzeugt
-    // wird
+    fos.close();
     rpt = null;
+    fos = null;
   }
 
   @Override

--- a/src/de/jost_net/JVerein/io/Kontoauszug.java
+++ b/src/de/jost_net/JVerein/io/Kontoauszug.java
@@ -68,6 +68,7 @@ public class Kontoauszug extends AbstractAusgabe
     }
     else
     {
+      rpt.resetPageCount();
       rpt.newPage();
     }
 

--- a/src/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
+++ b/src/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
@@ -163,6 +163,7 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
       }
       else
       {
+        rpt.resetPageCount();
         rpt.newPage();
       }
 

--- a/src/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
+++ b/src/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
@@ -40,7 +40,6 @@ import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.gui.control.PersonalbogenControl;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
-import de.jost_net.JVerein.keys.Ausgabeart;
 import de.jost_net.JVerein.keys.Beitragsmodel;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.keys.VorlageTyp;
@@ -82,15 +81,6 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
   public PersonalbogenAusgabe(PersonalbogenControl control)
   {
     this.control = control;
-  }
-
-  @Override
-  public void aufbereiten(ArrayList<? extends DBObject> list, Ausgabeart art,
-      String betreff, String text, boolean pdfa, boolean encrypt,
-      boolean versanddatum)
-      throws IOException, ApplicationException, DocumentException
-  {
-    super.aufbereiten(list, art, betreff, text, pdfa, encrypt, versanddatum);
   }
 
   @Override

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -199,8 +199,7 @@ public class Reporter implements AutoCloseable
       contentByte.addTemplate(page, 0, 0);
     }
     // Vordergrund Event immer setzen weil es für das Rücksetzen der
-    // Seitennummer
-    // gebraucht wird
+    // Seitennummer gebraucht wird
     PdfReader reader = vordergrund != null
         ? new PdfReader(vordergrund.getInhalt())
         : null;

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -79,6 +79,8 @@ public class Reporter implements AutoCloseable
 
   private BaseColor zellenColor = BaseColor.WHITE;
 
+  private boolean resetPageCount = false;
+
   private boolean headerTransparent = (Boolean) Einstellungen
       .getEinstellung(Property.TABELLEN_HEADER_TRANSPARENT);
 
@@ -196,11 +198,14 @@ public class Reporter implements AutoCloseable
       PdfContentByte contentByte = writer.getDirectContentUnder();
       contentByte.addTemplate(page, 0, 0);
     }
-    if (vordergrund != null)
-    {
-      PdfReader reader = new PdfReader(vordergrund.getInhalt());
-      writer.setPageEvent(new ReportVordergrund(reader));
-    }
+    // Vordergrund Event immer setzen weil es für das Rücksetzen der
+    // Seitennummer
+    // gebraucht wird
+    PdfReader reader = vordergrund != null
+        ? new PdfReader(vordergrund.getInhalt())
+        : null;
+    writer.setPageEvent(new ReportVordergrund(reader));
+
     if (this.zellenTransparent)
     {
       zellenColor = null;
@@ -618,7 +623,7 @@ public class Reporter implements AutoCloseable
   }
 
   /**
-   * Setzen eines Hintergrundes bei Reports.
+   * Setzen eines Vordergrund bei Reports.
    */
   private class ReportVordergrund extends PdfPageEventHelper
   {
@@ -644,6 +649,11 @@ public class Reporter implements AutoCloseable
         contentByte.saveState();
         contentByte.addTemplate(page, 0, 0);
         contentByte.restoreState();
+      }
+      if (resetPageCount)
+      {
+        document.resetPageCount();
+        resetPageCount = false;
       }
     }
   }
@@ -683,10 +693,14 @@ public class Reporter implements AutoCloseable
       pc.moveTo(left, bottom - 25);
       pc.lineTo(right, bottom - 25);
       pc.stroke();
-
       ColumnText.showTextAligned(pc, Element.ALIGN_CENTER,
           new Phrase(footer + " " + writer.getPageNumber(), getFreeSans(7)),
           (left + right) / 2, bottom - 18, 0);
     }
+  }
+
+  public void resetPageCount()
+  {
+    resetPageCount = true;
   }
 }

--- a/src/de/jost_net/JVerein/io/Reporter.java
+++ b/src/de/jost_net/JVerein/io/Reporter.java
@@ -689,12 +689,9 @@ public class Reporter implements AutoCloseable
       pc.moveTo(left, bottom - 5);
       pc.lineTo(right, bottom - 5);
       pc.stroke();
-      pc.moveTo(left, bottom - 25);
-      pc.lineTo(right, bottom - 25);
-      pc.stroke();
       ColumnText.showTextAligned(pc, Element.ALIGN_CENTER,
           new Phrase(footer + " " + writer.getPageNumber(), getFreeSans(7)),
-          (left + right) / 2, bottom - 18, 0);
+          (left + right) / 2, bottom - 15, 0);
     }
   }
 


### PR DESCRIPTION
Analog zu Personalbogen

Falls mehrere Mitglieder Reports in einer Datei gespeichert werden, wird bei jedem Mitglied mit der Seitennummerierung neu begonnen.

Auch bei Hintergrund und Vordergrund wird bei einer mehrseitigen Vorlage bei jedem Mitglied neu gestartet. 