### PR TITLE
Fix Wirtschaftsplan Export

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/WirtschaftsplanExporterPDF.java
+++ b/src/main/java/de/jost_net/JVerein/io/WirtschaftsplanExporterPDF.java
@@ -431,8 +431,8 @@ public class WirtschaftsplanExporterPDF implements Exporter
                     {
                       return;
                     }
-                    reporter.addColumn(postenEntry.getKey(),
-                        Element.ALIGN_RIGHT);
+                    reporter.addColumn("      " + postenEntry.getKey(),
+                        Element.ALIGN_LEFT);
                   }
 
                   Double[][] values = postenEntry.getValue();
@@ -440,11 +440,12 @@ public class WirtschaftsplanExporterPDF implements Exporter
                   for (Double[] betrag : values)
                   {
                     i++;
-                    reporter.addColumn(betrag[0], new BaseColor(230, 230, 230));
+                    reporter.addColumn(betrag[0] == null ? 0 : betrag[0],
+                        new BaseColor(230, 230, 230));
 
                     if (hatIst.contains(wirtschaftsplaene[i]))
                     {
-                      double wert = 0d;
+                      Double wert = null;
                       // Ist nur bei Buchungsart
                       if ("-".equals(postenEntry.getKey()))
                       {

--- a/src/main/java/de/jost_net/JVerein/io/WirtschaftsplanExporterPDFKlasse.java
+++ b/src/main/java/de/jost_net/JVerein/io/WirtschaftsplanExporterPDFKlasse.java
@@ -408,7 +408,7 @@ public class WirtschaftsplanExporterPDFKlasse implements Exporter
                       // Ist nur bei Buchungsart
                       if ("-".equals(postenEntry.getKey()))
                       {
-                        d = betrag[1];
+                        d = betrag[1] == null ? 0 : betrag[1];
 
                       }
                       reporter.addColumn(d);


### PR DESCRIPTION
Beim Wirtschaftsplan Exports sollten bei Sollwerten von null eine 0 ausgegeben werden. Bei Positionen ohne Wert sollte null ausgegeben werden.
Bei den Reports war bei jedem der eine oder andere Punkt falsch. Jetzt ist es angeglichen. Auch habe ich bei dem einen Reports die Positionen linksbündig mit Einrücken gemacht so wie bei dem anderen.