### PR TITLE
Fix EigenschaftenAuswahlDialog

### DIFF
--- a/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/EigenschaftenAuswahlDialog.java
@@ -184,7 +184,7 @@ public class EigenschaftenAuswahlDialog
     werte.add(ODER);
     eigenschaftenverknuepfung = new SelectInput(werte,
         control.getEigenschaftenVerknuepfung());
-    eigenschaftenverknuepfung.setName("Gruppen-Verknüpfung");
+    eigenschaftenverknuepfung.setName("Eigenschaften-Verknüpfung");
     return eigenschaftenverknuepfung;
   }
 


### PR DESCRIPTION
Bei der Eigenschaften Verknüpfung stand "Gruppen-Verknüpfung". Das war früher einmal so, dass die Verknüpfung auf Gruppenenbene war. Das habe ich aber schon vor langer Zeit geändert.
Es ist jetzt eine echte Eigenschaftenverknüpfung. Darum habe ich den Text geändert.