### PR TITLE
Fix Buchung zu Sollbuchung zuordnen

### DIFF
--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -21,6 +21,7 @@ import java.rmi.RemoteException;
 import java.util.Arrays;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.dialogs.SollbuchungAuswahlDialog;
 import de.jost_net.JVerein.gui.dialogs.YesNoCancelDialog;
@@ -45,6 +46,12 @@ public class BuchungSollbuchungZuordnungAction implements Action
 {
   private BuchungsControl control;
 
+  private Buchung[] buchungen = null;
+
+  private Sollbuchung[] sollbuchungen = null;
+
+  private Mitglied mitglied;
+
   public BuchungSollbuchungZuordnungAction(BuchungsControl control)
   {
     this.control = control;
@@ -60,244 +67,269 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
     try
     {
-      Buchung[] b = null;
       if (context instanceof Buchung)
       {
-        b = new Buchung[1];
-        b[0] = (Buchung) context;
+        buchungen = new Buchung[1];
+        buchungen[0] = (Buchung) context;
       }
       if (context instanceof Buchung[])
       {
-        b = (Buchung[]) context;
+        buchungen = (Buchung[]) context;
       }
-      if (b.length == 0)
+      if (buchungen.length == 0)
       {
         return;
       }
-      if (b[0].isNewObject())
+      if (buchungen[0].isNewObject())
       {
         return;
       }
-      SollbuchungAuswahlDialog mkaz = new SollbuchungAuswahlDialog(b[0], true);
+
+      DBTransaction.starten();
+      SollbuchungAuswahlDialog mkaz = new SollbuchungAuswahlDialog(buchungen[0],
+          true);
       Object open = mkaz.open();
-      Sollbuchung sollb = null;
 
       if (!mkaz.getAbort())
       {
-        if (open instanceof Sollbuchung)
-        {
-          sollb = (Sollbuchung) open;
-        }
-        else if (open instanceof Mitglied)
-        {
-          Mitglied m = (Mitglied) open;
-          sollb = (Sollbuchung) Einstellungen.getDBService()
-              .createObject(Sollbuchung.class, null);
-
-          Double betrag = 0d;
-          for (Buchung buchung : b)
-          {
-            betrag += buchung.getBetrag();
-          }
-
-          sollb.setBetrag(betrag);
-          sollb.setDatum(b[0].getDatum());
-          sollb.setMitglied(m);
-          sollb.setZahler(m);
-          sollb.setZahlungsweg(Zahlungsweg.ÜBERWEISUNG);
-          sollb.setZweck1(b[0].getZweck());
-          sollb.store();
-
-          for (Buchung buchung : b)
-          {
-            SollbuchungPosition sbp = (SollbuchungPosition) Einstellungen
-                .getDBService().createObject(SollbuchungPosition.class, null);
-            sbp.setBetrag(buchung.getBetrag());
-            sbp.setBuchungsartId(buchung.getBuchungsartId());
-            sbp.setBuchungsklasseId(buchung.getBuchungsklasseId());
-            sbp.setSteuer(buchung.getSteuer());
-            sbp.setDatum(buchung.getDatum());
-            sbp.setZweck(buchung.getZweck());
-            sbp.setSollbuchung(sollb.getID());
-            sbp.store();
-          }
-        }
-
         // Sollbuchung entfernen
         if (open == null)
         {
-          for (Buchung buchung : b)
-          {
-            buchung.setSollbuchung(null);
-            buchung.store();
-          }
-          GUI.getStatusBar().setSuccessText("Sollbuchung von Buchung gelöst");
+          zuordnungLoeschen();
         }
-        // Buchung mehreren Sollbuchungen zuordnen
-        else if (open instanceof Sollbuchung[])
+        else if (open instanceof Mitglied)
         {
-          if (b.length > 1)
-          {
-            throw new ApplicationException(
-                "Mehrere Buchungen mehreren Sollbuchungen zuordnen nicht möglich!");
-          }
-          if (b[0].getSplitTyp() != null
-              && (b[0].getSplitTyp() == SplitbuchungTyp.GEGEN
-                  || b[0].getSplitTyp() == SplitbuchungTyp.HAUPT))
-          {
-            throw new ApplicationException(
-                "Haupt- oder Gegen-Buchungen können nicht mehreren Sollbuchungen zugeordnet werden!");
-          }
-
-          Sollbuchung[] sollbs = (Sollbuchung[]) open;
-          // Nach Datum sortieren, so dass die ältesten Buchngen als erstes
-          // ausgeglichen werden
-          Arrays.sort(sollbs, (s1, s2) -> {
-            try
-            {
-              return s1.getDatum().compareTo(s2.getDatum());
-            }
-            catch (RemoteException e)
-            {
-              return 0;
-            }
-          });
-
-          sollb = sollbs[0];
-          Buchung buchung = b[0];
-
-          try
-          {
-            b[0].transactionBegin();
-            for (Sollbuchung s : sollbs)
-            {
-              if (buchung == null)
-              {
-                // Wenn keine Restbuchung existiert wurde alles zugewiesen und
-                // es ist nichts mehr für die restlichen Sollbuchungen übrig.
-                break;
-              }
-              buchung = SplitbuchungsContainer.autoSplit(buchung, s, false);
-            }
-            if (buchung != null)
-            {
-              YesNoDialog dialog = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-              dialog.setTitle("Buchung splitten");
-              dialog.setText(
-                  "Der Betrag der Buchung ist größer als der Fehlbetrag der Sollbuchungen.\n"
-                      + "Soll die Restbuchung auch der Sollbuchung zugewiesen werden?");
-              try
-              {
-                if ((Boolean) dialog.open())
-                {
-                  buchung.setSollbuchung(sollbs[sollbs.length - 1]);
-                  buchung.store();
-                }
-              }
-              catch (OperationCanceledException ignore)
-              {
-              }
-            }
-            b[0].transactionCommit();
-          }
-          catch (Exception e)
-          {
-            b[0].transactionRollback();
-            Logger.error("Fehler", e);
-            throw new ApplicationException(
-                "Fehler beim Splitten der Buchung: " + e.getLocalizedMessage());
-          }
+          mitglied = (Mitglied) open;
+          zuordnungMitglied();
         }
-        // Buchung einer Sollbuchung zuordnen
-        else
+        else if (open instanceof Sollbuchung)
         {
-          if (b.length == 1)
+          sollbuchungen = new Sollbuchung[1];
+          sollbuchungen[0] = (Sollbuchung) open;
+          if (buchungen.length == 1)
           {
-            Buchung buchung = b[0];
-            if (Math.abs(buchung.getBetrag()
-                - (sollb.getBetrag() - sollb.getIstSumme())) >= 0.01d)
-            {
-              YesNoCancelDialog dialog = new YesNoCancelDialog(
-                  YesNoDialog.POSITION_CENTER, true);
-              dialog.setTitle("Buchung splitten");
-              dialog.setText(
-                  "Die Fehlbetrag der Sollbuchung und der Betrag der Buchung stimmen nicht überein.\n"
-                      + "Soll die Buchung automatisch gesplittet werden?\n"
-                      + "Bei 'Nein' wird die Sollbuchung ohne Splitten zugeordnet.");
-              int ret = dialog.open();
-              if (ret == YesNoCancelDialog.YES)
-              {
-                Buchung restbuchung = SplitbuchungsContainer.autoSplit(buchung,
-                    sollb, false);
-                if (restbuchung != null)
-                {
-                  YesNoDialog restbuchungDialog = new YesNoDialog(
-                      YesNoDialog.POSITION_CENTER);
-                  restbuchungDialog.setTitle("Restbuchung zuordnen");
-                  restbuchungDialog.setText(
-                      "Der Betrag der Buchung ist größer als der Fehlbetrag der Sollbuchung.\n"
-                          + "Soll die Restbuchung auch der Sollbuchung zugewiesen werden?");
-                  try
-                  {
-                    if ((Boolean) restbuchungDialog.open())
-                    {
-                      restbuchung.setSollbuchung(sollb);
-                      restbuchung.store();
-                    }
-                  }
-                  catch (OperationCanceledException ignore)
-                  {
-                  }
-                }
-              }
-              else if (ret == YesNoCancelDialog.NO)
-              {
-                // Bei NEIN ohne Splitten zuordnen
-                buchung.setSollbuchung(sollb);
-                buchung.store();
-              }
-              else if (ret == YesNoCancelDialog.CANCEL)
-              {
-                throw new OperationCanceledException();
-              }
-
-            }
-            else
-            {
-              // Fehlbetrag und Buchungs-Betrag stimmen überein
-              SplitbuchungsContainer.autoSplit(buchung, sollb, true);
-            }
+            zuordnungBuchungZuSollbuchung();
           }
           else
           {
-            // Mehrere Buchungen einer Sollbuchung zuordnen geht nur ohne
-            // Splitten.
-            for (Buchung buchung : b)
-            {
-              buchung.setSollbuchung(sollb);
-              buchung.store();
-            }
+            zuordnungBuchungenZuSollbuchung();
+          }
+        }
+        else if (open instanceof Sollbuchung[])
+        {
+          sollbuchungen = (Sollbuchung[]) open;
+          if (buchungen.length == 1)
+          {
+            zuordnungBuchungZuSollbuchungen();
+          }
+          else
+          {
+            throw new ApplicationException(
+                "Mehrere Buchungen mehreren Sollbuchungen zuordnen ist nicht möglich!");
           }
         }
 
-        GUI.getStatusBar().setSuccessText("Sollbuchung zugeordnet");
+        if (open == null)
+        {
+          GUI.getStatusBar()
+              .setSuccessText("Sollbuchung von Buchung(en) gelöst");
+        }
+        else
+        {
+          GUI.getStatusBar().setSuccessText("Sollbuchung zugeordnet");
+        }
         control.refreshBuchungsList();
       }
+      DBTransaction.commit();
     }
     catch (OperationCanceledException oce)
     {
+      DBTransaction.rollback();
       throw oce;
     }
     catch (ApplicationException ae)
     {
+      DBTransaction.rollback();
       GUI.getStatusBar().setErrorText(
-          "Fehler bei der Zuordnung der Sollbuchung. " + ae.getMessage());
+          "Fehler bei der Zuordnung der Sollbuchung: " + ae.getMessage());
     }
     catch (Exception e)
     {
+      DBTransaction.rollback();
       Logger.error("Fehler bei der Zuordnung der Sollbuchung", e);
       GUI.getStatusBar()
           .setErrorText("Fehler bei der Zuordnung der Sollbuchung");
     }
   }
