### PR TITLE
Spaltenauswahl, CSV und PDF für TreeParts

### DIFF
--- a/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -24,7 +24,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.formatter.AbrechnungsmodusFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;

--- a/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
@@ -4,7 +4,7 @@ import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
-import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.gui.parts.IJVereinPart;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
@@ -68,7 +68,7 @@ public abstract class AbstractJVereinControl extends AbstractControl
    * @return
    * @throws RemoteException
    */
-  protected abstract JVereinTablePart getTablePart() throws RemoteException;
+  protected abstract IJVereinPart getTablePart() throws RemoteException;
 
   /**
    * Liefert den Titel für die Tabellenreports

--- a/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
@@ -3,7 +3,7 @@ package de.jost_net.JVerein.gui.control;
 import java.rmi.RemoteException;
 
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.IJVereinPart;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbstractSaldoControl.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.ISaldoExport;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.Datum;
@@ -201,10 +202,11 @@ public abstract class AbstractSaldoControl extends VorZurueckControl
       }
 
       ArrayList<PseudoDBObject> zeile = getList();
-      getTablePart().removeAll();
+      JVereinTablePart part = (JVereinTablePart) getTablePart();
+      part.removeAll();
       for (PseudoDBObject sz : zeile)
       {
-        getTablePart().addItem(sz);
+        part.addItem(sz);
       }
     }
     catch (RemoteException re)

--- a/src/de/jost_net/JVerein/gui/control/AbweichenderZahlerControl.java
+++ b/src/de/jost_net/JVerein/gui/control/AbweichenderZahlerControl.java
@@ -1,0 +1,206 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+
+import org.eclipse.swt.widgets.TreeItem;
+
+import de.jost_net.JVerein.Messaging.AbweichenderZahlerMessage;
+import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
+import de.jost_net.JVerein.gui.menu.AbweichenderZahlerMenu;
+import de.jost_net.JVerein.gui.parts.JVereinTreePart;
+import de.jost_net.JVerein.keys.VorlageTyp;
+import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.formatter.TreeFormatter;
+import de.willuhn.jameica.gui.util.SWTUtil;
+import de.willuhn.jameica.messaging.Message;
+import de.willuhn.jameica.messaging.MessageConsumer;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+
+public class AbweichenderZahlerControl extends FilterControl
+{
+  private JVereinTreePart abweichenderzahlertree;
+
+  private AbweichenderZahlerMessageConsumer azc = null;
+
+  public AbweichenderZahlerControl(AbstractView view)
+  {
+    super(view);
+    settings = new Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+  }
+
+  public JVereinTreePart getTablePart() throws RemoteException
+  {
+    if (abweichenderzahlertree != null)
+    {
+      return abweichenderzahlertree;
+    }
+    abweichenderzahlertree = new JVereinTreePart(
+        new AbweichenderZahlerNode(getMitgliedStatus()),
+        new MitgliedDetailAction());
+    abweichenderzahlertree.addColumn("Name", "name");
+    abweichenderzahlertree.addColumn("Zahlungsweg", "zahlungsweg");
+    abweichenderzahlertree.addColumn("IBAN", "iban", new IBANFormatter());
+    abweichenderzahlertree.setRememberColWidths(true);
+
+    abweichenderzahlertree.setContextMenu(new AbweichenderZahlerMenu());
+    this.azc = new AbweichenderZahlerMessageConsumer();
+    Application.getMessagingFactory().registerMessageConsumer(this.azc);
+    abweichenderzahlertree.setFormatter(new TreeFormatter()
+    {
+      @Override
+      public void format(TreeItem item)
+      {
+        AbweichenderZahlerNode azn = (AbweichenderZahlerNode) item.getData();
+        try
+        {
+          if (azn.getType() == AbweichenderZahlerNode.ROOT)
+            item.setImage(SWTUtil.getImage("users.png"));
+          if (azn.getType() == AbweichenderZahlerNode.ZAHLER
+              && (azn.getMitglied().getAustritt() == null
+                  || azn.getMitglied().getAustritt().after(new Date())))
+            item.setImage(SWTUtil.getImage("user-friends.png"));
+          if (azn.getType() == AbweichenderZahlerNode.ZAHLER
+              && azn.getMitglied().getAustritt() != null
+              && azn.getMitglied().getAustritt().before(new Date()))
+            item.setImage(SWTUtil.getImage("eraser.png"));
+          if (azn.getType() == AbweichenderZahlerNode.ANGEHOERIGER
+              && (azn.getMitglied().getAustritt() == null
+                  || azn.getMitglied().getAustritt().after(new Date())))
+            item.setImage(SWTUtil.getImage("user.png"));
+          if (azn.getType() == AbweichenderZahlerNode.ANGEHOERIGER
+              && azn.getMitglied().getAustritt() != null
+              && azn.getMitglied().getAustritt().before(new Date()))
+            item.setImage(SWTUtil.getImage("eraser.png"));
+        }
+        catch (Exception e)
+        {
+          Logger.error("Fehler beim TreeFormatter", e);
+        }
+      }
+    });
+    VorZurueckControl.setObjektListe(null, null);
+    return abweichenderzahlertree;
+  }
+
+  @Override
+  protected void TabRefresh()
+  {
+    if (abweichenderzahlertree != null)
+    {
+      try
+      {
+        abweichenderzahlertree.removeAll();
+        abweichenderzahlertree
+            .setRootObject(new AbweichenderZahlerNode(getMitgliedStatus()));
+      }
+      catch (RemoteException e1)
+      {
+        Logger.error("Fehler", e1);
+      }
+    }
+  }
+
+  /**
+   * Wird benachrichtigt um die Anzeige zu aktualisieren.
+   */
+  private class AbweichenderZahlerMessageConsumer implements MessageConsumer
+  {
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
+     */
+    @Override
+    public boolean autoRegister()
+    {
+      return false;
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
+     */
+    @Override
+    public Class<?>[] getExpectedMessageTypes()
+    {
+      return new Class[] { AbweichenderZahlerMessage.class };
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
+     */
+    @Override
+    public void handleMessage(final Message message) throws Exception
+    {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
+
+        @Override
+        public void run()
+        {
+          try
+          {
+            if (abweichenderzahlertree == null)
+            {
+              // Eingabe-Feld existiert nicht. Also abmelden
+              Application.getMessagingFactory().unRegisterMessageConsumer(
+                  AbweichenderZahlerMessageConsumer.this);
+              return;
+            }
+            abweichenderzahlertree
+                .setRootObject(new AbweichenderZahlerNode(getMitgliedStatus()));
+          }
+          catch (Exception e)
+          {
+            // Wenn hier ein Fehler auftrat, deregistrieren wir uns wieder
+            Logger.error("unable to refresh saldo", e);
+            Application.getMessagingFactory().unRegisterMessageConsumer(
+                AbweichenderZahlerMessageConsumer.this);
+          }
+        }
+      });
+    }
+  }
+
+  public void deregisterAlternativerZahlerConsumer()
+  {
+    Application.getMessagingFactory().unRegisterMessageConsumer(azc);
+  }
+
+  @Override
+  protected String getTableTitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.ABWEICHENDE_ZAHLER_TITEL);
+  }
+
+  @Override
+  protected String getTableSubtitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.ABWEICHENDE_ZAHLER_SUBTITEL);
+  }
+
+  @Override
+  protected String getTableDateiname()
+  {
+    return VorlageUtil.getName(VorlageTyp.ABWEICHENDE_ZAHLER_DATEINAME);
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzAbrechnungControl.java
+++ b/src/de/jost_net/JVerein/gui/control/ArbeitseinsatzAbrechnungControl.java
@@ -26,7 +26,7 @@ import org.kapott.hbci.sepa.SepaVersion;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.DBTools.DBTransaction;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.input.ArbeitseinsatzUeberpruefungInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.parts.ZusatzbetragPart;

--- a/src/de/jost_net/JVerein/gui/control/FamilienbeitragControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FamilienbeitragControl.java
@@ -1,0 +1,202 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.rmi.RemoteException;
+import org.eclipse.swt.widgets.TreeItem;
+
+import de.jost_net.JVerein.Messaging.FamilienbeitragMessage;
+import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
+import de.jost_net.JVerein.gui.menu.FamilienbeitragMenu;
+import de.jost_net.JVerein.gui.parts.JVereinTreePart;
+import de.jost_net.JVerein.keys.VorlageTyp;
+import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.formatter.TreeFormatter;
+import de.willuhn.jameica.gui.util.SWTUtil;
+import de.willuhn.jameica.messaging.Message;
+import de.willuhn.jameica.messaging.MessageConsumer;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+
+public class FamilienbeitragControl extends FilterControl
+{
+  private JVereinTreePart familienbeitragtree;
+
+  private FamilienbeitragMessageConsumer fbc = null;
+
+  public FamilienbeitragControl(AbstractView view)
+  {
+    super(view);
+    settings = new Settings(this.getClass());
+    settings.setStoreWhenRead(true);
+  }
+
+  public JVereinTreePart getTablePart() throws RemoteException
+  {
+    if (familienbeitragtree != null)
+    {
+      return familienbeitragtree;
+    }
+    familienbeitragtree = new JVereinTreePart(
+        new FamilienbeitragNode(getMitgliedStatus()),
+        new MitgliedDetailAction());
+    familienbeitragtree.addColumn("Name", "name");
+    familienbeitragtree.addColumn("Zahlungsweg", "zahlungsweg");
+    familienbeitragtree.addColumn("IBAN", "iban", new IBANFormatter());
+    familienbeitragtree.addColumn("Austritt", "austritt", new DateFormatter());
+    familienbeitragtree.setRememberColWidths(true);
+
+    familienbeitragtree.setContextMenu(new FamilienbeitragMenu());
+    this.fbc = new FamilienbeitragMessageConsumer();
+    Application.getMessagingFactory().registerMessageConsumer(this.fbc);
+    familienbeitragtree.setFormatter(new TreeFormatter()
+    {
+      @Override
+      public void format(TreeItem item)
+      {
+        FamilienbeitragNode fbn = (FamilienbeitragNode) item.getData();
+        try
+        {
+          if (fbn.getType() == FamilienbeitragNode.ROOT)
+            item.setImage(SWTUtil.getImage("users.png"));
+          if (fbn.getType() == FamilienbeitragNode.ZAHLER
+              && fbn.getMitglied().getAustritt() == null)
+            item.setImage(SWTUtil.getImage("user-friends.png"));
+          if (fbn.getType() == FamilienbeitragNode.ZAHLER
+              && fbn.getMitglied().getAustritt() != null)
+            item.setImage(SWTUtil.getImage("eraser.png"));
+          if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
+              && fbn.getMitglied().getAustritt() == null)
+            item.setImage(SWTUtil.getImage("user.png"));
+          if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
+              && fbn.getMitglied().getAustritt() != null)
+            item.setImage(SWTUtil.getImage("eraser.png"));
+        }
+        catch (Exception e)
+        {
+          Logger.error("Fehler beim TreeFormatter", e);
+        }
+      }
+    });
+    VorZurueckControl.setObjektListe(null, null);
+    return familienbeitragtree;
+  }
+
+  @Override
+  protected void TabRefresh()
+  {
+    if (familienbeitragtree != null)
+    {
+      try
+      {
+        familienbeitragtree.removeAll();
+        familienbeitragtree
+            .setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
+      }
+      catch (RemoteException e1)
+      {
+        Logger.error("Fehler", e1);
+      }
+    }
+  }
+
+  /**
+   * Wird benachrichtigt um die Anzeige zu aktualisieren.
+   */
+  private class FamilienbeitragMessageConsumer implements MessageConsumer
+  {
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
+     */
+    @Override
+    public boolean autoRegister()
+    {
+      return false;
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
+     */
+    @Override
+    public Class<?>[] getExpectedMessageTypes()
+    {
+      return new Class[] { FamilienbeitragMessage.class };
+    }
+
+    /**
+     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
+     */
+    @Override
+    public void handleMessage(final Message message) throws Exception
+    {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
+
+        @Override
+        public void run()
+        {
+          try
+          {
+            if (familienbeitragtree == null)
+            {
+              // Eingabe-Feld existiert nicht. Also abmelden
+              Application.getMessagingFactory().unRegisterMessageConsumer(
+                  FamilienbeitragMessageConsumer.this);
+              return;
+            }
+            familienbeitragtree
+                .setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
+          }
+          catch (Exception e)
+          {
+            // Wenn hier ein Fehler auftrat, deregistrieren wir uns wieder
+            Logger.error("unable to refresh saldo", e);
+            Application.getMessagingFactory()
+                .unRegisterMessageConsumer(FamilienbeitragMessageConsumer.this);
+          }
+        }
+      });
+    }
+  }
+
+  public void deregisterFamilienbeitragConsumer()
+  {
+    Application.getMessagingFactory().unRegisterMessageConsumer(fbc);
+  }
+
+  @Override
+  protected String getTableTitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.FAMILIENVERBAND_TITEL);
+  }
+
+  @Override
+  protected String getTableSubtitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.FAMILIENVERBAND_SUBTITEL);
+  }
+
+  @Override
+  protected String getTableDateiname()
+  {
+    return VorlageUtil.getName(VorlageTyp.FAMILIENVERBAND_DATEINAME);
+  }
+
+}

