### PR TITLE
Schriftartauswahl bei Tabellenexport

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/FormularfeldControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/FormularfeldControl.java
@@ -17,7 +17,6 @@
 package de.jost_net.JVerein.gui.control;
 
 import java.rmi.RemoteException;
-import java.util.ArrayList;
 import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
@@ -28,6 +27,7 @@ import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungMap;
 import de.jost_net.JVerein.Variable.SpendenbescheinigungVar;
+import de.jost_net.JVerein.gui.input.FontInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.keys.Ausrichtung;
 import de.jost_net.JVerein.rmi.Formular;
@@ -131,28 +131,7 @@ public class FormularfeldControl extends FormularPartControl implements Savable
     {
       return font;
     }
-    ArrayList<String> fonts = new ArrayList<>();
-    fonts.add("PTSans-Regular");
-    fonts.add("PTSans-Bold");
-    fonts.add("PTSans-Italic");
-    fonts.add("PTSans-BoldItalic");
-    fonts.add("FreeSans");
-    fonts.add("FreeSans-Bold");
-    fonts.add("FreeSans-BoldOblique");
-    fonts.add("FreeSans-Oblique");
-    fonts.add("Courier Prime");
-    fonts.add("Courier Prime Bold");
-    fonts.add("Courier Prime Bold Italic");
-    fonts.add("Courier Prime Italic");
-    fonts.add("LiberationSans-Bold");
-    fonts.add("LiberationSans-BoldItalic");
-    fonts.add("LiberationSans-Italic");
-    fonts.add("LiberationSans-Regular");
-    fonts.add("LiberationSerif-Bold");
-    fonts.add("LiberationSerif-BoldItalic");
-    fonts.add("LiberationSerif-Italic");
-    fonts.add("LiberationSerif-Regular");
-    font = new SelectInput(fonts, getFormularfeld().getFont());
+    font = new FontInput(getFormularfeld().getFont());
     return font;
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
@@ -40,6 +42,7 @@ import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.input.ColorInput;
 import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
@@ -92,19 +95,21 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   protected CheckboxInput zellenTransparent;
 
+  protected SelectInput fontHeader;
+
   protected SelectInput fontNormal;
 
   protected SelectInput fontFett;
 
   protected SelectInput fontItalic;
 
-  protected IntegerInput fontsizeNormal;
+  protected IntegerInput fontsizeHeader;
 
-  protected IntegerInput fontsizeFett;
-
-  protected IntegerInput fontsizeItalic;
+  protected IntegerInput fontsize;
 
   protected CheckboxInput negativRot;
+
+  protected ColorInput colorChooser;
 
   public AbstractPartExportDialog(String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
@@ -212,26 +217,33 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     tabFormular.addLabelPair("Querformat", querformat);
 
     // Schriftart
+    fontHeader = new FontInput(
+        settings.getString(settingPrefix + "font_header", "FreeSans"));
     fontNormal = new FontInput(
         settings.getString(settingPrefix + "font_normal", "FreeSans"));
     fontFett = new FontInput(
         settings.getString(settingPrefix + "font_fett", "FreeSans-Bold"));
     fontItalic = new FontInput(
         settings.getString(settingPrefix + "font_italic", "FreeSans-Oblique"));
-    fontsizeNormal = new IntegerInput(
-        settings.getInt(settingPrefix + "fontsize_normal", 8));
-    fontsizeFett = new IntegerInput(
-        settings.getInt(settingPrefix + "fontsize_fett", 8));
-    fontsizeItalic = new IntegerInput(
-        settings.getInt(settingPrefix + "fontsize_italic", 8));
+    fontsize = new IntegerInput(settings.getInt(settingPrefix + "fontsize", 8));
+    fontsizeHeader = new IntegerInput(
+        settings.getInt(settingPrefix + "fontsize_header", 8));
     negativRot = new CheckboxInput(
         settings.getBoolean(settingPrefix + "negativ_rot", true));
+    Color col = new Color(
+        (int) settings.getInt(settingPrefix + "color_red", 192),
+        (int) settings.getInt(settingPrefix + "color_green", 192),
+        (int) settings.getInt(settingPrefix + "color_blue", 192));
+    colorChooser = new ColorInput(col, false);
+    tabFont.addHeadline("Tabellen Spaltennamen");
+    tabFont.addLabelPair("Schriftart", fontHeader);
+    tabFont.addLabelPair("Schriftgröße", fontsizeHeader);
+    tabFont.addLabelPair("Hintergrund Farbe", colorChooser);
+    tabFont.addHeadline("Tabellen Inhalt");
     tabFont.addLabelPair("Schriftart Standard", fontNormal);
-    tabFont.addLabelPair("Schriftgröße Standard", fontsizeNormal);
     tabFont.addLabelPair("Schriftart Fett", fontFett);
-    tabFont.addLabelPair("Schriftgröße Fett", fontsizeFett);
     tabFont.addLabelPair("Schriftart Kursiv", fontItalic);
-    tabFont.addLabelPair("Schriftgröße Kursiv", fontsizeItalic);
+    tabFont.addLabelPair("Schriftgröße", fontsize);
     tabFont.addLabelPair("Negative Werte in Rot", negativRot);
   }
 