+
+  private void zuordnungLoeschen() throws RemoteException, ApplicationException
+  {
+    for (Buchung buchung : buchungen)
+    {
+      buchung.setSollbuchung(null);
+      buchung.store();
+    }
+  }
+
+  private void zuordnungMitglied() throws RemoteException, ApplicationException
+  {
+    Sollbuchung sollb = (Sollbuchung) Einstellungen.getDBService()
+        .createObject(Sollbuchung.class, null);
+
+    Double betrag = 0d;
+    for (Buchung buchung : buchungen)
+    {
+      betrag += buchung.getBetrag();
+    }
+
+    sollb.setBetrag(betrag);
+    sollb.setDatum(buchungen[0].getDatum());
+    sollb.setMitglied(mitglied);
+    sollb.setZahler(mitglied);
+    sollb.setZahlungsweg(Zahlungsweg.ÜBERWEISUNG);
+    sollb.setZweck1(buchungen[0].getZweck());
+    sollb.store();
+
+    for (Buchung buchung : buchungen)
+    {
+      SollbuchungPosition sbp = (SollbuchungPosition) Einstellungen
+          .getDBService().createObject(SollbuchungPosition.class, null);
+      sbp.setBetrag(buchung.getBetrag());
+      sbp.setBuchungsartId(buchung.getBuchungsartId());
+      sbp.setBuchungsklasseId(buchung.getBuchungsklasseId());
+      sbp.setSteuer(buchung.getSteuer());
+      sbp.setDatum(buchung.getDatum());
+      sbp.setZweck(buchung.getZweck());
+      sbp.setSollbuchung(sollb.getID());
+      sbp.store();
+    }
+  }
+
+  private void zuordnungBuchungZuSollbuchung()
+      throws RemoteException, ApplicationException, Exception
+  {
+    Buchung buchung = buchungen[0];
+    Sollbuchung sollb = sollbuchungen[0];
+
+    if (Math.abs(buchung.getBetrag()
+        - (sollb.getBetrag() - sollb.getIstSumme())) >= 0.01d)
+    {
+      YesNoCancelDialog dialog = new YesNoCancelDialog(
+          YesNoDialog.POSITION_CENTER, true);
+      dialog.setTitle("Buchung splitten");
+      dialog.setText(
+          "Die Fehlbetrag der Sollbuchung und der Betrag der Buchung stimmen nicht überein.\n"
+              + "Soll die Buchung automatisch gesplittet werden?\n"
+              + "Bei 'Nein' wird die Sollbuchung ohne Splitten zugeordnet.");
+      int ret = dialog.open();
+      if (ret == YesNoCancelDialog.YES)
+      {
+        Buchung restbuchung = SplitbuchungsContainer.autoSplit(buchung, sollb,
+            false);
+        if (restbuchung != null)
+        {
+          YesNoDialog restbuchungDialog = new YesNoDialog(
+              YesNoDialog.POSITION_CENTER);
+          restbuchungDialog.setTitle("Restbuchung zuordnen");
+          restbuchungDialog.setText(
+              "Der Betrag der Buchung ist größer als der Fehlbetrag der Sollbuchung.\n"
+                  + "Soll die Restbuchung auch der Sollbuchung zugewiesen werden?");
+          try
+          {
+            if ((Boolean) restbuchungDialog.open())
+            {
+              restbuchung.setSollbuchung(sollb);
+              restbuchung.store();
+            }
+          }
+          catch (OperationCanceledException ignore)
+          {
+          }
+        }
+      }
+      else if (ret == YesNoCancelDialog.NO)
+      {
+        // Bei NEIN ohne Splitten zuordnen
+        buchung.setSollbuchung(sollb);
+        buchung.store();
+      }
+      else if (ret == YesNoCancelDialog.CANCEL)
+      {
+        throw new OperationCanceledException();
+      }
+    }
+    else
+    {
+      // Fehlbetrag und Buchungs-Betrag stimmen überein
+      SplitbuchungsContainer.autoSplit(buchung, sollb, true);
+    }
+  }
+
+  private void zuordnungBuchungenZuSollbuchung()
+      throws RemoteException, ApplicationException
+  {
+    // Mehrere Buchungen einer Sollbuchung zuordnen geht nur ohne Splitten.
+    for (Buchung buchung : buchungen)
+    {
+      buchung.setSollbuchung(sollbuchungen[0]);
+      buchung.store();
+    }
+  }
+
+  private void zuordnungBuchungZuSollbuchungen() throws Exception
+  {
+    if (buchungen[0].getSplitTyp() != null
+        && (buchungen[0].getSplitTyp() == SplitbuchungTyp.GEGEN
+            || buchungen[0].getSplitTyp() == SplitbuchungTyp.HAUPT))
+    {
+      throw new ApplicationException(
+          "Haupt- oder Gegen-Buchungen können nicht mehreren Sollbuchungen zugeordnet werden!");
+    }
+
+    // Nach Datum sortieren, so dass die ältesten Buchngen als erstes
+    // ausgeglichen werden
+    Arrays.sort(sollbuchungen, (s1, s2) -> {
+      try
+      {
+        return s1.getDatum().compareTo(s2.getDatum());
+      }
+      catch (RemoteException e)
+      {
+        return 0;
+      }
+    });
+
+    Buchung buchung = buchungen[0];
+
+    for (Sollbuchung s : sollbuchungen)
+    {
+      if (buchung == null)
+      {
+        // Wenn keine Restbuchung existiert wurde alles zugewiesen und
+        // es ist nichts mehr für die restlichen Sollbuchungen übrig.
+        break;
+      }
+      buchung = SplitbuchungsContainer.autoSplit(buchung, s, false);
+    }
+    if (buchung != null)
+    {
+      YesNoDialog dialog = new YesNoDialog(YesNoDialog.POSITION_CENTER);
+      dialog.setTitle("Buchung splitten");
+      dialog.setText(
+          "Der Betrag der Buchung ist größer als der Fehlbetrag der Sollbuchungen.\n"
+              + "Soll die Restbuchung auch der Sollbuchung zugewiesen werden?");
+      try
+      {
+        if ((Boolean) dialog.open())
+        {
+          buchung.setSollbuchung(sollbuchungen[sollbuchungen.length - 1]);
+          buchung.store();
+        }
+      }
+      catch (OperationCanceledException ignore)
+      {
+      }
+    }
+  }
+
 }