--- a/src/de/jost_net/JVerein/gui/control/FormularControl.java
+++ b/src/de/jost_net/JVerein/gui/control/FormularControl.java
@@ -32,7 +32,7 @@ import de.jost_net.JVerein.gui.action.FormularfeldNeuAction;
 import de.jost_net.JVerein.gui.action.FormularfelderExportAction;
 import de.jost_net.JVerein.gui.action.FormularfelderImportAction;
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.formatter.FormularLinkFormatter;
 import de.jost_net.JVerein.gui.formatter.FormularartFormatter;
 import de.jost_net.JVerein.gui.input.FormularInput;

--- a/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
+++ b/src/de/jost_net/JVerein/gui/control/JahresabschlussControl.java
@@ -28,7 +28,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.menu.JahresabschlussMenu;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.gui.util.AfaUtil;

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -34,8 +34,6 @@ import org.eclipse.swt.widgets.TreeItem;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.Messaging.AbweichenderZahlerMessage;
-import de.jost_net.JVerein.Messaging.FamilienbeitragMessage;
 import de.jost_net.JVerein.Queries.MitgliedQuery;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.action.LesefelddefinitionenAction;
@@ -66,9 +64,7 @@ import de.jost_net.JVerein.gui.input.SpinnerNoScrollInput;
 import de.jost_net.JVerein.gui.input.StaatSearchInput;
 import de.jost_net.JVerein.gui.input.VollzahlerInput;
 import de.jost_net.JVerein.gui.input.VollzahlerSearchInput;
-import de.jost_net.JVerein.gui.menu.AbweichenderZahlerMenu;
 import de.jost_net.JVerein.gui.menu.ArbeitseinsatzMenu;
-import de.jost_net.JVerein.gui.menu.FamilienbeitragMenu;
 import de.jost_net.JVerein.gui.menu.LehrgangMenu;
 import de.jost_net.JVerein.gui.menu.MailMenu;
 import de.jost_net.JVerein.gui.menu.MitgliedMenu;
@@ -159,9 +155,6 @@ import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.PanelButton;
 import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.util.LabelGroup;
-import de.willuhn.jameica.gui.util.SWTUtil;
-import de.willuhn.jameica.messaging.Message;
-import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.BackgroundTask;
 import de.willuhn.jameica.system.OperationCanceledException;
@@ -252,10 +245,6 @@ public class MitgliedControl extends FilterControl implements Savable
 
   private MitgliedNextBGruppePart zukueftigeBeitraegeView;
 
-  private TreePart familienbeitragtree;
-
-  private TreePart abweichenderzahlertree;
-
   private AbstractInput zahler;
 
   private AbstractInput abweichenderZahlerInput;
@@ -286,10 +275,6 @@ public class MitgliedControl extends FilterControl implements Savable
   private SelectInput jubeljahr;
 
   private Mitglied mitglied;
-
-  private FamilienbeitragMessageConsumer fbc = null;
-
-  private AbweichenderZahlerMessageConsumer azc = null;
 
   // Liste aller Zusatzbeträge
   private BetragSummaryTablePart zusatzbetraegeList;
@@ -2764,111 +2749,6 @@ public class MitgliedControl extends FilterControl implements Savable
     }
   }
 
-  public TreePart getFamilienbeitraegeTree() throws RemoteException
-  {
-    familienbeitragtree = new TreePart(
-        new FamilienbeitragNode(getMitgliedStatus()),
-        new MitgliedDetailAction());
-    familienbeitragtree.addColumn("Name", "name");
-    familienbeitragtree.addColumn("Zahlungsweg", "zahlungsweg");
-    familienbeitragtree.addColumn("IBAN", "iban", new IBANFormatter());
-    familienbeitragtree.addColumn("Austritt", "austritt", new DateFormatter());
-    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
-    {
-      familienbeitragtree.addColumn(new Column("leer", ""));
-    }
-    familienbeitragtree.setRememberColWidths(true);
-
-    familienbeitragtree.setContextMenu(new FamilienbeitragMenu());
-    this.fbc = new FamilienbeitragMessageConsumer();
-    Application.getMessagingFactory().registerMessageConsumer(this.fbc);
-    familienbeitragtree.setFormatter(new TreeFormatter()
-    {
-      @Override
-      public void format(TreeItem item)
-      {
-        FamilienbeitragNode fbn = (FamilienbeitragNode) item.getData();
-        try
-        {
-          if (fbn.getType() == FamilienbeitragNode.ROOT)
-            item.setImage(SWTUtil.getImage("users.png"));
-          if (fbn.getType() == FamilienbeitragNode.ZAHLER
-              && fbn.getMitglied().getAustritt() == null)
-            item.setImage(SWTUtil.getImage("user-friends.png"));
-          if (fbn.getType() == FamilienbeitragNode.ZAHLER
-              && fbn.getMitglied().getAustritt() != null)
-            item.setImage(SWTUtil.getImage("eraser.png"));
-          if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
-              && fbn.getMitglied().getAustritt() == null)
-            item.setImage(SWTUtil.getImage("user.png"));
-          if (fbn.getType() == FamilienbeitragNode.ANGEHOERIGER
-              && fbn.getMitglied().getAustritt() != null)
-            item.setImage(SWTUtil.getImage("eraser.png"));
-        }
-        catch (Exception e)
-        {
-          Logger.error("Fehler beim TreeFormatter", e);
-        }
-      }
-    });
-    VorZurueckControl.setObjektListe(null, null);
-    return familienbeitragtree;
-  }
-
-  public TreePart getAbweichenderZahlerTree() throws RemoteException
-  {
-    abweichenderzahlertree = new TreePart(
-        new AbweichenderZahlerNode(getMitgliedStatus()),
-        new MitgliedDetailAction());
-    abweichenderzahlertree.addColumn("Name", "name");
-    abweichenderzahlertree.addColumn("Zahlungsweg", "zahlungsweg");
-    abweichenderzahlertree.addColumn("IBAN", "iban", new IBANFormatter());
-    if ((Boolean) Einstellungen.getEinstellung(Property.LEERESPALTE))
-    {
-      abweichenderzahlertree.addColumn(new Column("leer", ""));
-    }
-    abweichenderzahlertree.setRememberColWidths(true);
-
-    abweichenderzahlertree.setContextMenu(new AbweichenderZahlerMenu());
-    this.azc = new AbweichenderZahlerMessageConsumer();
-    Application.getMessagingFactory().registerMessageConsumer(this.azc);
-    abweichenderzahlertree.setFormatter(new TreeFormatter()
-    {
-      @Override
-      public void format(TreeItem item)
-      {
-        AbweichenderZahlerNode azn = (AbweichenderZahlerNode) item.getData();
-        try
-        {
-          if (azn.getType() == AbweichenderZahlerNode.ROOT)
-            item.setImage(SWTUtil.getImage("users.png"));
-          if (azn.getType() == AbweichenderZahlerNode.ZAHLER
-              && (azn.getMitglied().getAustritt() == null
-                  || azn.getMitglied().getAustritt().after(new Date())))
-            item.setImage(SWTUtil.getImage("user-friends.png"));
-          if (azn.getType() == AbweichenderZahlerNode.ZAHLER
-              && azn.getMitglied().getAustritt() != null
-              && azn.getMitglied().getAustritt().before(new Date()))
-            item.setImage(SWTUtil.getImage("eraser.png"));
-          if (azn.getType() == AbweichenderZahlerNode.ANGEHOERIGER
-              && (azn.getMitglied().getAustritt() == null
-                  || azn.getMitglied().getAustritt().after(new Date())))
-            item.setImage(SWTUtil.getImage("user.png"));
-          if (azn.getType() == AbweichenderZahlerNode.ANGEHOERIGER
-              && azn.getMitglied().getAustritt() != null
-              && azn.getMitglied().getAustritt().before(new Date()))
-            item.setImage(SWTUtil.getImage("eraser.png"));
-        }
-        catch (Exception e)
-        {
-          Logger.error("Fehler beim TreeFormatter", e);
-        }
-      }
-    });
-    VorZurueckControl.setObjektListe(null, null);
-    return abweichenderzahlertree;
-  }
-
   private void starteAuswertung() throws RemoteException
   {
     final IAuswertung ausw = (IAuswertung) getAusgabe().getValue();
@@ -3116,126 +2996,6 @@ public class MitgliedControl extends FilterControl implements Savable
 
   }
 
-  /**
-   * Wird benachrichtigt um die Anzeige zu aktualisieren.
-   */
-  private class FamilienbeitragMessageConsumer implements MessageConsumer
-  {
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
-     */
-    @Override
-    public boolean autoRegister()
-    {
-      return false;
-    }
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
-     */
-    @Override
-    public Class<?>[] getExpectedMessageTypes()
-    {
-      return new Class[] { FamilienbeitragMessage.class };
-    }
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
-     */
-    @Override
-    public void handleMessage(final Message message) throws Exception
-    {
-      GUI.getDisplay().syncExec(new Runnable()
-      {
-
-        @Override
-        public void run()
-        {
-          try
-          {
-            if (familienbeitragtree == null)
-            {
-              // Eingabe-Feld existiert nicht. Also abmelden
-              Application.getMessagingFactory().unRegisterMessageConsumer(
-                  FamilienbeitragMessageConsumer.this);
-              return;
-            }
-            familienbeitragtree
-                .setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
-          }
-          catch (Exception e)
-          {
-            // Wenn hier ein Fehler auftrat, deregistrieren wir uns wieder
-            Logger.error("unable to refresh saldo", e);
-            Application.getMessagingFactory()
-                .unRegisterMessageConsumer(FamilienbeitragMessageConsumer.this);
-          }
-        }
-      });
-    }
-  }
-
-  /**
-   * Wird benachrichtigt um die Anzeige zu aktualisieren.
-   */
-  private class AbweichenderZahlerMessageConsumer implements MessageConsumer
-  {
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#autoRegister()
-     */
-    @Override
-    public boolean autoRegister()
-    {
-      return false;
-    }
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#getExpectedMessageTypes()
-     */
-    @Override
-    public Class<?>[] getExpectedMessageTypes()
-    {
-      return new Class[] { AbweichenderZahlerMessage.class };
-    }
-
-    /**
-     * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
-     */
-    @Override
-    public void handleMessage(final Message message) throws Exception
-    {
-      GUI.getDisplay().syncExec(new Runnable()
-      {
-
-        @Override
-        public void run()
-        {
-          try
-          {
-            if (abweichenderzahlertree == null)
-            {
-              // Eingabe-Feld existiert nicht. Also abmelden
-              Application.getMessagingFactory().unRegisterMessageConsumer(
-                  AbweichenderZahlerMessageConsumer.this);
-              return;
-            }
-            abweichenderzahlertree
-                .setRootObject(new AbweichenderZahlerNode(getMitgliedStatus()));
-          }
-          catch (Exception e)
-          {
-            // Wenn hier ein Fehler auftrat, deregistrieren wir uns wieder
-            Logger.error("unable to refresh saldo", e);
-            Application.getMessagingFactory().unRegisterMessageConsumer(
-                AbweichenderZahlerMessageConsumer.this);
-          }
-        }
-      });
-    }
-  }
-
   public JVereinTablePart getMitgliedBeitraegeTabelle() throws RemoteException
   {
     if (beitragsTabelle != null)
@@ -3294,34 +3054,6 @@ public class MitgliedControl extends FilterControl implements Savable
         {
           refreshMitgliedTable(0);
         }
-      }
-      catch (RemoteException e1)
-      {
-        Logger.error("Fehler", e1);
-      }
-    }
-
-    if (familienbeitragtree != null)
-    {
-      try
-      {
-        familienbeitragtree.removeAll();
-        familienbeitragtree
-            .setRootObject(new FamilienbeitragNode(getMitgliedStatus()));
-      }
-      catch (RemoteException e1)
-      {
-        Logger.error("Fehler", e1);
-      }
-    }
-
-    if (abweichenderzahlertree != null)
-    {
-      try
-      {
-        abweichenderzahlertree.removeAll();
-        abweichenderzahlertree
-            .setRootObject(new AbweichenderZahlerNode(getMitgliedStatus()));
       }
       catch (RemoteException e1)
       {
@@ -3412,16 +3144,6 @@ public class MitgliedControl extends FilterControl implements Savable
         settings.setAttribute("auswertung.vorlagedateicsv", "");
       }
     }
