### PR TITLE
Fix Buchungsliste Report

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/BuchungAuswertungEinzelExportPDF.java
+++ b/src/main/java/de/jost_net/JVerein/io/BuchungAuswertungEinzelExportPDF.java
@@ -221,6 +221,10 @@ public class BuchungAuswertungEinzelExportPDF extends BuchungAuswertungExportPDF
       reporter.addColumn("", Element.ALIGN_LEFT);
       reporter.addColumn("Gesamtsumme", Element.ALIGN_LEFT);
       reporter.addColumn(summe);
+      if ((Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))
+      {
+        reporter.addColumn("", Element.ALIGN_LEFT);
+      }
       reporter.closeTable();
     }
 
@@ -237,6 +241,10 @@ public class BuchungAuswertungEinzelExportPDF extends BuchungAuswertungExportPDF
       reporter.addColumn("", Element.ALIGN_LEFT);
       reporter.addColumn("Keine Buchungen", Element.ALIGN_LEFT);
       reporter.addColumn("", Element.ALIGN_LEFT);
+      if ((Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))
+      {
+        reporter.addColumn("", Element.ALIGN_LEFT);
+      }
       reporter.closeTable();
     }
     reporter.addParams(control.getParams());
@@ -362,6 +370,10 @@ public class BuchungAuswertungEinzelExportPDF extends BuchungAuswertungExportPDF
           Element.ALIGN_LEFT);
       summe += buchungsartSumme;
       reporter.addColumn(buchungsartSumme);
+    }
+    if ((Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))
+    {
+      reporter.addColumn("", Element.ALIGN_LEFT);
     }
     reporter.closeTable();
     return true;


### PR DESCRIPTION
Bei der Buchungsliste wurde am Ende die Gesamtsumme nicht angezeigt wenn Steuer in Buchung ausgewählt ist.