--- a/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -46,12 +46,6 @@ public class BuchungSollbuchungZuordnungAction implements Action
 {
   private BuchungsControl control;
 
-  private Buchung[] buchungen = null;
-
-  private Sollbuchung[] sollbuchungen = null;
-
-  private Mitglied mitglied;
-
   public BuchungSollbuchungZuordnungAction(BuchungsControl control)
   {
     this.control = control;
@@ -67,6 +61,7 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
     try
     {
+      Buchung[] buchungen = null;
       if (context instanceof Buchung)
       {
         buchungen = new Buchung[1];
@@ -95,32 +90,28 @@ public class BuchungSollbuchungZuordnungAction implements Action
         // Sollbuchung entfernen
         if (open == null)
         {
-          zuordnungLoeschen();
+          zuordnungLoeschen(buchungen);
         }
         else if (open instanceof Mitglied)
         {
-          mitglied = (Mitglied) open;
-          zuordnungMitglied();
+          zuordnungMitglied(buchungen, (Mitglied) open);
         }
         else if (open instanceof Sollbuchung)
         {
-          sollbuchungen = new Sollbuchung[1];
-          sollbuchungen[0] = (Sollbuchung) open;
           if (buchungen.length == 1)
           {
-            zuordnungBuchungZuSollbuchung();
+            zuordnungBuchungZuSollbuchung(buchungen[0], (Sollbuchung) open);
           }
           else
           {
-            zuordnungBuchungenZuSollbuchung();
+            zuordnungBuchungenZuSollbuchung(buchungen, (Sollbuchung) open);
           }
         }
         else if (open instanceof Sollbuchung[])
         {
-          sollbuchungen = (Sollbuchung[]) open;
           if (buchungen.length == 1)
           {
-            zuordnungBuchungZuSollbuchungen();
+            zuordnungBuchungZuSollbuchungen(buchungen[0], (Sollbuchung[]) open);
           }
           else
           {
@@ -162,7 +153,8 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
   }
 
-  private void zuordnungLoeschen() throws RemoteException, ApplicationException
+  private void zuordnungLoeschen(Buchung[] buchungen)
+      throws RemoteException, ApplicationException
   {
     for (Buchung buchung : buchungen)
     {
@@ -171,7 +163,8 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
   }
 
-  private void zuordnungMitglied() throws RemoteException, ApplicationException
+  private void zuordnungMitglied(Buchung[] buchungen, Mitglied mitglied)
+      throws RemoteException, ApplicationException
   {
     Sollbuchung sollb = (Sollbuchung) Einstellungen.getDBService()
         .createObject(Sollbuchung.class, null);
@@ -205,12 +198,9 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
   }
 
-  private void zuordnungBuchungZuSollbuchung()
+  private void zuordnungBuchungZuSollbuchung(Buchung buchung, Sollbuchung sollb)
       throws RemoteException, ApplicationException, Exception
   {
-    Buchung buchung = buchungen[0];
-    Sollbuchung sollb = sollbuchungen[0];
-
     if (Math.abs(buchung.getBetrag()
         - (sollb.getBetrag() - sollb.getIstSumme())) >= 0.01d)
     {
@@ -265,22 +255,23 @@ public class BuchungSollbuchungZuordnungAction implements Action
     }
   }
 
-  private void zuordnungBuchungenZuSollbuchung()
-      throws RemoteException, ApplicationException
+  private void zuordnungBuchungenZuSollbuchung(Buchung[] buchungen,
+      Sollbuchung sollb) throws RemoteException, ApplicationException
   {
     // Mehrere Buchungen einer Sollbuchung zuordnen geht nur ohne Splitten.
     for (Buchung buchung : buchungen)
     {
-      buchung.setSollbuchung(sollbuchungen[0]);
+      buchung.setSollbuchung(sollb);
       buchung.store();
     }
   }
 
-  private void zuordnungBuchungZuSollbuchungen() throws Exception
+  private void zuordnungBuchungZuSollbuchungen(Buchung buch,
+      Sollbuchung[] sollbuchungen) throws Exception
   {
-    if (buchungen[0].getSplitTyp() != null
-        && (buchungen[0].getSplitTyp() == SplitbuchungTyp.GEGEN
-            || buchungen[0].getSplitTyp() == SplitbuchungTyp.HAUPT))
+    if (buch.getSplitTyp() != null
+        && (buch.getSplitTyp() == SplitbuchungTyp.GEGEN
+            || buch.getSplitTyp() == SplitbuchungTyp.HAUPT))
     {
       throw new ApplicationException(
           "Haupt- oder Gegen-Buchungen können nicht mehreren Sollbuchungen zugeordnet werden!");
@@ -299,7 +290,7 @@ public class BuchungSollbuchungZuordnungAction implements Action
       }
     });
 
-    Buchung buchung = buchungen[0];
+    Buchung buchung = buch;
 
     for (Sollbuchung s : sollbuchungen)
     {

--- a/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -778,6 +778,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
       }
       try
       {
+        DBTransaction.starten();
         String b = "";
         String message = "";
         Sollbuchung sollb = null;
@@ -853,19 +854,29 @@ public class BuchungsControl extends VorZurueckControl implements Savable
               + Einstellungen.DECIMALFORMAT.format(sollb.getBetrag());
         }
         getSollbuchungInput().setText(b);
+        DBTransaction.commit();
         GUI.getStatusBar().setSuccessText(message);
       }
       catch (ApplicationException ae)
       {
+        DBTransaction.rollback();
         String error = ae.getMessage();
         Logger.error(error, ae);
         GUI.getStatusBar().setErrorText(error);
       }
       catch (RemoteException er)
       {
+        DBTransaction.rollback();
         String error = "Fehler bei Zuordnung der Sollbuchung";
         Logger.error(error, er);
         GUI.getStatusBar().setErrorText(error);
+      }
+      catch (Exception e)
+      {
+        DBTransaction.rollback();
+        Logger.error("Fehler bei der Zuordnung der Sollbuchung", e);
+        GUI.getStatusBar()
+            .setErrorText("Fehler bei der Zuordnung der Sollbuchung");
       }
     }
   }

--- a/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/SollbuchungAuswahlDialog.java
@@ -83,12 +83,12 @@ public class SollbuchungAuswahlDialog extends AbstractDialog<Object>
     this.setTitle("Sollbuchung Auswahl");
     this.buchung = buchung;
     this.multi = multi;
-    control = new SollbuchungControl(null);
   }
 
   @Override
   protected void paint(Composite parent) throws Exception
   {
+    control = new SollbuchungControl(null);
     final TabFolder folder = new TabFolder(parent, SWT.NONE);
     folder.setLayoutData(new GridData(GridData.FILL_BOTH));
     folder.addSelectionListener(new SelectionAdapter()


### PR DESCRIPTION
Bei der Zuordnung von Buchungen zu Sollbuchungen war nur ein Teil in einer DB Transaktion. Wenn z.B. beim Zuordnen zu einem Mitglied Fehler passieren bleibt eine erzeugte Sollbuchung übrig.

Außerdem wurde der Staustext "Sollbuchung von Buchung gelöst" von der Meldung "Sollbuchung zugeordnet" überschrieben, wodurch er nie sichtbar wurde.

Ich habe jetzt alles in eine Transaktion gepackt. Da der Code etwas verschachtelt war habe ich die Teile in Methoden verschoben. Der dortige Code ist unverändet bis auf Variablen Umbenennungen. So ist es besser lesbar und wartbar.

Dann habe ich auch noch die DB Transaktion eingebaut wenn die Zuordnung aus dem BuchungDetailView gemacht wird.

Dabei habe ich auch gesehen, dass es eine Exception gibt wenn man den Zuordnungsdialog aus der Buchung zum zweiten Mal aufruft. Das kommt aus meiner letzten Änderung, dass das Attribut Differenz in FilterControl wenn es existiert nicht neu erzeugt wird.
Das Problem hier war, dass der SollbuchungAuswahlDialog beim Öffnen der Buchung erzeugt wird. Mit jedem Klick wird er neu gezeichnet, da sind die vorher erzeugten Widgets aber schon disposed. Im Control ist aber noch der alte Differenz Input der dann beim Zeichnen zu der Widget Disposed Exception führt. Ich erzeuge jetzt den Control im SollbuchungAuswahlDialog in der Paint Methode. Dann wird auch immer ein neuer Differenz Input erzeugt.