@@ -324,53 +336,95 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
       settings.setAttribute(settingPrefix + "quer",
           (Boolean) querformat.getValue());
 
+      settings.setAttribute(settingPrefix + "font_header",
+          (String) fontHeader.getValue());
       settings.setAttribute(settingPrefix + "font_normal",
           (String) fontNormal.getValue());
       settings.setAttribute(settingPrefix + "font_fett",
           (String) fontFett.getValue());
       settings.setAttribute(settingPrefix + "font_italic",
           (String) fontItalic.getValue());
-      settings.setAttribute(settingPrefix + "fontsize_normal",
-          (Integer) fontsizeNormal.getValue());
-      settings.setAttribute(settingPrefix + "fontsize_fett",
-          (Integer) fontsizeFett.getValue());
-      settings.setAttribute(settingPrefix + "fontsize_italic",
-          (Integer) fontsizeItalic.getValue());
+      settings.setAttribute(settingPrefix + "fontsize_header",
+          (Integer) fontsizeHeader.getValue());
+      settings.setAttribute(settingPrefix + "fontsize",
+          (Integer) fontsize.getValue());
       settings.setAttribute(settingPrefix + "negativ_rot",
           (Boolean) negativRot.getValue());
+      Color col = (Color) colorChooser.getValue();
+      settings.setAttribute(settingPrefix + "color_red",
+          (Integer) col.getRed());
+      settings.setAttribute(settingPrefix + "color_green",
+          (Integer) col.getGreen());
+      settings.setAttribute(settingPrefix + "color_blue",
+          (Integer) col.getBlue());
     }
