### PR TITLE
Fix EigenschaftenAuswahl Mails

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/MailEmpfaengerAuswahlDialog.java
@@ -100,7 +100,8 @@ public class MailEmpfaengerAuswahlDialog extends AbstractDialog<Object>
       {
         try
         {
-          EigenschaftenAuswahlDialog ead = new EigenschaftenAuswahlDialog(null);
+          EigenschaftenAuswahlDialog ead = new EigenschaftenAuswahlDialog(
+              param);
           param = ead.open();
           setSelection();
         }


### PR DESCRIPTION
Bei der Eigenschaftenauswahl der Mails waren die Eigenschaften immer alle Abgewählt, wenn der Eigenschaftendialog geöffnet wurde, die Übergabe der params hat gefehlt.