### PR TITLE
Fix Buchungsübernahme bei Gegenkontonummer länger als IBAN-Spalte

### DIFF
--- a/src/de/jost_net/JVerein/io/Buchungsuebernahme.java
+++ b/src/de/jost_net/JVerein/io/Buchungsuebernahme.java
@@ -180,7 +180,19 @@ public class Buchungsuebernahme
         b.setUmsatzid(Integer.valueOf(u.getID()));
         b.setKonto(kto);
         b.setName(u.getGegenkontoName());
-        b.setIban(u.getGegenkontoNummer());
+        String gegenkonto = u.getGegenkontoNummer();
+        if (gegenkonto != null && gegenkonto.length() > 34)
+        {
+          // Hibiscus liefert in Gegenkontonummer nicht immer eine IBAN
+          // (z. B. bei PayPal/Alibaba eine E-Mail-Adresse). Die Spalte ist
+          // auf 34 Zeichen begrenzt, daher übernehmen wir den Wert in
+          // diesem Fall nicht als IBAN.
+          Logger.warn("Gegenkontonummer '" + gegenkonto
+              + "' ist keine gültige IBAN (länger als 34 Zeichen), "
+              + "wird nicht als IBAN übernommen.");
+          gegenkonto = null;
+        }
+        b.setIban(gegenkonto);
         b.setBetrag(u.getBetrag());
         b.setZweck(u.getZweck());
         String[] moreLines = u.getWeitereVerwendungszwecke();


### PR DESCRIPTION
## Problem

Beim Übernehmen von Hibiscus-Umsätzen kann der Import komplett abbrechen, wenn die `Gegenkontonummer` keine gültige IBAN ist. Hibiscus liefert dort z. B. bei Drittanbieter-Zahlungen (PayPal, Alibaba/AliPay) eine E-Mail-Adresse wie `ae-alipayeupaypal@service.alibaba.com` (37 Zeichen). Die Spalte `BUCHUNG.IBAN` ist auf `VARCHAR(34)` begrenzt, sodass H2 mit folgendem Fehler abbricht:

```
java.rmi.RemoteException: insert failed, rollback successful; nested exception is:
    org.h2.jdbc.JdbcSQLDataException: Wert zu gross / lang für Feld
    """IBAN"" VARCHAR(34) DEFAULT NULL SELECTIVITY 1":
    "'ae-alipayeupaypal@service.alibaba.com' (37)"
    ...
    at de.jost_net.JVerein.io.Buchungsuebernahme.importiereUmsatz(Buchungsuebernahme.java:234)
    at de.jost_net.JVerein.io.Buchungsuebernahme.leseHibiscus(Buchungsuebernahme.java:167)
```

Da der gesamte Übernahmevorgang an dieser einen Buchung scheitert, werden auch alle nachfolgenden Buchungen nicht importiert.

## Fix

In `Buchungsuebernahme.importiereUmsatz` wird vor dem `b.setIban(...)`-Aufruf geprüft, ob der Wert die maximale IBAN-Länge (34 Zeichen) überschreitet. Ist das der Fall, wird der Wert verworfen (mit `Logger.warn`), statt den gesamten Import abzubrechen. Name und Verwendungszweck der Buchung bleiben unverändert erhalten, sodass der Buchungsempfänger weiterhin erkennbar ist.

## Diff

```java
 b.setName(u.getGegenkontoName());
-b.setIban(u.getGegenkontoNummer());
+String gegenkonto = u.getGegenkontoNummer();
+if (gegenkonto != null && gegenkonto.length() > 34)
+{
+  // Hibiscus liefert in Gegenkontonummer nicht immer eine IBAN
+  // (z. B. bei PayPal/Alibaba eine E-Mail-Adresse). Die Spalte ist
+  // auf 34 Zeichen begrenzt, daher übernehmen wir den Wert in
+  // diesem Fall nicht als IBAN.
+  Logger.warn("Gegenkontonummer '" + gegenkonto
+      + "' ist keine gültige IBAN (länger als 34 Zeichen), "
+      + "wird nicht als IBAN übernommen.");
+  gegenkonto = null;
+}
+b.setIban(gegenkonto);
```