### PR TITLE
Fix Sachspendenbescheinigung

### DIFF
--- a/src/de/jost_net/JVerein/io/SpendenbescheinigungAusgabe.java
+++ b/src/de/jost_net/JVerein/io/SpendenbescheinigungAusgabe.java
@@ -232,7 +232,7 @@ public class SpendenbescheinigungAusgabe extends AbstractAusgabe
       rpt.addColumn(
           "Genaue Bezeichnung der Sachzuwendung mit Alter, Zustand, Kaufpreis usw.\n\n"
               + spb.getBezeichnungSachzuwendung(),
-          Element.ALIGN_LEFT);
+          Element.ALIGN_LEFT, (BaseColor) null);
       rpt.closeTable();
 
       Paragraph p = new Paragraph();


### PR DESCRIPTION
Das Feld mit der Bezeichnung der Sachzuwendung war nicht transparent so wie die anderen Felder.