+  }
+
+  protected Font getFont(String text, FontData[] data)
+  {
+    BaseColor color = BaseColor.BLACK;
+    try
+    {
+      String text2 = text.replaceAll("\\.", "").replaceAll("\\,", "\\.");
+      Double value = Double.valueOf(text2);
+      if (value < 0)
+      {
+        color = BaseColor.RED;
+      }
+    }
+    catch (NumberFormatException ex)
+    {
+      // Dann bleibt es Schwarz
+    }
+    for (FontData fdata : data)
+    {
+      switch (fdata.getStyle())
+      {
+        case SWT.BOLD:
+          return getFontFett(color);
+        case SWT.ITALIC:
+          return getFontKursiv(color);
+        case SWT.NORMAL:
+          return getFontNormal(color);
+      }
+    }
+    return null;
+  }
+
+  protected Font getFontHeader(BaseColor color)
+  {
+    return FontFactory.getFont(
+        "/fonts/" + (String) fontHeader.getValue() + ".ttf",
+        BaseFont.IDENTITY_H, (Integer) fontsizeHeader.getValue(),
+        Font.UNDEFINED, color);
+  }
+
+  protected BaseColor getHintergrundHeader()
+  {
+    Color col = (Color) colorChooser.getValue();
+    return new BaseColor(col.getRed(), col.getGreen(), col.getBlue());
   }
 
   protected Font getFontNormal(BaseColor color)
   {
     return FontFactory.getFont(
         "/fonts/" + (String) fontNormal.getValue() + ".ttf",
-        BaseFont.IDENTITY_H, (Integer) fontsizeNormal.getValue(),
-        Font.UNDEFINED, getColor(color));
+        BaseFont.IDENTITY_H, (Integer) fontsize.getValue(), Font.UNDEFINED,
+        color);
   }
 
   protected Font getFontFett(BaseColor color)
   {
     return FontFactory.getFont(
         "/fonts/" + (String) fontFett.getValue() + ".ttf", BaseFont.IDENTITY_H,
-        (Integer) fontsizeFett.getValue(), Font.UNDEFINED, getColor(color));
+        (Integer) fontsize.getValue(), Font.UNDEFINED, color);
   }
 
   protected Font getFontKursiv(BaseColor color)
   {
     return FontFactory.getFont(
         "/fonts/" + (String) fontItalic.getValue() + ".ttf",
-        BaseFont.IDENTITY_H, (Integer) fontsizeItalic.getValue(), Font.ITALIC,
-        getColor(color));
-  }
-
-  private BaseColor getColor(BaseColor color)
-  {
-    if (!(Boolean) negativRot.getValue())
-    {
-      color = BaseColor.BLACK;
-    }
-    return color;
+        BaseFont.IDENTITY_H, (Integer) fontsize.getValue(), Font.ITALIC, color);
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -109,7 +109,9 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   protected CheckboxInput negativRot;
 
-  protected ColorInput colorChooser;
+  protected ColorInput colorHeader;
+
+  protected ColorInput colorTable;
 
   public AbstractPartExportDialog(String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
@@ -231,18 +233,23 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     negativRot = new CheckboxInput(
         settings.getBoolean(settingPrefix + "negativ_rot", true));
     Color col = new Color(
-        (int) settings.getInt(settingPrefix + "color_red", 192),
+        (int) settings.getInt(settingPrefix + "header_color_red", 192),
+        (int) settings.getInt(settingPrefix + "header_color_green", 192),
+        (int) settings.getInt(settingPrefix + "header_color_blue", 192));
+    colorHeader = new ColorInput(col, false);
+    col = new Color((int) settings.getInt(settingPrefix + "color_red", 192),
         (int) settings.getInt(settingPrefix + "color_green", 192),
         (int) settings.getInt(settingPrefix + "color_blue", 192));
-    colorChooser = new ColorInput(col, false);
+    colorTable = new ColorInput(col, false);
     tabFont.addHeadline("Tabellen Spaltennamen");
     tabFont.addLabelPair("Schriftart", fontHeader);
     tabFont.addLabelPair("Schriftgröße", fontsizeHeader);
-    tabFont.addLabelPair("Hintergrund Farbe", colorChooser);
+    tabFont.addLabelPair("Hintergrund Farbe", colorHeader);
     tabFont.addHeadline("Tabellen Inhalt");
     tabFont.addLabelPair("Schriftart Standard", fontNormal);
     tabFont.addLabelPair("Schriftart Fett", fontFett);
     tabFont.addLabelPair("Schriftart Kursiv", fontItalic);
+    tabFont.addLabelPair("Hintergrund Farbe", colorTable);
     tabFont.addLabelPair("Schriftgröße", fontsize);
     tabFont.addLabelPair("Negative Werte in Rot", negativRot);
   }
@@ -350,7 +357,14 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
           (Integer) fontsize.getValue());
       settings.setAttribute(settingPrefix + "negativ_rot",
           (Boolean) negativRot.getValue());
