### PR TITLE
Fix Mail

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/MailControl.java
@@ -494,8 +494,8 @@ public class MailControl extends FilterControl implements IMailControl, Savable
                 String textParsed = VelocityTool.eval(map, txt);
                 try
                 {
-                  sender.sendMail(empf.getMailAdresse(), textParsed,
-                      betreffParsed, getMail().getAnhang());
+                  sender.sendMail(empf.getMailAdresse(), betreffParsed,
+                      textParsed, getMail().getAnhang());
                 }
                 // Wenn eine ApplicationException geworfen wurde, wurde die
                 // Mails erfolgreich versendet, erst danach trat ein Fehler auf.


### PR DESCRIPTION
Beim Mailverssand waren Betreff und Text vertauscht. Siehe https://jverein-forum.de/viewtopic.php?p=21591#p21591
Danach würde ich direkt eine 4.2.1 rausgeben.