### PR TITLE
Fix Sollbuchung Zuordnen Dialog

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/BuchungSollbuchungZuordnungAction.java
@@ -195,6 +195,9 @@ public class BuchungSollbuchungZuordnungAction implements Action
       sbp.setZweck(buchung.getZweck());
       sbp.setSollbuchung(sollb.getID());
       sbp.store();
+
+      buchung.setSollbuchung(sollb);
+      buchung.store();
     }
   }
 


### PR DESCRIPTION
Im SollbuchungZuordnenDialog fürde beim erstellen der Sollbuchung diese nicht der Buchung zugeordnet.