-      Color col = (Color) colorChooser.getValue();
+      Color col = (Color) colorHeader.getValue();
+      settings.setAttribute(settingPrefix + "header_color_red",
+          (Integer) col.getRed());
+      settings.setAttribute(settingPrefix + "header_color_green",
+          (Integer) col.getGreen());
+      settings.setAttribute(settingPrefix + "header_color_blue",
+          (Integer) col.getBlue());
+      col = (Color) colorTable.getValue();
       settings.setAttribute(settingPrefix + "color_red",
           (Integer) col.getRed());
       settings.setAttribute(settingPrefix + "color_green",
@@ -401,7 +415,13 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   protected BaseColor getHintergrundHeader()
   {
-    Color col = (Color) colorChooser.getValue();
+    Color col = (Color) colorHeader.getValue();
+    return new BaseColor(col.getRed(), col.getGreen(), col.getBlue());
+  }
+
+  protected BaseColor getHintergrundTabelle()
+  {
+    Color col = (Color) colorTable.getValue();
     return new BaseColor(col.getRed(), col.getGreen(), col.getBlue());
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -22,9 +22,15 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.TabFolder;
 
+import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.FontFactory;
+import com.itextpdf.text.pdf.BaseFont;
+
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.input.FontInput;
 import de.jost_net.JVerein.gui.input.FormularInput;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.FileViewer;
@@ -86,6 +92,20 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   protected CheckboxInput zellenTransparent;
 
+  protected SelectInput fontNormal;
+
+  protected SelectInput fontFett;
+
+  protected SelectInput fontItalic;
+
+  protected IntegerInput fontsizeNormal;
+
+  protected IntegerInput fontsizeFett;
+
+  protected IntegerInput fontsizeItalic;
+
+  protected CheckboxInput negativRot;
+
   public AbstractPartExportDialog(String settingPrefix, ExportArt art,
       String title, String subtitle, String filename)
       throws ApplicationException
@@ -138,13 +158,16 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
     TabGroup tabRaender = new TabGroup(folder, "Ränder", true, 2);
     TabGroup tabFormular = new TabGroup(folder, "Formular", true, 2);
+    TabGroup tabFont = new TabGroup(folder, "Schriftart", true, 2);
 
+    // Spalten
     tabSpalten.addPart(spaltenList);
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(
         new Button("Breiten zurücksetzen", action, null, false, "eraser.png"));
     tabSpalten.addButtonArea(buttons);
 
+    // Ränder
     links = new IntegerInput(settings.getInt(settingPrefix + "links", 20));
     rechts = new IntegerInput(settings.getInt(settingPrefix + "rechts", 20));
     oben = new IntegerInput(settings.getInt(settingPrefix + "oben", 20));
@@ -167,6 +190,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     // tabRaender.addLabelPair("Oben ab 2. Seite", oben2);
     // tabRaender.addLabelPair("Unten ab 2. Seite", unten2);
 
+    // Formular
     hintergrund = new FormularInput(FormularArt.HINTERGRUND,
         settings.getString(settingPrefix + "hintergrund", ""));
     hintergrund.setPleaseChoose("Kein Formular");
@@ -186,6 +210,29 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     tabFormular.addLabelPair("Tabellen Header transparent", headerTransparent);
     tabFormular.addLabelPair("Tabellen Zellen transparent", zellenTransparent);
     tabFormular.addLabelPair("Querformat", querformat);
+
+    // Schriftart
+    fontNormal = new FontInput(
+        settings.getString(settingPrefix + "font_normal", "FreeSans"));
+    fontFett = new FontInput(
+        settings.getString(settingPrefix + "font_fett", "FreeSans-Bold"));
+    fontItalic = new FontInput(
+        settings.getString(settingPrefix + "font_italic", "FreeSans-Oblique"));
+    fontsizeNormal = new IntegerInput(
+        settings.getInt(settingPrefix + "fontsize_normal", 8));
+    fontsizeFett = new IntegerInput(
+        settings.getInt(settingPrefix + "fontsize_fett", 8));
+    fontsizeItalic = new IntegerInput(
+        settings.getInt(settingPrefix + "fontsize_italic", 8));
+    negativRot = new CheckboxInput(
+        settings.getBoolean(settingPrefix + "negativ_rot", true));
+    tabFont.addLabelPair("Schriftart Standard", fontNormal);
+    tabFont.addLabelPair("Schriftgröße Standard", fontsizeNormal);
+    tabFont.addLabelPair("Schriftart Fett", fontFett);
+    tabFont.addLabelPair("Schriftgröße Fett", fontsizeFett);
+    tabFont.addLabelPair("Schriftart Kursiv", fontItalic);
+    tabFont.addLabelPair("Schriftgröße Kursiv", fontsizeItalic);
+    tabFont.addLabelPair("Negative Werte in Rot", negativRot);
   }
 
   protected void export() throws ApplicationException
@@ -276,7 +323,54 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
       settings.setAttribute(settingPrefix + "quer",
           (Boolean) querformat.getValue());
+
+      settings.setAttribute(settingPrefix + "font_normal",
+          (String) fontNormal.getValue());
+      settings.setAttribute(settingPrefix + "font_fett",
+          (String) fontFett.getValue());
+      settings.setAttribute(settingPrefix + "font_italic",
+          (String) fontItalic.getValue());
+      settings.setAttribute(settingPrefix + "fontsize_normal",
+          (Integer) fontsizeNormal.getValue());
+      settings.setAttribute(settingPrefix + "fontsize_fett",
+          (Integer) fontsizeFett.getValue());
+      settings.setAttribute(settingPrefix + "fontsize_italic",
+          (Integer) fontsizeItalic.getValue());
+      settings.setAttribute(settingPrefix + "negativ_rot",
+          (Boolean) negativRot.getValue());
     }