-  }
-
-  public void deregisterFamilienbeitragConsumer()
-  {
-    Application.getMessagingFactory().unRegisterMessageConsumer(fbc);
-  }
-
-  public void deregisterAlternativerZahlerConsumer()
-  {
-    Application.getMessagingFactory().unRegisterMessageConsumer(azc);
   }
 
   public LesefeldControl getLesefeldControl()

--- a/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -44,7 +44,7 @@ import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
 import de.jost_net.JVerein.gui.dialogs.AbweichenderZahlerNeuDialog;
 import de.jost_net.JVerein.gui.dialogs.PersonenartDialog;
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;

--- a/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -109,18 +109,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
     if (art.equals(ExportArt.PDF))
     {
-      spaltenList.addColumn("Breite", "data", null, true);
-      TabFolder folder = new TabFolder(parent, SWT.BORDER);
-      folder.setLayoutData(new GridData(GridData.FILL_BOTH));
-
-      TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
-      tabSpalten.addPart(spaltenList);
-      ButtonArea buttons = new ButtonArea();
-      buttons.addButton(new Button("Breiten zurücksetzen", action, null, false,
-          "eraser.png"));
-      tabSpalten.addButtonArea(buttons);
-
-      addRaenderFormularTabs(folder);
+      zeichnePDF(parent, action);
     }
     else
     {
@@ -139,10 +128,22 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     b.paint(parent);
   }
 
-  protected void addRaenderFormularTabs(TabFolder folder) throws RemoteException
+  protected void zeichnePDF(Composite parent, Action action)
+      throws RemoteException
   {
+    spaltenList.addColumn("Breite", "data", null, true);
+
+    TabFolder folder = new TabFolder(parent, SWT.BORDER);
+    folder.setLayoutData(new GridData(GridData.FILL_BOTH));
+    TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
     TabGroup tabRaender = new TabGroup(folder, "Ränder", true, 2);
     TabGroup tabFormular = new TabGroup(folder, "Formular", true, 2);
+
+    tabSpalten.addPart(spaltenList);
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton(
+        new Button("Breiten zurücksetzen", action, null, false, "eraser.png"));
+    tabSpalten.addButtonArea(buttons);
 
     links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
     rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));

--- a/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -17,7 +17,11 @@ import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.TabFolder;
+
 import com.itextpdf.text.DocumentException;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
@@ -26,11 +30,14 @@ import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Formular;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.parts.Button;
+import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
@@ -94,9 +101,49 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     setSize(400, SWT.DEFAULT);
   }
 
-  protected void addRaenderFormularTabs(TabGroup tabRaender,
-      TabGroup tabFormular) throws RemoteException
+  protected void createGui(Composite parent, Action action)
+      throws RemoteException
   {
+    spaltenList.addColumn("Name", "text");
+    spaltenList.setCheckable(true);
+
+    if (art.equals(ExportArt.PDF))
+    {
+      spaltenList.addColumn("Breite", "data", null, true);
+      TabFolder folder = new TabFolder(parent, SWT.BORDER);
+      folder.setLayoutData(new GridData(GridData.FILL_BOTH));
+
+      TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
+      tabSpalten.addPart(spaltenList);
+      ButtonArea buttons = new ButtonArea();
+      buttons.addButton(new Button("Breiten zurücksetzen", action, null, false,
+          "eraser.png"));
+      tabSpalten.addButtonArea(buttons);
+
+      addRaenderFormularTabs(folder);
+    }
+    else
+    {
+      spaltenList.paint(parent);
+    }
+
+    setChecked();
+
+    ButtonArea b = new ButtonArea();
+    b.addButton("Speichern", c -> export(), null, true, "ok.png");
+
+    b.addButton("Abbrechen", c -> {
+      throw new OperationCanceledException();
+    }, null, false, "process-stop.png");
+
+    b.paint(parent);
+  }
+
+  protected void addRaenderFormularTabs(TabFolder folder) throws RemoteException
+  {
+    TabGroup tabRaender = new TabGroup(folder, "Ränder", true, 2);
+    TabGroup tabFormular = new TabGroup(folder, "Formular", true, 2);
+
     links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
     rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));
     oben = new IntegerInput(settings.getInt(settingPrefix + "oben", 20));
@@ -236,6 +283,8 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
   {
     return success;
   }
+
+  abstract void setChecked();
 
   abstract void exportCSV(File file) throws IOException;
 

--- a/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -1,0 +1,244 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.io.File;
+import java.io.IOException;
+import java.rmi.RemoteException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.FileDialog;
+import com.itextpdf.text.DocumentException;
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.input.FormularInput;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.io.FileViewer;
+import de.jost_net.JVerein.keys.FormularArt;
+import de.jost_net.JVerein.rmi.Formular;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.IntegerInput;
+import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.util.TabGroup;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
+{
+  public enum ExportArt
+  {
+    PDF,
+    CSV
+  }
+
+  private boolean success = false;
+
+  protected Settings settings;
+
+  protected String title;
+
+  protected String subtitle;
+
+  protected String filename;
+
+  protected ExportArt art;
+
+  protected String settingPrefix;
+
+  protected IntegerInput links;
+
+  protected IntegerInput rechts;
+
+  protected IntegerInput oben;
+
+  protected IntegerInput unten;
+
+  protected CheckboxInput querformat;
+
+  protected SelectInput vordergrund;
+
+  protected SelectInput hintergrund;
+
+  protected JVereinTablePart spaltenList;
+
+  protected CheckboxInput headerTransparent;
+
+  protected CheckboxInput zellenTransparent;
+
+  public AbstractPartExportDialog(String settingPrefix, ExportArt art,
+      String title, String subtitle, String filename)
+      throws ApplicationException
+  {
+    super(AbstractPartExportDialog.POSITION_CENTER);
+    this.title = title;
+    this.subtitle = subtitle;
+    this.filename = filename;
+    this.art = art;
+    this.settingPrefix = settingPrefix + art.toString() + ".";
+
+    setTitle("Tabelle exportieren");
+    setSize(400, SWT.DEFAULT);
+  }
+
+  protected void addRaenderFormularTabs(TabGroup tabRaender,
+      TabGroup tabFormular) throws RemoteException
+  {
+    links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
+    rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));
+    oben = new IntegerInput(settings.getInt(settingPrefix + "oben", 20));
+    unten = new IntegerInput(settings.getInt(settingPrefix + "unten", 20));
+    tabRaender.addLabelPair("Links", links);
+    tabRaender.addLabelPair("Rechts", rechts);
+    tabRaender.addLabelPair("Oben", oben);
+    tabRaender.addLabelPair("Unten", unten);
+
+    // IntegerInput links2 = new IntegerInput(settings.getInt(id + "links2",
+    // 20));
+    // IntegerInput rechts2 = new IntegerInput(
+    // settings.getInt(id + "rechts2", 20));
+    // IntegerInput oben2 = new IntegerInput(settings.getInt(id + "oben2",
+    // 20));
+    // IntegerInput unten2 = new IntegerInput(settings.getInt(id + "unten2",
+    // 20));
+    // tabRaender.addLabelPair("Links ab 2. Seite", links2);
+    // tabRaender.addLabelPair("Rechts ab 2. Seite", rechts2);
+    // tabRaender.addLabelPair("Oben ab 2. Seite", oben2);
+    // tabRaender.addLabelPair("Unten ab 2. Seite", unten2);
+
+    hintergrund = new FormularInput(FormularArt.HINTERGRUND,
+        settings.getString(settingPrefix + "hintergrund", ""));
+    hintergrund.setPleaseChoose("Kein Formular");
+    vordergrund = new FormularInput(FormularArt.HINTERGRUND,
+        settings.getString(settingPrefix + "vordergrund", ""));
+    vordergrund.setPleaseChoose("Kein Formular");
+    headerTransparent = new CheckboxInput(settings
+        .getBoolean(settingPrefix + "headerTransparent", (Boolean) Einstellungen
+            .getEinstellung(Property.TABELLEN_HEADER_TRANSPARENT)));
+    zellenTransparent = new CheckboxInput(settings
+        .getBoolean(settingPrefix + "zellenTransparent", (Boolean) Einstellungen
+            .getEinstellung(Property.TABELLEN_ZELLEN_TRANSPARENT)));
+    querformat = new CheckboxInput(
+        settings.getBoolean(settingPrefix + "quer", false));
+    tabFormular.addLabelPair("Formular Hintergrund", hintergrund);
+    tabFormular.addLabelPair("Formular Vordergrund", vordergrund);
+    tabFormular.addLabelPair("Tabellen Header transparent", headerTransparent);
+    tabFormular.addLabelPair("Tabellen Zellen transparent", zellenTransparent);
+    tabFormular.addLabelPair("Querformat", querformat);
+  }
+
+  protected void export() throws ApplicationException
+  {
+    try
+    {
+      String extension = "";
+      switch (art)
+      {
+        case CSV:
+          extension = ".csv";
+          break;
+        case PDF:
+          extension = ".pdf";
+          break;
+      }
+
+      FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
+      fd.setText("Ausgabedatei wählen.");
+
+      String path = settings.getString(settingPrefix + "lastdir",
+          System.getProperty("user.home"));
+      if (path != null && path.length() > 0)
+      {
+        fd.setFilterPath(path);
+      }
+
+      fd.setFileName(filename);
+      fd.setFilterExtensions(new String[] { "*" + extension });
+
+      final String p = fd.open();
+
+      if (p == null || p.length() == 0)
+      {
+        throw new OperationCanceledException("Abgebrochen");
+      }
+
+      File file = new File(p);
+      settings.setAttribute(settingPrefix + "lastdir", file.getParent());
+
+      switch (art)
+      {
+        case CSV:
+          exportCSV(file);
+          break;
+        case PDF:
+          exportPDF(file);
+          break;
+      }
+      saveSettings();
+
+      FileViewer.show(file);
+
+      success = true;
+      close();
+    }
+    catch (IOException | DocumentException e)
+    {
+      String fehler = "Fehler beim Export";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
+    }
+  }
+
+  protected void saveSettings() throws RemoteException
+  {
+    if (art.equals(ExportArt.PDF))
+    {
+      settings.setAttribute(settingPrefix + "links",
+          (Integer) links.getValue());
+      settings.setAttribute(settingPrefix + "rechts",
+          (Integer) rechts.getValue());
+      settings.setAttribute(settingPrefix + "oben", (Integer) oben.getValue());
+      settings.setAttribute(settingPrefix + "unten",
+          (Integer) unten.getValue());
+
+      settings.setAttribute(settingPrefix + "hintergrund",
+          hintergrund.getValue() == null ? null
+              : ((Formular) hintergrund.getValue()).getID());
+      settings.setAttribute(settingPrefix + "vordergrund",
+          vordergrund.getValue() == null ? null
+              : ((Formular) vordergrund.getValue()).getID());
+
+      settings.setAttribute(settingPrefix + "headerTransparent",
+          (Boolean) headerTransparent.getValue());
+      settings.setAttribute(settingPrefix + "zellenTransparent",
+          (Boolean) zellenTransparent.getValue());
+
+      settings.setAttribute(settingPrefix + "quer",
+          (Boolean) querformat.getValue());
+    }
+  }
+
+  @Override
+  protected Boolean getData() throws Exception
+  {
+    return success;
+  }
+
+  abstract void exportCSV(File file) throws IOException;
+
+  abstract void exportPDF(File file) throws IOException, DocumentException;
+
+}

--- a/src/de/jost_net/JVerein/gui/dialogs/ArbeitseinsatzAuswertungDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/ArbeitseinsatzAuswertungDialog.java
@@ -18,7 +18,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import de.jost_net.JVerein.gui.control.ArbeitseinsatzAbrechnungControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.view.DokumentationUtil;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.parts.ButtonArea;

--- a/src/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
@@ -27,6 +27,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.TabFolder;
 
+import de.jost_net.JVerein.gui.parts.IJVereinPart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
 import de.willuhn.jameica.gui.GUI;
@@ -44,15 +45,15 @@ public class TabelleSpaltenAuswahlDialog extends AbstractDialog<Object>
    * Map mit dem TablePart aus der View als Key, und dem TablePart im Dialog als
    * Value.
    */
