### PR TITLE
Fix Automatische Sollbocungszuordnung

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
@@ -277,7 +277,7 @@ public class BuchungenSollbuchungZuordnungDialog extends AbstractDialog<Object>
 
             it.addColumn(
                 "sollbuchung.betrag -sum(COALESCE(buchung.betrag,0)) as fehlbetrag");
-            it.addHaving("ABS(fehlbetrag) > 0.01");
+            it.addHaving("ABS(fehlbetrag) >= 0.01");
             it.addColumn("sollbuchung.zweck1 as sollbuchung_zweck");
 
             it.leftJoin("mitglied", "mitglied.id = sollbuchung.mitglied");

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/BuchungenSollbuchungZuordnungDialog.java
@@ -276,8 +276,8 @@ public class BuchungenSollbuchungZuordnungDialog extends AbstractDialog<Object>
             it.leftJoin("buchung", "buchung.sollbuchung = sollbuchung.id");
 
             it.addColumn(
-                "sum(sollbuchung.betrag -COALESCE(buchung.betrag,0)) as fehlbetrag");
-            it.addHaving("fehlbetrag != 0");
+                "sollbuchung.betrag -sum(COALESCE(buchung.betrag,0)) as fehlbetrag");
+            it.addHaving("ABS(fehlbetrag) > 0.01");
             it.addColumn("sollbuchung.zweck1 as sollbuchung_zweck");
 
             it.leftJoin("mitglied", "mitglied.id = sollbuchung.mitglied");


### PR DESCRIPTION
Wenn eine Sollbuchung mehrere Buchungen zugeordnet hatte, wurde sie bei der automatischen Sollbuchungszuordnung nicht als bezahlt erkannt und trotzdem nochmal zugeordnet.