+  }
+
+  protected Font getFontNormal(BaseColor color)
+  {
+    return FontFactory.getFont(
+        "/fonts/" + (String) fontNormal.getValue() + ".ttf",
+        BaseFont.IDENTITY_H, (Integer) fontsizeNormal.getValue(),
+        Font.UNDEFINED, getColor(color));
+  }
+
+  protected Font getFontFett(BaseColor color)
+  {
+    return FontFactory.getFont(
+        "/fonts/" + (String) fontFett.getValue() + ".ttf", BaseFont.IDENTITY_H,
+        (Integer) fontsizeFett.getValue(), Font.UNDEFINED, getColor(color));
+  }
+
+  protected Font getFontKursiv(BaseColor color)
+  {
+    return FontFactory.getFont(
+        "/fonts/" + (String) fontItalic.getValue() + ".ttf",
+        BaseFont.IDENTITY_H, (Integer) fontsizeItalic.getValue(), Font.ITALIC,
+        getColor(color));
+  }
+
+  private BaseColor getColor(BaseColor color)
+  {
+    if (!(Boolean) negativRot.getValue())
+    {
+      color = BaseColor.BLACK;
+    }
+    return color;
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -249,9 +249,11 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     tabFont.addLabelPair("Schriftart Standard", fontNormal);
     tabFont.addLabelPair("Schriftart Fett", fontFett);
     tabFont.addLabelPair("Schriftart Kursiv", fontItalic);
-    tabFont.addLabelPair("Hintergrund Farbe", colorTable);
+    tabFont.addLabelPair("Hintergrund Farbe *", colorTable);
     tabFont.addLabelPair("Schriftgröße", fontsize);
     tabFont.addLabelPair("Negative Werte in Rot", negativRot);
+    tabFont.addSeparator();
+    tabFont.addText("* Bei Zeilen mit Hintergrundfarbe", false);
   }
 
   protected void export() throws ApplicationException

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -249,8 +249,8 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     tabFont.addLabelPair("Schriftart Standard", fontNormal);
     tabFont.addLabelPair("Schriftart Fett", fontFett);
     tabFont.addLabelPair("Schriftart Kursiv", fontItalic);
-    tabFont.addLabelPair("Hintergrund Farbe *", colorTable);
     tabFont.addLabelPair("Schriftgröße", fontsize);
+    tabFont.addLabelPair("Hintergrund Farbe *", colorTable);
     tabFont.addLabelPair("Negative Werte in Rot", negativRot);
     tabFont.addSeparator();
     tabFont.addText("* Bei Zeilen mit Hintergrundfarbe", false);

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -24,9 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
@@ -206,8 +204,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         reporter.addHeaderColumn(col.getText(),
             col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                 : Element.ALIGN_RIGHT,
-            (int) col.getData(), BaseColor.LIGHT_GRAY,
-            getFontNormal(BaseColor.BLACK));
+            (int) col.getData(), getHintergrundHeader(),
+            getFontHeader(BaseColor.BLACK));
       }
       reporter.createHeader();
 