-  private Map<JVereinTablePart, JVereinTablePart> tableMap = new LinkedHashMap<>();
+  private Map<IJVereinPart, JVereinTablePart> tableMap = new LinkedHashMap<>();
 
-  public TabelleSpaltenAuswahlDialog(JVereinTablePart... tableParts)
+  public TabelleSpaltenAuswahlDialog(IJVereinPart... tableParts)
       throws RemoteException, ApplicationException
   {
     super(TabelleSpaltenAuswahlDialog.POSITION_CENTER);
 
     boolean leer = true;
-    for (JVereinTablePart table : tableParts)
+    for (IJVereinPart table : tableParts)
     {
       if (table == null)
       {
@@ -77,7 +78,7 @@ public class TabelleSpaltenAuswahlDialog extends AbstractDialog<Object>
   protected void paint(Composite parent) throws Exception
   {
     TabFolder folder = null;
-    for (JVereinTablePart table : tableMap.keySet())
+    for (IJVereinPart table : tableMap.keySet())
     {
       if (table.getItems().size() == 0)
       {
@@ -133,8 +134,7 @@ public class TabelleSpaltenAuswahlDialog extends AbstractDialog<Object>
     buttons.addButton("Speichern", c -> {
       try
       {
-        for (Entry<JVereinTablePart, JVereinTablePart> entry : tableMap
-            .entrySet())
+        for (Entry<IJVereinPart, JVereinTablePart> entry : tableMap.entrySet())
         {
           if (entry.getValue() == null)
           {

--- a/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -47,11 +45,8 @@ import com.itextpdf.text.Font;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.Reporter;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.parts.Button;
-import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.Column;
-import de.willuhn.jameica.gui.util.TabGroup;
-import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -79,7 +74,6 @@ public class TablePartExportDialog extends AbstractPartExportDialog
     settings = new Settings(this.getClass());
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   protected void paint(Composite parent)
       throws ApplicationException, RemoteException
@@ -109,10 +103,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         return;
       }
     };
-    spaltenList.addColumn("Name", "text");
     if (art.equals(ExportArt.PDF))
     {
-      spaltenList.addColumn("Breite", "data", null, true);
       spaltenList.addChangeListener((object, attribute, newValue) -> {
         try
         {
@@ -124,20 +116,13 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         }
       });
     }
-    spaltenList.setCheckable(true);
-
-    if (art.equals(ExportArt.PDF))
+    createGui(parent, new Action()
     {
-      TabFolder folder = new TabFolder(parent, SWT.BORDER);
-      folder.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-      TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
-      TabGroup tabRaender = new TabGroup(folder, "Ränder", true, 2);
-      TabGroup tabFormular = new TabGroup(folder, "Formular", true, 2);
-
-      tabSpalten.addPart(spaltenList);
-      ButtonArea buttons = new ButtonArea();
-      buttons.addButton(new Button("Breiten zurücksetzen", (e) -> {
+      @SuppressWarnings("unchecked")
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
         try
         {
           for (TableColumn col : (List<TableColumn>) spaltenList.getItems())
@@ -158,31 +143,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
           throw new ApplicationException(
               "Fehler beim zurücksetzen der Breiten");
         }
-
-      }, null, false, "eraser.png"));
-      tabSpalten.addButtonArea(buttons);
-
-      addRaenderFormularTabs(tabRaender, tabFormular);
-    }
-    else
-    {
-      spaltenList.paint(parent);
-    }
-
-    for (TableColumn col : table.getColumns())
-    {
-      spaltenList.setChecked(col, settings
-          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-    }
-
-    ButtonArea b = new ButtonArea();
-    b.addButton("Speichern", c -> export(), null, true, "ok.png");
-
-    b.addButton("Abbrechen", c -> {
-      throw new OperationCanceledException();
-    }, null, false, "process-stop.png");
-
-    b.paint(parent);
+      }
+    });
   }
 
   @Override
@@ -291,6 +253,7 @@ public class TablePartExportDialog extends AbstractPartExportDialog
   }
 
   @SuppressWarnings("unchecked")
+  @Override
   protected void saveSettings() throws RemoteException
   {
     List<TableColumn> itemsChecked = spaltenList.getItems();
@@ -305,6 +268,16 @@ public class TablePartExportDialog extends AbstractPartExportDialog
       }
     }
     super.saveSettings();
+  }
+
+  @Override
+  void setChecked()
+  {
+    for (TableColumn col : table.getColumns())
+    {
+      spaltenList.setChecked(col, settings
+          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
+    }
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -119,6 +119,7 @@ public class TablePartExportDialog extends AbstractPartExportDialog
     createGui(parent, new Action()
     {
 
+      // Action zum Reset der Spaltenbreiten
       @SuppressWarnings("unchecked")
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -1,5 +1,4 @@
 /**********************************************************************
- * Copyright (c) by Heiner Jostkleigrewe
  * This program is free software: you can redistribute it and/or modify it under the terms of the 
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
  * License, or (at your option) any later version.
@@ -11,8 +10,6 @@
  * You should have received a copy of the GNU General Public License along with this program.  If not, 
  * see <http://www.gnu.org/licenses/>.
  * 
- * heiner@jverein.de
- * www.jverein.de
  **********************************************************************/
 package de.jost_net.JVerein.gui.dialogs;
 
@@ -32,7 +29,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
@@ -48,19 +44,9 @@ import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
 import com.itextpdf.text.Font;
 
-import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
-import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
-import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.dialogs.AbstractDialog;
-import de.willuhn.jameica.gui.input.CheckboxInput;
-import de.willuhn.jameica.gui.input.IntegerInput;
-import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.Column;
@@ -70,55 +56,15 @@ import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class TablePartExportDialog extends AbstractDialog<Boolean>
+public class TablePartExportDialog extends AbstractPartExportDialog
 {
-  public enum ExportArt
-  {
-    PDF,
-    CSV
-  }
-
-  private boolean success = false;
-
-  private Settings settings;
-
   private Table table;
-
-  private String title;
-
-  private String subtitle;
-
-  private String filename;
-
-  private ExportArt art;
-
-  private String settingPrefix;
-
-  IntegerInput links;
-
-  IntegerInput rechts;
-
-  IntegerInput oben;
-
-  IntegerInput unten;
-
-  private CheckboxInput querformat;
-
-  private SelectInput vordergrund;
-
-  private SelectInput hintergrund;
-
-  private JVereinTablePart spaltenList;
-
-  private CheckboxInput headerTransparent;
-
-  private CheckboxInput zellenTransparent;
 
   public TablePartExportDialog(Table table, String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
       throws ApplicationException
   {
-    super(TablePartExportDialog.POSITION_CENTER);
+    super(settingPrefix, art, title, subtitle, filename);
 
     if (table == null || table.isDisposed() || !(table instanceof Table))
     {
@@ -130,15 +76,6 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
     }
 
     this.table = table;
-    this.title = title;
-    this.subtitle = subtitle;
-    this.filename = filename;
-    this.art = art;
-    this.settingPrefix = settingPrefix + art.toString() + ".";
-
-    setTitle("Tabelle exportieren");
-    setSize(400, SWT.DEFAULT);
-
     settings = new Settings(this.getClass());
   }
 
@@ -225,49 +162,7 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       }, null, false, "eraser.png"));
       tabSpalten.addButtonArea(buttons);
 
-      links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
-      rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));
-      oben = new IntegerInput(settings.getInt(settingPrefix + "oben", 20));
-      unten = new IntegerInput(settings.getInt(settingPrefix + "unten", 20));
-      tabRaender.addLabelPair("Links", links);
-      tabRaender.addLabelPair("Rechts", rechts);
-      tabRaender.addLabelPair("Oben", oben);
-      tabRaender.addLabelPair("Unten", unten);
-
-      // IntegerInput links2 = new IntegerInput(settings.getInt(id + "links2",
-      // 20));
-      // IntegerInput rechts2 = new IntegerInput(
-      // settings.getInt(id + "rechts2", 20));
-      // IntegerInput oben2 = new IntegerInput(settings.getInt(id + "oben2",
-      // 20));
-      // IntegerInput unten2 = new IntegerInput(settings.getInt(id + "unten2",
-      // 20));
-      // tabRaender.addLabelPair("Links ab 2. Seite", links2);
-      // tabRaender.addLabelPair("Rechts ab 2. Seite", rechts2);
-      // tabRaender.addLabelPair("Oben ab 2. Seite", oben2);
-      // tabRaender.addLabelPair("Unten ab 2. Seite", unten2);
-
-      hintergrund = new FormularInput(FormularArt.HINTERGRUND,
-          settings.getString(settingPrefix + "hintergrund", ""));
-      hintergrund.setPleaseChoose("Kein Formular");
-      vordergrund = new FormularInput(FormularArt.HINTERGRUND,
-          settings.getString(settingPrefix + "vordergrund", ""));
-      vordergrund.setPleaseChoose("Kein Formular");
-      headerTransparent = new CheckboxInput(settings.getBoolean(
-          settingPrefix + "headerTransparent", (Boolean) Einstellungen
-              .getEinstellung(Property.TABELLEN_HEADER_TRANSPARENT)));
-      zellenTransparent = new CheckboxInput(settings.getBoolean(
-          settingPrefix + "zellenTransparent", (Boolean) Einstellungen
-              .getEinstellung(Property.TABELLEN_ZELLEN_TRANSPARENT)));
-      querformat = new CheckboxInput(
-          settings.getBoolean(settingPrefix + "quer", false));
-      tabFormular.addLabelPair("Formular Hintergrund", hintergrund);
-      tabFormular.addLabelPair("Formular Vordergrund", vordergrund);
-      tabFormular.addLabelPair("Tabellen Header transparent",
-          headerTransparent);
-      tabFormular.addLabelPair("Tabellen Zellen transparent",
-          zellenTransparent);
-      tabFormular.addLabelPair("Querformat", querformat);
+      addRaenderFormularTabs(tabRaender, tabFormular);
     }
     else
     {
@@ -290,69 +185,8 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
     b.paint(parent);
   }
 
-  private void export() throws ApplicationException
-  {
-    try
-    {
-      String extension = "";
-      switch (art)
-      {
-        case CSV:
-          extension = ".csv";
-          break;
-        case PDF:
-          extension = ".pdf";
-          break;
-      }
-
-      FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
-      fd.setText("Ausgabedatei wählen.");
-
-      String path = settings.getString(settingPrefix + "lastdir",
-          System.getProperty("user.home"));
-      if (path != null && path.length() > 0)
-      {
-        fd.setFilterPath(path);
-      }
-
-      fd.setFileName(filename);
-      fd.setFilterExtensions(new String[] { "*" + extension });
-
-      final String p = fd.open();
-
-      if (p == null || p.length() == 0)
-      {
-        throw new OperationCanceledException("Abgebrochen");
-      }
-
-      File file = new File(p);
-      settings.setAttribute(settingPrefix + "lastdir", file.getParent());
-
-      switch (art)
-      {
-        case CSV:
-          exportCSV(file);
-          break;
-        case PDF:
-          exportPDF(file);
-          break;
-      }
-      saveSettings();
-
-      FileViewer.show(file);
-
-      success = true;
-      close();
-    }
-    catch (IOException | DocumentException e)
-    {
-      String fehler = "Fehler beim Export";
-      Logger.error(fehler, e);
-      throw new ApplicationException(fehler);
-    }
-  }
-
-  private void exportCSV(File file) throws IOException
+  @Override
+  protected void exportCSV(File file) throws IOException
   {
     try (ICsvMapWriter writer = new CsvMapWriter(new FileWriter(file),
         CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE))
@@ -387,7 +221,8 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
     }
   }
 
-  private void exportPDF(File file) throws IOException, DocumentException
+  @Override
+  protected void exportPDF(File file) throws IOException, DocumentException
   {
     try (FileOutputStream fos = new FileOutputStream(file);
         Reporter reporter = new Reporter(fos, title, subtitle,
@@ -456,7 +291,7 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
   }
 
   @SuppressWarnings("unchecked")
-  private void saveSettings() throws RemoteException
+  protected void saveSettings() throws RemoteException
   {
     List<TableColumn> itemsChecked = spaltenList.getItems();
     for (TableColumn col : (List<TableColumn>) spaltenList.getItems(false))
@@ -469,38 +304,7 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
             (Integer) col.getData());
       }
     }
-
-    if (art.equals(ExportArt.PDF))
-    {
-      settings.setAttribute(settingPrefix + "links",
-          (Integer) links.getValue());
-      settings.setAttribute(settingPrefix + "rechts",
-          (Integer) rechts.getValue());
-      settings.setAttribute(settingPrefix + "oben", (Integer) oben.getValue());
-      settings.setAttribute(settingPrefix + "unten",
-          (Integer) unten.getValue());
-
-      settings.setAttribute(settingPrefix + "hintergrund",
-          hintergrund.getValue() == null ? null
-              : ((Formular) hintergrund.getValue()).getID());
-      settings.setAttribute(settingPrefix + "vordergrund",
-          vordergrund.getValue() == null ? null
-              : ((Formular) vordergrund.getValue()).getID());
-
-      settings.setAttribute(settingPrefix + "headerTransparent",
-          (Boolean) headerTransparent.getValue());
-      settings.setAttribute(settingPrefix + "zellenTransparent",
-          (Boolean) zellenTransparent.getValue());
-
-      settings.setAttribute(settingPrefix + "quer",
-          (Boolean) querformat.getValue());
-    }
-  }
-
-  @Override
-  protected Boolean getData() throws Exception
-  {
-    return success;
+    super.saveSettings();
   }
 
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -135,6 +135,7 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     createGui(parent, new Action()
     {
 
+      // Action zum Reset der Spaltenbreiten
       @SuppressWarnings("unchecked")
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -1,5 +1,4 @@
 /**********************************************************************
- * Copyright (c) by Heiner Jostkleigrewe
  * This program is free software: you can redistribute it and/or modify it under the terms of the 
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
  * License, or (at your option) any later version.
@@ -11,8 +10,6 @@
  * You should have received a copy of the GNU General Public License along with this program.  If not, 
  * see <http://www.gnu.org/licenses/>.
  * 
- * heiner@jverein.de
- * www.jverein.de
  **********************************************************************/
 package de.jost_net.JVerein.gui.dialogs;
 
@@ -34,9 +31,9 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.TabFolder;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableColumn;
-import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeColumn;
+import org.eclipse.swt.widgets.TreeItem;
 import org.supercsv.cellprocessor.ConvertNullTo;
 import org.supercsv.cellprocessor.ift.CellProcessor;
 import org.supercsv.io.CsvMapWriter;
@@ -50,6 +47,7 @@ import com.itextpdf.text.Font;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.FileViewer;
@@ -70,19 +68,14 @@ import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class TablePartExportDialog extends AbstractDialog<Boolean>
+public class TreePartExportDialog extends AbstractDialog<Boolean>
 {
-  public enum ExportArt
-  {
-    PDF,
-    CSV
-  }
 
   private boolean success = false;
 
   private Settings settings;
 
-  private Table table;
+  private Tree tree;
 
   private String title;
 
@@ -114,29 +107,44 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
 
   private CheckboxInput zellenTransparent;
 
-  public TablePartExportDialog(Table table, String settingPrefix, ExportArt art,
+  public TreePartExportDialog(Tree tree, String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
       throws ApplicationException
   {
-    super(TablePartExportDialog.POSITION_CENTER);
+    super(TreePartExportDialog.POSITION_CENTER);
 
-    if (table == null || table.isDisposed() || !(table instanceof Table))
+    if (tree == null || tree.isDisposed() || !(tree instanceof Tree))
     {
       throw new ApplicationException("Tabelle nicht geladen");
     }
-    if (table.getItems().length == 0)
+    TreeItem[] rootItems = tree.getItems();
+    if (rootItems.length == 0)
+    {
+      throw new ApplicationException("Tabelle enthält keine Daten");
+    }
+    // wir haben immer den Root Node, darum prüfen wir die Childs
+    boolean leer = true;
+    for (TreeItem item : rootItems)
+    {
+      if (item.getItems().length > 0)
+      {
+        leer = false;
+        break;
+      }
+    }
+    if (leer)
     {
       throw new ApplicationException("Tabelle enthält keine Daten");
     }
 
-    this.table = table;
+    this.tree = tree;
     this.title = title;
     this.subtitle = subtitle;
     this.filename = filename;
     this.art = art;
     this.settingPrefix = settingPrefix + art.toString() + ".";
 
-    setTitle("Tabelle exportieren");
+    setTitle("Tree exportieren");
     setSize(400, SWT.DEFAULT);
 
     settings = new Settings(this.getClass());
@@ -148,11 +156,11 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       throws ApplicationException, RemoteException
   {
     // Spalten so wie angezeigt sortieren
-    List<TableColumn> listeSortiert = new ArrayList<>();
-    int[] order = table.getColumnOrder();
-    for (int i = 0; i < table.getColumnCount(); i++)
+    List<TreeColumn> listeSortiert = new ArrayList<>();
+    int[] order = tree.getColumnOrder();
+    for (int i = 0; i < tree.getColumnCount(); i++)
     {
-      TableColumn col = table.getColumn(order[i]);
+      TreeColumn col = tree.getColumn(order[i]);
       // Leere Dummy-Spalte am Ende überspringen
       if (col.getText().isBlank())
       {
@@ -179,7 +187,7 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       spaltenList.addChangeListener((object, attribute, newValue) -> {
         try
         {
-          ((TableColumn) object).setData(Integer.parseInt(newValue));
+          ((TreeColumn) object).setData(Integer.parseInt(newValue));
         }
         catch (Exception e)
         {
@@ -203,12 +211,12 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       buttons.addButton(new Button("Breiten zurücksetzen", (e) -> {
         try
         {
-          for (TableColumn col : (List<TableColumn>) spaltenList.getItems())
+          for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems())
           {
             col.setData(col.getWidth());
           }
           spaltenList.removeAll();
-          for (TableColumn col : listeSortiert)
+          for (TreeColumn col : listeSortiert)
           {
             spaltenList.addItem(col);
             spaltenList.setChecked(col, settings
@@ -274,7 +282,7 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       spaltenList.paint(parent);
     }
 
-    for (TableColumn col : table.getColumns())
+    for (TreeColumn col : tree.getColumns())
     {
       spaltenList.setChecked(col, settings
           .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
@@ -358,29 +366,70 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
         CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE))
     {
       @SuppressWarnings("unchecked")
-      List<TableColumn> listeAuswahl = spaltenList.getItems();
-      List<TableColumn> listeOrig = Arrays.asList(table.getColumns());
-      TableItem[] rows = table.getItems();
+      List<TreeColumn> listeAuswahl = spaltenList.getItems();
+      List<TreeColumn> listeOrig = Arrays.asList(tree.getColumns());
+      List<MyTreeItem> rows = new ArrayList<>();
 
-      CellProcessor[] cellProcessor = new CellProcessor[listeAuswahl.size()];
-      String[] header = new String[listeAuswahl.size()];
+      for (TreeItem item : tree.getItems())
+      {
+        // Die Root Ebene geben wir nicht aus
+        getItemRekursiv(rows, item, 0);
+      }
+      int ebenen = 0;
+      for (MyTreeItem item : rows)
+      {
+        ebenen = Math.max(ebenen, item.getEbene());
+      }
+      int size = listeAuswahl.size();
+      TreeColumn first = listeAuswahl.get(0);
+      if (listeOrig.indexOf(first) == 0)
+      {
+        size += ebenen;
+      }
+      else
+      {
+        ebenen = 0;
+      }
+
+      CellProcessor[] cellProcessor = new CellProcessor[size];
+      String[] header = new String[size];
 
       int n = 0;
-      for (TableColumn col : listeAuswahl)
+      for (TreeColumn col : listeAuswahl)
       {
-        header[n] = col.getText();
-        cellProcessor[n++] = new ConvertNullTo("");
+        if (listeOrig.indexOf(col) == 0)
+        {
+          for (int i = 0; i <= ebenen; i++)
+          {
+            header[n] = col.getText() + " - " + (i + 1);
+            cellProcessor[n++] = new ConvertNullTo("");
+          }
+        }
+        else
+        {
+          header[n] = col.getText();
+          cellProcessor[n++] = new ConvertNullTo("");
+        }
       }
       writer.writeHeader(header);
 
-      for (TableItem row : rows)
+      for (MyTreeItem row : rows)
       {
         Map<String, Object> csvzeile = new HashMap<>();
         int i = 0;
-        for (TableColumn col : listeAuswahl)
+        for (TreeColumn col : listeAuswahl)
         {
           int index = listeOrig.indexOf(col);
-          csvzeile.put(header[i++], row.getText(index));
+          if (index == 0)
+          {
+            csvzeile.put(header[row.getEbene() + i++],
+                row.getTreeItem().getText(index));
+          }
+          else
+          {
+            csvzeile.put(header[ebenen + i++],
+                row.getTreeItem().getText(index));
+          }
         }
         writer.write(csvzeile, header, cellProcessor);
       }
@@ -399,11 +448,17 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
             (Boolean) zellenTransparent.getValue());)
     {
       @SuppressWarnings("unchecked")
-      List<TableColumn> listeAuswahl = spaltenList.getItems();
-      List<TableColumn> listeOrig = Arrays.asList(table.getColumns());
-      TableItem[] rows = table.getItems();
+      List<TreeColumn> listeAuswahl = spaltenList.getItems();
+      List<TreeColumn> listeOrig = Arrays.asList(tree.getColumns());
+      List<MyTreeItem> rows = new ArrayList<>();
 
-      for (TableColumn col : listeAuswahl)
+      for (TreeItem item : tree.getItems())
+      {
+        // Die Root Ebene geben wir nicht aus
+        getItemRekursiv(rows, item, 0);
+      }
+
+      for (TreeColumn col : listeAuswahl)
       {
         reporter.addHeaderColumn(col.getText(),
             col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
@@ -412,16 +467,16 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
       }
       reporter.createHeader();
 
-      for (TableItem row : rows)
+      for (MyTreeItem row : rows)
       {
-        for (TableColumn col : listeAuswahl)
+        for (TreeColumn col : listeAuswahl)
         {
           int index = listeOrig.indexOf(col);
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
-          Color bg = (Color) row.getData("background");
+          Color bg = (Color) row.getTreeItem().getData("background");
           Font font = null;
-          for (FontData data : row.getFont(index).getFontData())
+          for (FontData data : row.getTreeItem().getFont(index).getFontData())
           {
             switch (data.getStyle())
             {
@@ -436,30 +491,34 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
                 break;
             }
           }
+          int alignment = col.getAlignment() == Column.ALIGN_LEFT
+              ? Element.ALIGN_LEFT
+              : Element.ALIGN_RIGHT;
+          if (row.getEbene() == 1 && index == 0)
+          {
+            alignment = Element.ALIGN_RIGHT;
+          }
           if (bg == null)
           {
-            reporter.addColumn(row.getText(index),
-                col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                    : Element.ALIGN_RIGHT,
+            reporter.addColumn(row.getTreeItem().getText(index), alignment,
                 font);
           }
           else
           {
-            reporter.addColumn(row.getText(index),
-                col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                    : Element.ALIGN_RIGHT,
+            reporter.addColumn(row.getTreeItem().getText(index), alignment,
                 new BaseColor(bg.getRed(), bg.getGreen(), bg.getBlue()), font);
           }
         }
       }
     }
+
   }
 
   @SuppressWarnings("unchecked")
   private void saveSettings() throws RemoteException
   {
-    List<TableColumn> itemsChecked = spaltenList.getItems();
-    for (TableColumn col : (List<TableColumn>) spaltenList.getItems(false))
+    List<TreeColumn> itemsChecked = spaltenList.getItems();
+    for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems(false))
     {
       settings.setAttribute(settingPrefix + "anzeigen." + col.getText(),
           itemsChecked.contains(col));
@@ -503,4 +562,36 @@ public class TablePartExportDialog extends AbstractDialog<Boolean>
     return success;
   }
 
+  private void getItemRekursiv(List<MyTreeItem> rows, TreeItem item, int ebene)
+  {
+    // Unterelemente durchlaufen
+    for (TreeItem child : item.getItems())
+    {
+      rows.add(new MyTreeItem(child, ebene));
+      getItemRekursiv(rows, child, ebene + 1);
+    }
+  }
+
+  public class MyTreeItem
+  {
+    private TreeItem treeItem;
+
+    private int ebene;
+
+    private MyTreeItem(TreeItem treeItem, int ebene)
+    {
+      this.treeItem = treeItem;
+      this.ebene = ebene;
+    }
+
+    public TreeItem getTreeItem()
+    {
+      return treeItem;
+    }
+
+    public int getEbene()
+    {
+      return ebene;
+    }
+  }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -381,8 +381,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
         ebenen = Math.max(ebenen, item.getEbene());
       }
       int size = listeAuswahl.size();
-      TreeColumn first = listeAuswahl.get(0);
-      if (listeOrig.indexOf(first) == 0)
+      if (listeOrig.indexOf(listeAuswahl.get(0)) == 0)
       {
         size += ebenen;
       }

--- a/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
@@ -47,11 +45,8 @@ import com.itextpdf.text.Font;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.Reporter;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.parts.Button;
-import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.parts.Column;
-import de.willuhn.jameica.gui.util.TabGroup;
-import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -95,7 +90,6 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     settings = new Settings(this.getClass());
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   protected void paint(Composite parent)
       throws ApplicationException, RemoteException
@@ -125,10 +119,8 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         return;
       }
     };
-    spaltenList.addColumn("Name", "text");
     if (art.equals(ExportArt.PDF))
     {
-      spaltenList.addColumn("Breite", "data", null, true);
       spaltenList.addChangeListener((object, attribute, newValue) -> {
         try
         {
@@ -140,20 +132,13 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         }
       });
     }
-    spaltenList.setCheckable(true);
-
-    if (art.equals(ExportArt.PDF))
+    createGui(parent, new Action()
     {
-      TabFolder folder = new TabFolder(parent, SWT.BORDER);
-      folder.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-      TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
-      TabGroup tabRaender = new TabGroup(folder, "Ränder", true, 2);
-      TabGroup tabFormular = new TabGroup(folder, "Formular", true, 2);
-
-      tabSpalten.addPart(spaltenList);
-      ButtonArea buttons = new ButtonArea();
-      buttons.addButton(new Button("Breiten zurücksetzen", (e) -> {
+      @SuppressWarnings("unchecked")
+      @Override
+      public void handleAction(Object context) throws ApplicationException
+      {
         try
         {
           for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems())
@@ -174,31 +159,8 @@ public class TreePartExportDialog extends AbstractPartExportDialog
           throw new ApplicationException(
               "Fehler beim zurücksetzen der Breiten");
         }
-
-      }, null, false, "eraser.png"));
-      tabSpalten.addButtonArea(buttons);
-
-      addRaenderFormularTabs(tabRaender, tabFormular);
-    }
-    else
-    {
-      spaltenList.paint(parent);
-    }
-
-    for (TreeColumn col : tree.getColumns())
-    {
-      spaltenList.setChecked(col, settings
-          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-    }
-
-    ButtonArea b = new ButtonArea();
-    b.addButton("Speichern", c -> export(), null, true, "ok.png");
-
-    b.addButton("Abbrechen", c -> {
-      throw new OperationCanceledException();
-    }, null, false, "process-stop.png");
-
-    b.paint(parent);
+      }
+    });
   }
 
   @Override
@@ -356,23 +318,6 @@ public class TreePartExportDialog extends AbstractPartExportDialog
 
   }
 
-  @SuppressWarnings("unchecked")
-  protected void saveSettings() throws RemoteException
-  {
-    List<TreeColumn> itemsChecked = spaltenList.getItems();
-    for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems(false))
-    {
-      settings.setAttribute(settingPrefix + "anzeigen." + col.getText(),
-          itemsChecked.contains(col));
-      if (art.equals(ExportArt.PDF))
-      {
-        settings.setAttribute(settingPrefix + "breite." + col.getText(),
-            (Integer) col.getData());
-      }
-    }
-    super.saveSettings();
-  }
-
   private void getItemRekursiv(List<MyTreeItem> rows, TreeItem item, int ebene)
   {
     // Unterelemente durchlaufen
@@ -403,6 +348,34 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     public int getEbene()
     {
       return ebene;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  protected void saveSettings() throws RemoteException
+  {
+    List<TreeColumn> itemsChecked = spaltenList.getItems();
+    for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems(false))
+    {
+      settings.setAttribute(settingPrefix + "anzeigen." + col.getText(),
+          itemsChecked.contains(col));
+      if (art.equals(ExportArt.PDF))
+      {
+        settings.setAttribute(settingPrefix + "breite." + col.getText(),
+            (Integer) col.getData());
+      }
+    }
+    super.saveSettings();
+  }
+
+  @Override
+  void setChecked()
+  {
+    for (TreeColumn col : tree.getColumns())
+    {
+      spaltenList.setChecked(col, settings
+          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
     }
   }
 }

--- a/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -29,7 +29,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.TabFolder;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
@@ -45,20 +44,9 @@ import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
 import com.itextpdf.text.Font;
 
-import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
-import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
-import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
-import de.jost_net.JVerein.keys.FormularArt;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.dialogs.AbstractDialog;
-import de.willuhn.jameica.gui.input.CheckboxInput;
-import de.willuhn.jameica.gui.input.IntegerInput;
-import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.parts.Column;
@@ -68,50 +56,16 @@ import de.willuhn.jameica.system.Settings;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class TreePartExportDialog extends AbstractDialog<Boolean>
+public class TreePartExportDialog extends AbstractPartExportDialog
 {
 
-  private boolean success = false;
-
-  private Settings settings;
-
   private Tree tree;
-
-  private String title;
-
-  private String subtitle;
-
-  private String filename;
-
-  private ExportArt art;
-
-  private String settingPrefix;
-
-  IntegerInput links;
-
-  IntegerInput rechts;
-
-  IntegerInput oben;
-
-  IntegerInput unten;
-
-  private CheckboxInput querformat;
-
-  private SelectInput vordergrund;
-
-  private SelectInput hintergrund;
-
-  private JVereinTablePart spaltenList;
-
-  private CheckboxInput headerTransparent;
-
-  private CheckboxInput zellenTransparent;
 
   public TreePartExportDialog(Tree tree, String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
       throws ApplicationException
   {
-    super(TreePartExportDialog.POSITION_CENTER);
+    super(settingPrefix, art, title, subtitle, filename);
 
     if (tree == null || tree.isDisposed() || !(tree instanceof Tree))
     {
@@ -122,7 +76,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
     {
       throw new ApplicationException("Tabelle enthält keine Daten");
     }
-    // wir haben immer den Root Node, darum prüfen wir die Childs
+    // Wir haben immer den Root Node, darum prüfen wir die Childs
     boolean leer = true;
     for (TreeItem item : rootItems)
     {
@@ -138,15 +92,6 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
     }
 
     this.tree = tree;
-    this.title = title;
-    this.subtitle = subtitle;
-    this.filename = filename;
-    this.art = art;
-    this.settingPrefix = settingPrefix + art.toString() + ".";
-
-    setTitle("Tree exportieren");
-    setSize(400, SWT.DEFAULT);
-
     settings = new Settings(this.getClass());
   }
 
@@ -233,49 +178,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
       }, null, false, "eraser.png"));
       tabSpalten.addButtonArea(buttons);
 
-      links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
-      rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));
-      oben = new IntegerInput(settings.getInt(settingPrefix + "oben", 20));
-      unten = new IntegerInput(settings.getInt(settingPrefix + "unten", 20));
-      tabRaender.addLabelPair("Links", links);
-      tabRaender.addLabelPair("Rechts", rechts);
-      tabRaender.addLabelPair("Oben", oben);
-      tabRaender.addLabelPair("Unten", unten);
-
-      // IntegerInput links2 = new IntegerInput(settings.getInt(id + "links2",
-      // 20));
-      // IntegerInput rechts2 = new IntegerInput(
-      // settings.getInt(id + "rechts2", 20));
-      // IntegerInput oben2 = new IntegerInput(settings.getInt(id + "oben2",
-      // 20));
-      // IntegerInput unten2 = new IntegerInput(settings.getInt(id + "unten2",
-      // 20));
-      // tabRaender.addLabelPair("Links ab 2. Seite", links2);
-      // tabRaender.addLabelPair("Rechts ab 2. Seite", rechts2);
-      // tabRaender.addLabelPair("Oben ab 2. Seite", oben2);
-      // tabRaender.addLabelPair("Unten ab 2. Seite", unten2);
-
-      hintergrund = new FormularInput(FormularArt.HINTERGRUND,
-          settings.getString(settingPrefix + "hintergrund", ""));
-      hintergrund.setPleaseChoose("Kein Formular");
-      vordergrund = new FormularInput(FormularArt.HINTERGRUND,
-          settings.getString(settingPrefix + "vordergrund", ""));
-      vordergrund.setPleaseChoose("Kein Formular");
-      headerTransparent = new CheckboxInput(settings.getBoolean(
-          settingPrefix + "headerTransparent", (Boolean) Einstellungen
-              .getEinstellung(Property.TABELLEN_HEADER_TRANSPARENT)));
-      zellenTransparent = new CheckboxInput(settings.getBoolean(
-          settingPrefix + "zellenTransparent", (Boolean) Einstellungen
-              .getEinstellung(Property.TABELLEN_ZELLEN_TRANSPARENT)));
-      querformat = new CheckboxInput(
-          settings.getBoolean(settingPrefix + "quer", false));
-      tabFormular.addLabelPair("Formular Hintergrund", hintergrund);
-      tabFormular.addLabelPair("Formular Vordergrund", vordergrund);
-      tabFormular.addLabelPair("Tabellen Header transparent",
-          headerTransparent);
-      tabFormular.addLabelPair("Tabellen Zellen transparent",
-          zellenTransparent);
-      tabFormular.addLabelPair("Querformat", querformat);
+      addRaenderFormularTabs(tabRaender, tabFormular);
     }
     else
     {
@@ -298,69 +201,8 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
     b.paint(parent);
   }
 
-  private void export() throws ApplicationException
-  {
-    try
-    {
-      String extension = "";
-      switch (art)
-      {
-        case CSV:
-          extension = ".csv";
-          break;
-        case PDF:
-          extension = ".pdf";
-          break;
-      }
-
-      FileDialog fd = new FileDialog(GUI.getShell(), SWT.SAVE);
-      fd.setText("Ausgabedatei wählen.");
-
-      String path = settings.getString(settingPrefix + "lastdir",
-          System.getProperty("user.home"));
-      if (path != null && path.length() > 0)
-      {
-        fd.setFilterPath(path);
-      }
-
-      fd.setFileName(filename);
-      fd.setFilterExtensions(new String[] { "*" + extension });
-
-      final String p = fd.open();
-
-      if (p == null || p.length() == 0)
-      {
-        throw new OperationCanceledException("Abgebrochen");
-      }
-
-      File file = new File(p);
-      settings.setAttribute(settingPrefix + "lastdir", file.getParent());
-
-      switch (art)
-      {
-        case CSV:
-          exportCSV(file);
-          break;
-        case PDF:
-          exportPDF(file);
-          break;
-      }
-      saveSettings();
-
-      FileViewer.show(file);
-
-      success = true;
-      close();
-    }
-    catch (IOException | DocumentException e)
-    {
-      String fehler = "Fehler beim Export";
-      Logger.error(fehler, e);
-      throw new ApplicationException(fehler);
-    }
-  }
-
-  private void exportCSV(File file) throws IOException
+  @Override
+  protected void exportCSV(File file) throws IOException
   {
     try (ICsvMapWriter writer = new CsvMapWriter(new FileWriter(file),
         CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE))
@@ -435,7 +277,8 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
     }
   }
 
-  private void exportPDF(File file) throws IOException, DocumentException
+  @Override
+  protected void exportPDF(File file) throws IOException, DocumentException
   {
     try (FileOutputStream fos = new FileOutputStream(file);
         Reporter reporter = new Reporter(fos, title, subtitle,
@@ -514,7 +357,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
   }
 
   @SuppressWarnings("unchecked")
-  private void saveSettings() throws RemoteException
+  protected void saveSettings() throws RemoteException
   {
     List<TreeColumn> itemsChecked = spaltenList.getItems();
     for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems(false))
@@ -527,38 +370,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
             (Integer) col.getData());
       }
     }
-
-    if (art.equals(ExportArt.PDF))
-    {
-      settings.setAttribute(settingPrefix + "links",
-          (Integer) links.getValue());
-      settings.setAttribute(settingPrefix + "rechts",
-          (Integer) rechts.getValue());
-      settings.setAttribute(settingPrefix + "oben", (Integer) oben.getValue());
-      settings.setAttribute(settingPrefix + "unten",
-          (Integer) unten.getValue());
-
-      settings.setAttribute(settingPrefix + "hintergrund",
-          hintergrund.getValue() == null ? null
-              : ((Formular) hintergrund.getValue()).getID());
-      settings.setAttribute(settingPrefix + "vordergrund",
-          vordergrund.getValue() == null ? null
-              : ((Formular) vordergrund.getValue()).getID());
-
-      settings.setAttribute(settingPrefix + "headerTransparent",
-          (Boolean) headerTransparent.getValue());
-      settings.setAttribute(settingPrefix + "zellenTransparent",
-          (Boolean) zellenTransparent.getValue());
-
-      settings.setAttribute(settingPrefix + "quer",
-          (Boolean) querformat.getValue());
-    }
-  }
-
-  @Override
-  protected Boolean getData() throws Exception
-  {
-    return success;
+    super.saveSettings();
   }
 
   private void getItemRekursiv(List<MyTreeItem> rows, TreeItem item, int ebene)
@@ -571,7 +383,7 @@ public class TreePartExportDialog extends AbstractDialog<Boolean>
     }
   }
 
-  public class MyTreeItem
+  private class MyTreeItem
   {
     private TreeItem treeItem;
 

--- a/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.parts;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.util.ApplicationException;
+
+public interface IJVereinPart
+{
+
+  @SuppressWarnings("rawtypes")
+  public List getItems() throws RemoteException;
+
+  public List<Column> getAllColums();
+
+  public List<Column> getColums();
+
+  public void export(String title, String subtitle, String filename,
+      ExportArt art) throws ApplicationException;
+
+  public void saveSpalten(List<Column> columns) throws RemoteException;
+
+  public String getTableName();
+}

--- a/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
@@ -18,7 +18,9 @@ import java.rmi.RemoteException;
 import java.util.List;
 
 import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
+import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.jameica.system.Settings;
 import de.willuhn.util.ApplicationException;
 
 public interface IJVereinPart
@@ -37,4 +39,55 @@ public interface IJVereinPart
   public void saveSpalten(List<Column> columns) throws RemoteException;
 
   public String getTableName();
+
+  /**
+   * Ermittelt die ID der Tablepart aus der View und dem Objekttyp
+   * 
+   * @param tablePartId
+   * @param tableName
+   * @return
+   * @throws RemoteException
+   */
+  default String getTablePartID(String tablePartId, String tableName)
+      throws RemoteException
+  {
+    if (tablePartId != null)
+    {
+      return tablePartId;
+    }
+    List<?> items = getItems();
+
+    if (items.size() == 0)
+    {
+      tablePartId = "";
+      return tablePartId;
+    }
+    StringBuilder sb = new StringBuilder();
+
+    sb.append(GUI.getCurrentView().getClass().getSimpleName());
+    sb.append(".");
+    if (tableName != null)
+    {
+      sb.append(tableName);
+    }
+    else
+    {
+      sb.append(items.get(0).getClass().getSimpleName());
+    }
+    sb.append(".");
+
+    tablePartId = sb.toString();
+    return tablePartId;
+  }
+
+  default void saveSpalten(List<Column> columns, String tablePartId,
+      String tableName, Settings settings) throws RemoteException
+  {
+    for (Column c : getAllColums())
+    {
+      settings.setAttribute(
+          getTablePartID(tablePartId, tableName) + c.getName(),
+          columns.contains(c));
+    }
+  }
 }

--- a/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
+++ b/src/de/jost_net/JVerein/gui/parts/IJVereinPart.java
@@ -17,7 +17,7 @@ package de.jost_net.JVerein.gui.parts;
 import java.rmi.RemoteException;
 import java.util.List;
 
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.util.ApplicationException;
 

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 
 import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.willuhn.datasource.GenericIterator;

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
@@ -30,7 +30,6 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.willuhn.datasource.GenericIterator;
 import de.willuhn.jameica.gui.Action;
-import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TablePart;
 import de.willuhn.jameica.gui.parts.table.Feature;
@@ -169,7 +168,9 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   {
     try
     {
-      if (settings.getBoolean(getTablePartID() + col.getName(), defaultVisible))
+      if (settings.getBoolean(
+          getTablePartID(tablePartId, tableName) + col.getName(),
+          defaultVisible))
       {
         super.addColumn(col);
       }
@@ -196,48 +197,7 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   @Override
   public void saveSpalten(List<Column> columns) throws RemoteException
   {
-    for (Column c : allColumns)
-    {
-      settings.setAttribute(getTablePartID() + c.getName(),
-          columns.contains(c));
-    }
-  }
-
-  /**
-   * Ermittelt die ID der Tablepart aus der View und dem Objekttyp
-   * 
-   * @return
-   * @throws RemoteException
-   */
-  private String getTablePartID() throws RemoteException
-  {
-    if (tablePartId != null)
-    {
-      return tablePartId;
-    }
-    List<?> items = getItems();
-
-    if (items.size() == 0)
-    {
-      tablePartId = "";
-      return tablePartId;
-    }
-    StringBuilder sb = new StringBuilder();
-
-    sb.append(GUI.getCurrentView().getClass().getSimpleName());
-    sb.append(".");
-    if (tableName != null)
-    {
-      sb.append(tableName);
-    }
-    else
-    {
-      sb.append(items.get(0).getClass().getSimpleName());
-    }
-    sb.append(".");
-
-    tablePartId = sb.toString();
-    return tablePartId;
+    saveSpalten(columns, tablePartId, tableName, settings);
   }
 
   /**
@@ -276,8 +236,9 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   {
     try
     {
-      if (!new TablePartExportDialog((Table) tableControl, getTablePartID(),
-          art, title, subtitle, filename).open())
+      if (!new TablePartExportDialog((Table) tableControl,
+          getTablePartID(tablePartId, tableName), art, title, subtitle,
+          filename).open())
       {
         throw new OperationCanceledException();
       }

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
@@ -1,5 +1,4 @@
 /**********************************************************************
- * Copyright (c) by Heiner Jostkleigrewe
  * This program is free software: you can redistribute it and/or modify it under the terms of the 
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
  * License, or (at your option) any later version.
@@ -11,8 +10,6 @@
  * You should have received a copy of the GNU General Public License along with this program.  If not, 
  * see <http://www.gnu.org/licenses/>.
  * 
- * heiner@jverein.de
- * www.jverein.de
  **********************************************************************/
 package de.jost_net.JVerein.gui.parts;
 
@@ -28,7 +25,6 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.dialogs.TreePartExportDialog;
 import de.willuhn.jameica.gui.Action;
-import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.parts.table.Feature;
@@ -101,7 +97,9 @@ public class JVereinTreePart extends TreePart implements IJVereinPart
   {
     try
     {
-      if (settings.getBoolean(getTablePartID() + col.getName(), defaultVisible))
+      if (settings.getBoolean(
+          getTablePartID(tablePartId, tableName) + col.getName(),
+          defaultVisible))
       {
         super.addColumn(col);
       }
@@ -128,48 +126,7 @@ public class JVereinTreePart extends TreePart implements IJVereinPart
   @Override
   public void saveSpalten(List<Column> columns) throws RemoteException
   {
-    for (Column c : allColumns)
-    {
-      settings.setAttribute(getTablePartID() + c.getName(),
-          columns.contains(c));
-    }
-  }
-
-  /**
-   * Ermittelt die ID der Tablepart aus der View und dem Objekttyp
-   * 
-   * @return
-   * @throws RemoteException
-   */
-  private String getTablePartID() throws RemoteException
-  {
-    if (tablePartId != null)
-    {
-      return tablePartId;
-    }
-    List<?> items = getItems();
-
-    if (items.size() == 0)
-    {
-      tablePartId = "";
-      return tablePartId;
-    }
-    StringBuilder sb = new StringBuilder();
-
-    sb.append(GUI.getCurrentView().getClass().getSimpleName());
-    sb.append(".");
-    if (tableName != null)
-    {
-      sb.append(tableName);
-    }
-    else
-    {
-      sb.append(items.get(0).getClass().getSimpleName());
-    }
-    sb.append(".");
-
-    tablePartId = sb.toString();
-    return tablePartId;
+    saveSpalten(columns, tablePartId, tableName, settings);
   }
 
   /**
@@ -208,8 +165,9 @@ public class JVereinTreePart extends TreePart implements IJVereinPart
   {
     try
     {
-      if (!new TreePartExportDialog((Tree) treeControl, getTablePartID(), art,
-          title, subtitle, filename).open())
+      if (!new TreePartExportDialog((Tree) treeControl,
+          getTablePartID(tablePartId, tableName), art, title, subtitle,
+          filename).open())
       {
         throw new OperationCanceledException();
       }

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Tree;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.dialogs.TreePartExportDialog;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
+++ b/src/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
@@ -21,28 +21,26 @@ import java.util.LinkedList;
 import java.util.List;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.Tree;
 
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
-import de.willuhn.datasource.GenericIterator;
+import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.TreePartExportDialog;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.Column;
-import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.parts.table.Feature;
 import de.willuhn.jameica.gui.parts.table.Feature.Context;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
-public class JVereinTablePart extends TablePart implements IJVereinPart
+public class JVereinTreePart extends TreePart implements IJVereinPart
 {
 
-  private Control tableControl;
+  private Control treeControl;
 
   private List<Column> allColumns = new LinkedList<Column>();
 
@@ -51,40 +49,16 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   private String tableName = null;
 
   /**
-   * Erzeugt eine neue leere Standard-Tabelle auf dem uebergebenen Composite.
+   * Erzeugt einen neuen Tree basierend auf dem uebergebenen Objekt.
    * 
+   * @param object
+   *          Das Objekt, fuer das der Baum erzeugt werden soll.
    * @param action
-   *          die beim Doppelklick auf ein Element ausgefuehrt wird.
+   *          Action, die bei der Auswahl eines Elements ausgeloest werden soll.
    */
-  public JVereinTablePart(Action action)
+  public JVereinTreePart(Object object, Action action)
   {
-    this((List<?>) null, action);
-  }
-
-  /**
-   * Erzeugt eine neue Standard-Tabelle auf dem uebergebenen Composite.
-   * 
-   * @param list
-   *          Liste mit Objekten, die angezeigt werden soll.
-   * @param action
-   *          die beim Doppelklick auf ein Element ausgefuehrt wird.
-   */
-  public JVereinTablePart(GenericIterator<?> list, Action action)
-  {
-    this(asList(list), action);
-  }
-
-  /**
-   * Erzeugt eine neue Standard-Tabelle auf dem uebergebenen Composite.
-   * 
-   * @param list
-   *          Liste mit Objekten, die angezeigt werden soll.
-   * @param action
-   *          die beim Doppelklick auf ein Element ausgefuehrt wird.
-   */
-  public JVereinTablePart(List<?> list, Action action)
-  {
-    super(list, action);
+    super(object, action);
     setRememberColWidths(true);
     setRememberOrder(true);
   }
@@ -110,53 +84,11 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   {
     Context ctx = super.createFeatureEventContext(e, data);
 
-    this.tableControl = ctx.control;
-
-    if (!e.equals(Feature.Event.PAINT))
+    if (e.equals(Feature.Event.PAINT))
     {
-      return ctx;
+      this.treeControl = ctx.control;
     }
-    Table table = (Table) ctx.control;
-
-    // Die letzte Spalte packen wir nach Titelbreite, falls diese kleiner als
-    // der gespeicherte Wert ist. So wird ggf. verhindert, dass eine horizontale
-    // Scrollbar angezeigt wird, wenn es gar nicht nötig ist.
-    if (table.getColumnCount() == 0)
-    {
-      return ctx;
-    }
-    TableColumn c = table.getColumn(table.getColumnCount() - 1);
-    int widthOld = c.getWidth();
-    c.pack();
-    if (c.getWidth() > widthOld)
-    {
-      c.setWidth(widthOld);
-    }
-
     return ctx;
-  }
-
-  // Überschrieben um den Checked-Status beim sortieren beizubehalten
-  @Override
-  protected void orderBy(int index)
-  {
-    if (checkable)
-    {
-      try
-      {
-        List<?> l = getItems();
-        super.orderBy(index);
-        setChecked(l.toArray(), true);
-      }
-      catch (RemoteException e)
-      {
-        Logger.error("Fehler beim Sortieren");
-      }
-    }
-    else
-    {
-      super.orderBy(index);
-    }
   }
 
   @Override
@@ -276,8 +208,8 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   {
     try
     {
-      if (!new TablePartExportDialog((Table) tableControl, getTablePartID(),
-          art, title, subtitle, filename).open())
+      if (!new TreePartExportDialog((Tree) treeControl, getTablePartID(), art,
+          title, subtitle, filename).open())
       {
         throw new OperationCanceledException();
       }
@@ -303,4 +235,5 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
   {
     return tableName;
   }
+
 }

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufDetailView.java
@@ -34,7 +34,7 @@ import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AbrechnungslaufControl;
 import de.jost_net.JVerein.gui.control.Savable;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
 import de.jost_net.JVerein.gui.parts.SaveButton;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbrechnungslaufListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.AbrechnungAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AbrechnungslaufControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedDetailView.java
@@ -44,7 +44,7 @@ import de.jost_net.JVerein.gui.control.LesefeldControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
 import de.jost_net.JVerein.gui.control.MitgliedControl.TabSelection;
 import de.jost_net.JVerein.gui.control.SollbuchungControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
 import de.jost_net.JVerein.gui.util.SimpleVerticalContainer;

--- a/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbstractMitgliedListeView.java
@@ -24,7 +24,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.gui.action.MitgliederImportAction;
 import de.jost_net.JVerein.gui.control.FilterControl.Mitgliedstypen;
 import de.jost_net.JVerein.gui.control.MitgliedControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;

--- a/src/de/jost_net/JVerein/gui/view/AbweichendeZahlerView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbweichendeZahlerView.java
@@ -17,7 +17,8 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
-import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.AbweichenderZahlerControl;
+import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -27,24 +28,26 @@ import de.willuhn.util.ApplicationException;
 
 public class AbweichendeZahlerView extends AbstractView
 {
-  final MitgliedControl control = new MitgliedControl(this);
+  final AbweichenderZahlerControl control = new AbweichenderZahlerControl(this);
 
   @Override
   public void bind() throws Exception
   {
     GUI.getView().setTitle("Abweichende Zahler");
 
-    control.init("abweichendezahler.", null, null);
-
     LabelGroup group = new LabelGroup(getParent(), "Filter");
     group.addInput(control.getMitgliedStatus());
 
-    control.getAbweichenderZahlerTree().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.ABWEICHENDEZAHLER, false, "question-circle.png");
     buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/AbweichendeZahlerView.java
+++ b/src/de/jost_net/JVerein/gui/view/AbweichendeZahlerView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AbweichenderZahlerControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;

--- a/src/de/jost_net/JVerein/gui/view/AnfangsbestandListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnfangsbestandListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.AnfangsbestandNeuAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AnfangsbestandControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenbuchungListeView.java
@@ -29,7 +29,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenfilter;
 import de.jost_net.JVerein.gui.control.BuchungsHeaderControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;

--- a/src/de/jost_net/JVerein/gui/view/AnlagenverzeichnisView.java
+++ b/src/de/jost_net/JVerein/gui/view/AnlagenverzeichnisView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.AnlagenlisteControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ArbeitseinsatzListeView.java
@@ -22,7 +22,7 @@ import de.jost_net.JVerein.gui.action.ArbeitseinsatzZusatzbetraegeAction;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.ArbeitseinsatzControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Arbeitseinsatz;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/BeitragsgruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BeitragsgruppeListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.BeitragsgruppeControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Beitragsgruppe;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungListeView.java
@@ -30,7 +30,7 @@ import de.jost_net.JVerein.gui.action.StartViewAction;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
 import de.jost_net.JVerein.gui.control.BuchungsControl.Kontenfilter;
 import de.jost_net.JVerein.gui.control.BuchungsHeaderControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;

--- a/src/de/jost_net/JVerein/gui/view/BuchungsartListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsartListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.BuchungsartControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Buchungsart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.BuchungsklasseControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/BuchungsklasseSaldoView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.BuchungsklasseSaldoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftGruppeListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.EigenschaftGruppeControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.EigenschaftGruppe;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/EigenschaftListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.EigenschaftControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Eigenschaft;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
+++ b/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
@@ -17,7 +17,8 @@
 package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
-import de.jost_net.JVerein.gui.control.MitgliedControl;
+import de.jost_net.JVerein.gui.control.FamilienbeitragControl;
+import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;
@@ -27,24 +28,26 @@ import de.willuhn.util.ApplicationException;
 
 public class FamilienbeitragView extends AbstractView
 {
-  final MitgliedControl control = new MitgliedControl(this);
+  final FamilienbeitragControl control = new FamilienbeitragControl(this);
 
   @Override
   public void bind() throws Exception
   {
     GUI.getView().setTitle("Familienverband");
 
-    control.init("familie.", null, null);
-
     LabelGroup group = new LabelGroup(getParent(), "Filter");
     group.addInput(control.getMitgliedStatus());
 
-    control.getFamilienbeitraegeTree().paint(this.getParent());
+    control.getTablePart().paint(this.getParent());
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.FAMILIENBEITRAG, false, "question-circle.png");
     buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
   }
 
   @Override

--- a/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
+++ b/src/de/jost_net/JVerein/gui/view/FamilienbeitragView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.FamilienbeitragControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;

--- a/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularDetailView.java
@@ -25,7 +25,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.FormularAnzeigeAction;
 import de.jost_net.JVerein.gui.control.FormularControl;
 import de.jost_net.JVerein.gui.control.Savable;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
 import de.jost_net.JVerein.gui.parts.SaveButton;
 import de.jost_net.JVerein.gui.parts.SaveNeuButton;

--- a/src/de/jost_net/JVerein/gui/view/FormularListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/FormularListeView.java
@@ -20,7 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.FormularImportAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.FormularControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Formular;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussDetailView.java
@@ -20,7 +20,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.JahresabschlussControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
 import de.jost_net.JVerein.gui.parts.ButtonRtoL;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/JahresabschlussListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/JahresabschlussListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.JahresabschlussControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/KontoListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoListeView.java
@@ -20,7 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.HibiscusKontenImportAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.KontoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Konto;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/KontoSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/KontoSaldoView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.KontensaldoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/KursteilnehmerListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/KursteilnehmerListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.KursteilnehmerControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LastschriftListeView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.LastschriftControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/LehrgangListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.LehrgangControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Lehrgang;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LehrgangsartListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.LehrgangsartControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Lehrgangsart;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/LesefeldListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/LesefeldListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.LesefeldControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Lesefeld;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/MailListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.MailNeuAction;
 import de.jost_net.JVerein.gui.control.MailControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;

--- a/src/de/jost_net/JVerein/gui/view/MailVorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MailVorlageListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.MailVorlageControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.MailVorlage;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/MitgliedstypListeView.java
@@ -21,7 +21,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.MitgliedstypDefaultAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.MitgliedstypControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Mitgliedstyp;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/MittelverwendungReportView.java
+++ b/src/de/jost_net/JVerein/gui/view/MittelverwendungReportView.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.TabFolder;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MittelverwendungControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/MittelverwendungSaldoView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.MittelverwendungSaldoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/ProjektListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.ProjektControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Projekt;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/ProjektSaldoView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.ProjektSaldoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.parts.ButtonArea;

--- a/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/RechnungListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.RechnungControl;
 import de.jost_net.JVerein.gui.control.RechnungControl.TYP;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SollbuchungListeView.java
@@ -20,7 +20,7 @@ import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.SollbuchungExportAction;
 import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
 import de.jost_net.JVerein.gui.control.SollbuchungControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SpendenbescheinigungListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.StartViewAction;
 import de.jost_net.JVerein.gui.control.SpendenbescheinigungControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/SteuerListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/SteuerListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.SteuerControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Steuer;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
+++ b/src/de/jost_net/JVerein/gui/view/UmsatzsteuerSaldoView.java
@@ -18,7 +18,7 @@ package de.jost_net.JVerein.gui.view;
 
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.UmsatzsteuerSaldoControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.QuickAccessPart;
 import de.jost_net.JVerein.gui.parts.VonBisPart;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/WiedervorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/WiedervorlageListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.WiedervorlageControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.gui.parts.ToolTipButton;
 import de.jost_net.JVerein.rmi.Wiedervorlage;
 import de.willuhn.jameica.gui.AbstractView;

--- a/src/de/jost_net/JVerein/gui/view/WirtschaftsplanListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/WirtschaftsplanListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.WirtschaftsplanControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Wirtschaftsplan;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragListeView.java
@@ -21,7 +21,7 @@ import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.action.StartViewAction;
 import de.jost_net.JVerein.gui.action.ZusatzbetraegeImportAction;
 import de.jost_net.JVerein.gui.control.ZusatzbetragControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzbetragVorlageListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.ZusatzbetragVorlageControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.ZusatzbetragVorlage;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/gui/view/ZusatzfeldListeView.java
+++ b/src/de/jost_net/JVerein/gui/view/ZusatzfeldListeView.java
@@ -19,7 +19,7 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.control.FelddefinitionControl;
-import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
 import de.jost_net.JVerein.rmi.Felddefinition;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;

--- a/src/de/jost_net/JVerein/keys/VorlageTyp.java
+++ b/src/de/jost_net/JVerein/keys/VorlageTyp.java
@@ -109,6 +109,14 @@ public enum VorlageTyp
       "Pre-Notification-Kursteilnehmer Dateiname",
       "Prenotification-$lastschrift_name-$lastschrift_vorname-$aktuellesdatum-$aktuellezeit",
       Vorlageart.DATEINAME.getKey()),
+  ABWEICHENDE_ZAHLER_DATEINAME("abweichende-zahler-dateiname",
+      "Abweichende Zahler Dateiname",
+      "Abweichende-Zahler-$aktuellesdatum-$aktuellezeit",
+      Vorlageart.DATEINAME.getKey()),
+  FAMILIENVERBAND_DATEINAME("familienverband-dateiname",
+      "Familienverband Dateiname",
+      "Familienverband-$aktuellesdatum-$aktuellezeit",
+      Vorlageart.DATEINAME.getKey()),
 
   // Reports aus Mitglieder
   PERSONALBOGEN_DATEINAME("personalbogen-dateiname", "Personalbogen Dateiname",
@@ -484,6 +492,15 @@ public enum VorlageTyp
       "Wiedervorlagen", Vorlageart.TITEL.getKey()),
   WIEDERVORLAGEN_SUBTITEL("wiedervorlagen-subtitel", "Wiedervorlagen Subtitel",
       "", Vorlageart.TITEL.getKey()),
+  ABWEICHENDE_ZAHLER_TITEL("abweichende-zahler-titel",
+      "Abweichende Zahler Titel", "Abweichende Zahler",
+      Vorlageart.TITEL.getKey()),
+  ABWEICHENDE_ZAHLER_SUBTITEL("abweichende-zahler-subtitel",
+      "Abweichende Zahler Subtitel", "", Vorlageart.TITEL.getKey()),
+  FAMILIENVERBAND_TITEL("familienverband-titel", "Familienverband Titel",
+      "Familienverband", Vorlageart.TITEL.getKey()),
+  FAMILIENVERBAND_SUBTITEL("familienverband-subtitel",
+      "Familienverband Subtitel", "", Vorlageart.TITEL.getKey()),
 
   // Reports aus Buchführung
   KONTEN_TITEL("konten-titel", "Konten Titel", "Konten",

--- a/src/de/jost_net/JVerein/util/VorlageUtil.java
+++ b/src/de/jost_net/JVerein/util/VorlageUtil.java
@@ -448,6 +448,12 @@ public class VorlageUtil
         case MAILVORLAGEN_DATEINAME:
         case MAILVORLAGEN_TITEL:
         case MAILVORLAGEN_SUBTITEL:
+        case ABWEICHENDE_ZAHLER_DATEINAME:
+        case ABWEICHENDE_ZAHLER_SUBTITEL:
+        case ABWEICHENDE_ZAHLER_TITEL:
+        case FAMILIENVERBAND_DATEINAME:
+        case FAMILIENVERBAND_SUBTITEL:
+        case FAMILIENVERBAND_TITEL:
           // Bei zip oder einzelnes Dokument für mehrere Einträge
           // Nur die allgemeine Map
           break;
@@ -813,6 +819,12 @@ public class VorlageUtil
         case MAILVORLAGEN_DATEINAME:
         case MAILVORLAGEN_TITEL:
         case MAILVORLAGEN_SUBTITEL:
+        case ABWEICHENDE_ZAHLER_DATEINAME:
+        case ABWEICHENDE_ZAHLER_SUBTITEL:
+        case ABWEICHENDE_ZAHLER_TITEL:
+        case FAMILIENVERBAND_DATEINAME:
+        case FAMILIENVERBAND_SUBTITEL:
+        case FAMILIENVERBAND_TITEL:
           // Bei zip oder einzelnes Dokument für mehrere Einträge
           // Nur die allgemeine Map
           break;


### PR DESCRIPTION
Zur Abbrundung unseres Spaltenauswahl und CSV/PDF Reports Feature habe ich das auch für TreeParts implementiert.
Es ist für den Familieneverband und Abweichende Zahler implementiert.
Beim CSV Reports wird die erste Spalte auf mehrere Spalten aufgeteilt je nach Tiefe des Trees. Beim PDF habe ich ersteinmal nur das Alignment geändert

Den Code für AbweichendeZahlerControl und FamilienBeitragControl habe ich aus MitgiedControl heraus kopiert und nicht verändert. 

Ich möchte aber nicht die 4.2 blockieren. Nach #1517 können wird den #1479 übernehmen wenn dessen Mergekonflikte behoben sind. Ich kann das dann entsprechend migrieren.