### PR TITLE
Fix Buchungsliste Refresh bei grünen Buttons

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -2142,14 +2142,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
           calendar.add(Calendar.DAY_OF_MONTH, -1);
           getBisdatum().setValue(calendar.getTime());
         }
-        try
-        {
-          getTablePart();
-        }
-        catch (RemoteException ex)
-        {
-          throw new ApplicationException(ex.getMessage());
-        }
+        refreshBuchungsList();
       }
     }, null, false, "go-previous.png");
   }
@@ -2190,14 +2183,7 @@ public class BuchungsControl extends VorZurueckControl implements Savable
           calendar.add(Calendar.DAY_OF_MONTH, -1);
           getBisdatum().setValue(calendar.getTime());
         }
-        try
-        {
-          getTablePart();
-        }
-        catch (RemoteException ex)
-        {
-          throw new ApplicationException(ex.getMessage());
-        }
+        refreshBuchungsList();
       }
     }, null, false, "go-next.png");
   }


### PR DESCRIPTION
Bei den grünen vor/zurück Buttons im Filterbereich der Buchungsliste gab es keinen Refresh mehr da getTablePart() mit meiner letzten Änderung nur noch den Part liefert und keinen Refresh mehr macht.