@@ -217,39 +215,11 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         {
           int index = listeOrig.indexOf(col);
           String text = row.getText(index);
-          BaseColor color = BaseColor.BLACK;
-          try
-          {
-            String text2 = text.replaceAll("\\.", "").replaceAll("\\,", "\\.");
-            Double value = Double.valueOf(text2);
-            if (value < 0)
-            {
-              color = BaseColor.RED;
-            }
-          }
-          catch (NumberFormatException ex)
-          {
-            // Dann bleibt es Schwarz
-          }
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
           Color bg = (Color) row.getData("background");
-          Font font = null;
-          for (FontData data : row.getFont(index).getFontData())
-          {
-            switch (data.getStyle())
-            {
-              case SWT.BOLD:
-                font = getFontFett(color);
-                break;
-              case SWT.ITALIC:
-                font = getFontKursiv(color);
-                break;
-              case SWT.NORMAL:
-                font = getFontNormal(color);
-                break;
-            }
-          }
+          Font font = getFont(text, row.getFont(index).getFontData());
+
           if (bg == null)
           {
             reporter.addColumn(text,

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -206,7 +206,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         reporter.addHeaderColumn(col.getText(),
             col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                 : Element.ALIGN_RIGHT,
-            (int) col.getData(), BaseColor.LIGHT_GRAY);
+            (int) col.getData(), BaseColor.LIGHT_GRAY,
+            getFontNormal(BaseColor.BLACK));
       }
       reporter.createHeader();
 
@@ -215,6 +216,21 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         for (TableColumn col : listeAuswahl)
         {
           int index = listeOrig.indexOf(col);
+          String text = row.getText(index);
+          BaseColor color = BaseColor.BLACK;
+          try
+          {
+            String text2 = text.replaceAll("\\.", "").replaceAll("\\,", "\\.");
+            Double value = Double.valueOf(text2);
+            if (value < 0)
+            {
+              color = BaseColor.RED;
+            }
+          }
+          catch (NumberFormatException ex)
+          {
+            // Dann bleibt es Schwarz
+          }
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
           Color bg = (Color) row.getData("background");
@@ -224,26 +240,26 @@ public class TablePartExportDialog extends AbstractPartExportDialog
             switch (data.getStyle())
             {
               case SWT.BOLD:
-                font = Reporter.getFreeSansBold(8);
+                font = getFontFett(color);
                 break;
               case SWT.ITALIC:
-                font = Reporter.getFreeSansItalic(8);
+                font = getFontKursiv(color);
                 break;
               case SWT.NORMAL:
-                font = Reporter.getFreeSans(8);
+                font = getFontNormal(color);
                 break;
             }
           }
           if (bg == null)
           {
-            reporter.addColumn(row.getText(index),
+            reporter.addColumn(text,
                 col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                     : Element.ALIGN_RIGHT,
                 font);
           }
           else
           {
-            reporter.addColumn(row.getText(index),
+            reporter.addColumn(text,
                 col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                     : Element.ALIGN_RIGHT,
                 new BaseColor(bg.getRed(), bg.getGreen(), bg.getBlue()), font);

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -232,7 +232,7 @@ public class TablePartExportDialog extends AbstractPartExportDialog
             reporter.addColumn(text,
                 col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                     : Element.ALIGN_RIGHT,
-                new BaseColor(bg.getRed(), bg.getGreen(), bg.getBlue()), font);
+                getHintergrundTabelle(), font);
           }
         }
       }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -24,9 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
@@ -268,8 +266,8 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         reporter.addHeaderColumn(col.getText(),
             col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                 : Element.ALIGN_RIGHT,
-            (int) col.getData(), BaseColor.LIGHT_GRAY,
-            getFontNormal(BaseColor.BLACK));
+            (int) col.getData(), getHintergrundHeader(),
+            getFontHeader(BaseColor.BLACK));
       }
       reporter.createHeader();
 
