### PR TITLE
Fix Sollbuchungszuordnung Zweck

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
@@ -485,7 +485,7 @@ public class BuchungenSollbuchungZuordnungDialog extends AbstractDialog<Object>
                   break;
                 case ZWECK:
                   buchungIt.addFilter(
-                      "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(LOWER(buchung.name),"
+                      "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(LOWER(buchung.zweck),"
                           + "'ss', 's'),'ß', 's'),'ue', 'u'),'oe', 'o'),'ü', 'u'),'ö', 'o'),'ae', 'a'),'ä', 'a')"
                           + " LIKE CONCAT('%',?,'%')",
                       umlauteEretzen(


### PR DESCRIPTION
Bei der Sollbuchungzuordnung war ein Fehler, bei Zuordnung nach Zweck wurde der Name statt der Zweck verwendet.