@@ -279,39 +277,12 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         {
           int index = listeOrig.indexOf(col);
           String text = row.getTreeItem().getText(index);
-          BaseColor color = BaseColor.BLACK;
-          try
-          {
-            String text2 = text.replaceAll("\\.", "").replaceAll("\\,", "\\.");
-            Double value = Double.valueOf(text2);
-            if (value < 0)
-            {
-              color = BaseColor.RED;
-            }
-          }
-          catch (NumberFormatException ex)
-          {
-            // Dann bleibt es Schwarz
-          }
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
           Color bg = (Color) row.getTreeItem().getData("background");
-          Font font = null;
-          for (FontData data : row.getTreeItem().getFont(index).getFontData())
-          {
-            switch (data.getStyle())
-            {
-              case SWT.BOLD:
-                font = getFontFett(color);
-                break;
-              case SWT.ITALIC:
-                font = getFontKursiv(color);
-                break;
-              case SWT.NORMAL:
-                font = getFontNormal(color);
-                break;
-            }
-          }
+          Font font = getFont(text,
+              row.getTreeItem().getFont(index).getFontData());
+
           int alignment = col.getAlignment() == Column.ALIGN_LEFT
               ? Element.ALIGN_LEFT
               : Element.ALIGN_RIGHT;

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -268,7 +268,8 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         reporter.addHeaderColumn(col.getText(),
             col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
                 : Element.ALIGN_RIGHT,
-            (int) col.getData(), BaseColor.LIGHT_GRAY);
+            (int) col.getData(), BaseColor.LIGHT_GRAY,
+            getFontNormal(BaseColor.BLACK));
       }
       reporter.createHeader();
 
@@ -277,6 +278,21 @@ public class TreePartExportDialog extends AbstractPartExportDialog
         for (TreeColumn col : listeAuswahl)
         {
           int index = listeOrig.indexOf(col);
+          String text = row.getTreeItem().getText(index);
+          BaseColor color = BaseColor.BLACK;
+          try
+          {
+            String text2 = text.replaceAll("\\.", "").replaceAll("\\,", "\\.");
+            Double value = Double.valueOf(text2);
+            if (value < 0)
+            {
+              color = BaseColor.RED;
+            }
+          }
+          catch (NumberFormatException ex)
+          {
+            // Dann bleibt es Schwarz
+          }
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
           Color bg = (Color) row.getTreeItem().getData("background");
@@ -286,13 +302,13 @@ public class TreePartExportDialog extends AbstractPartExportDialog
             switch (data.getStyle())
             {
               case SWT.BOLD:
-                font = Reporter.getFreeSansBold(8);
+                font = getFontFett(color);
                 break;
               case SWT.ITALIC:
-                font = Reporter.getFreeSansItalic(8);
+                font = getFontKursiv(color);
                 break;
               case SWT.NORMAL:
-                font = Reporter.getFreeSans(8);
+                font = getFontNormal(color);
                 break;
             }
           }
@@ -305,12 +321,11 @@ public class TreePartExportDialog extends AbstractPartExportDialog
           }
           if (bg == null)
           {
-            reporter.addColumn(row.getTreeItem().getText(index), alignment,
-                font);
+            reporter.addColumn(text, alignment, font);
           }
           else
           {
-            reporter.addColumn(row.getTreeItem().getText(index), alignment,
+            reporter.addColumn(text, alignment,
                 new BaseColor(bg.getRed(), bg.getGreen(), bg.getBlue()), font);
           }
         }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -296,8 +296,7 @@ public class TreePartExportDialog extends AbstractPartExportDialog
           }
           else
           {
-            reporter.addColumn(text, alignment,
-                new BaseColor(bg.getRed(), bg.getGreen(), bg.getBlue()), font);
+            reporter.addColumn(text, alignment, getHintergrundTabelle(), font);
           }
         }
       }

--- a/src/main/java/de/jost_net/JVerein/gui/input/FontInput.java
+++ b/src/main/java/de/jost_net/JVerein/gui/input/FontInput.java
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+
+package de.jost_net.JVerein.gui.input;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+
+import de.willuhn.jameica.gui.input.SelectInput;
+
+/**
+ * Combo-Box, fuer die Font Auswahl.
+ */
+public class FontInput extends SelectInput
+{
+
+  public FontInput(String font) throws RemoteException
+  {
+    super(init(), font);
+    setName("Font");
+  }
+
+  /**
+   * @return initialisiert die Liste der Fonts.
+   * @throws RemoteException
+   */
+  private static ArrayList<String> init()
+  {
+    ArrayList<String> fonts = new ArrayList<>();
+    fonts.add("PTSans-Regular");
+    fonts.add("PTSans-Bold");
+    fonts.add("PTSans-Italic");
+    fonts.add("PTSans-BoldItalic");
+    fonts.add("FreeSans");
+    fonts.add("FreeSans-Bold");
+    fonts.add("FreeSans-BoldOblique");
+    fonts.add("FreeSans-Oblique");
+    fonts.add("Courier Prime");
+    fonts.add("Courier Prime Bold");
+    fonts.add("Courier Prime Bold Italic");
+    fonts.add("Courier Prime Italic");
+    fonts.add("LiberationSans-Bold");
+    fonts.add("LiberationSans-BoldItalic");
+    fonts.add("LiberationSans-Italic");
+    fonts.add("LiberationSans-Regular");
+    fonts.add("LiberationSerif-Bold");
+    fonts.add("LiberationSerif-BoldItalic");
+    fonts.add("LiberationSerif-Italic");
+    fonts.add("LiberationSerif-Regular");
+    return fonts;
+  }
+
+}

--- a/src/main/java/de/jost_net/JVerein/io/Reporter.java
+++ b/src/main/java/de/jost_net/JVerein/io/Reporter.java
@@ -104,8 +104,8 @@ public class Reporter implements AutoCloseable
 
   public static Font getFreeSansItalic(float size, BaseColor color)
   {
-    return FontFactory.getFont("/fonts/FreeSansItalic.ttf", BaseFont.IDENTITY_H,
-        size, Font.ITALIC, color);
+    return FontFactory.getFont("/fonts/FreeSans-Oblique.ttf",
+        BaseFont.IDENTITY_H, size, Font.ITALIC, color);
   }
 
   public static Font getFreeSansItalic(float size)
@@ -300,8 +300,23 @@ public class Reporter implements AutoCloseable
   public void addHeaderColumn(String text, int align, int width,
       BaseColor color)
   {
+    addHeaderColumn(text, align, width, color, getFreeSans(8));
+  }
+
+  /**
+   * Fuegt der Tabelle einen neuen Spaltenkopf hinzu.
+   * 
+   * @param text
+   * @param align
+   * @param width
+   * @param color
+   * @param font
+   */
+  public void addHeaderColumn(String text, int align, int width,
+      BaseColor color, Font font)
+  {
     headers.add(getDetailCell(text, align, headerTransparent ? null : color,
-        true, getFreeSans(8), 1));
+        true, font, 1));
     widths.add(width);
   }
 


### PR DESCRIPTION
Ich habe den Tabellenexport erweitert, so dass man die Schriftart und Schriftgröße für Normal, Fett und Kursiv konfigurieren kann. 
Für die Spaltennamen kann man separat Schriftart, Schriftgröße und Hintergrundfarbe konfigurieren.
Auch kann man auswählen, ob negative Werte in roter Schrift sein sollen. Ich habe gesehen, dass bei meinem Schwarz/Weiß Druck die rote Farbe ein Grau wird und evtl. schwerer lesbar. In dem Fall würde ich auf Schwarze Farbe stellen.
<img width="396" height="552" alt="Bildschirmfoto_20260624_102425" src="https://github.com/user-attachments/assets/eb25d65d-2e60-4923-977b-2ea8cddd614a" />

Beispiel:
<img width="749" height="291" alt="Bildschirmfoto_20260624_100447" src="https://github.com/user-attachments/assets/89fc96ce-901f-498e-b4ca-8ac64251b3e2" />


PS: Im Reporter gab es FreeSansItalic was wir aber nicht im Font Verzeuchnis haben. Ich habe es durch FreeSans-Oblique ersetzt.
