### PR TITLE
Fix Mail Versand Datum bei Mitglied

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/action/PseudoDBObjectDeleteAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/PseudoDBObjectDeleteAction.java
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.server.AbstractJVereinDBObject;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class PseudoDBObjectDeleteAction extends DeleteAction
+{
+  private Class<? extends DBObject> objectClass;
+
+  public PseudoDBObjectDeleteAction(Class<? extends DBObject> objectClass)
+  {
+    this.objectClass = objectClass;
+  }
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    try
+    {
+      if (!(context instanceof PseudoDBObject
+          || context instanceof PseudoDBObject[]))
+      {
+        throw new ApplicationException("Kein Objekt ausgewählt");
+      }
+
+      PseudoDBObject[] pseudoObjects;
+      if (context instanceof PseudoDBObject)
+      {
+        pseudoObjects = new PseudoDBObject[] { (PseudoDBObject) context };
+      }
+      else
+      {
+        pseudoObjects = (PseudoDBObject[]) context;
+      }
+
+      List<AbstractJVereinDBObject> jvereinDBObjects = new ArrayList<>();
+      for (PseudoDBObject o : pseudoObjects)
+      {
+        if (o.getAttribute(PseudoDBObject.ID) != null)
+        {
+          jvereinDBObjects.add(Einstellungen.getDBService().createObject(
+              objectClass, o.getAttribute(PseudoDBObject.ID).toString()));
+        }
+      }
+
+      super.handleAction(
+          jvereinDBObjects.toArray(new AbstractJVereinDBObject[0]));
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Serverfehler", e);
+      throw new ApplicationException("Serverfehler", e);
+    }
+  }
+
+  protected void doFinally() throws RemoteException, ApplicationException
+  {
+    GUI.getCurrentView().reload();
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/action/PseudoDBObjectEditAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/PseudoDBObjectEditAction.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.server.PseudoDBObject;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class PseudoDBObjectEditAction implements Action
+{
+  private Class<? extends DBObject> objectClass;
+
+  private Class<? extends AbstractView> viewClass;
+
+  public PseudoDBObjectEditAction(Class<? extends DBObject> objectClass,
+      Class<? extends AbstractView> viewClass)
+  {
+    this.objectClass = objectClass;
+    this.viewClass = viewClass;
+  }
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    try
+    {
+      if (!(context instanceof PseudoDBObject))
+      {
+        throw new ApplicationException("Kein Objekt ausgewählt");
+      }
+      PseudoDBObject o = (PseudoDBObject) context;
+      if (o.getAttribute(PseudoDBObject.ID) != null)
+      {
+        String id = o.getAttribute(PseudoDBObject.ID).toString();
+        Object object = Einstellungen.getDBService().createObject(objectClass,
+            id);
+        GUI.startView(viewClass, object);
+      }
+      else
+      {
+        throw new ApplicationException("Eintrag kann nicht bearbeitet werden");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Serverfehler", e);
+      throw new ApplicationException("Serverfehler", e);
+    }
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/control/MitgliedControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/MitgliedControl.java
@@ -40,6 +40,7 @@ import de.jost_net.JVerein.Queries.MitgliedQuery.MitgliedAuswahl;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.action.LesefelddefinitionenAction;
 import de.jost_net.JVerein.gui.action.MitgliedDetailAction;
+import de.jost_net.JVerein.gui.action.PseudoDBObjectEditAction;
 import de.jost_net.JVerein.gui.action.NewAction;
 import de.jost_net.JVerein.gui.action.NichtMitgliedDetailAction;
 import de.jost_net.JVerein.gui.action.SollbuchungNeuAction;
@@ -68,7 +69,7 @@ import de.jost_net.JVerein.gui.input.VollzahlerInput;
 import de.jost_net.JVerein.gui.input.VollzahlerSearchInput;
 import de.jost_net.JVerein.gui.menu.ArbeitseinsatzMenu;
 import de.jost_net.JVerein.gui.menu.LehrgangMenu;
-import de.jost_net.JVerein.gui.menu.MailMenu;
+import de.jost_net.JVerein.gui.menu.MitgliedMailMenu;
 import de.jost_net.JVerein.gui.menu.MitgliedMenu;
 import de.jost_net.JVerein.gui.menu.MitgliedNextBGruppeMenue;
 import de.jost_net.JVerein.gui.menu.WiedervorlageMenu;
@@ -126,6 +127,8 @@ import de.jost_net.JVerein.rmi.Wiedervorlage;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.rmi.Zusatzfelder;
 import de.jost_net.JVerein.server.EigenschaftenNode;
+import de.jost_net.JVerein.server.ExtendedDBIterator;
+import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.JVDateFormatTIMESTAMP;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
@@ -1667,21 +1670,31 @@ public class MitgliedControl extends FilterControl implements Savable
     {
       return mailList;
     }
-    DBService service = Einstellungen.getDBService();
-    DBIterator<Mail> me = service.createList(Mail.class);
-    me.join("mailempfaenger");
-    me.addFilter("mailempfaenger.mail = mail.id");
-    me.addFilter("mailempfaenger.mitglied = ?", getMitglied().getID());
-    mailList = new JVereinTablePart(me, new EditAction(MailDetailView.class));
+    ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<PseudoDBObject>(
+        "mail");
+    it.join("mailempfaenger");
+    it.addFilter("mailempfaenger.mail = mail.id");
+    it.addFilter("mailempfaenger.mitglied = ?", getMitglied().getID());
+    it.join("mailanhang");
+    it.addFilter("mailanhang.mail = mail.id");
+    it.addColumn("mail.id as " + PseudoDBObject.ID);
+    it.addColumn("bearbeitung");
+    it.addColumn("mailempfaenger.versand as versand");
+    it.addColumn("betreff");
+    it.addColumn("count(mailanhang.id) as anhaenge");
+    it.addGroupBy("mailempfaenger.mail");
+    mailList = new JVereinTablePart(it,
+        new PseudoDBObjectEditAction(Mail.class, MailDetailView.class));
     mailList.setTableName("Mails");
     mailList.setMulti(true);
+    mailList.addColumn("Id", PseudoDBObject.ID);
     mailList.addColumn("Bearbeitung", "bearbeitung",
         new DateFormatter(new JVDateFormatTIMESTAMP()));
     mailList.addColumn("Versand", "versand",
         new DateFormatter(new JVDateFormatTIMESTAMP()));
     mailList.addColumn("Betreff", "betreff");
     mailList.addColumn("Anhänge", "anhaenge");
-    mailList.setContextMenu(new MailMenu(null));
+    mailList.setContextMenu(new MitgliedMailMenu());
     return mailList;
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/menu/MitgliedMailMenu.java
+++ b/src/main/java/de/jost_net/JVerein/gui/menu/MitgliedMailMenu.java
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.menu;
+
+import de.jost_net.JVerein.gui.action.PseudoDBObjectDeleteAction;
+import de.jost_net.JVerein.gui.action.PseudoDBObjectEditAction;
+import de.jost_net.JVerein.gui.view.MailDetailView;
+import de.jost_net.JVerein.rmi.Mail;
+import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+
+/**
+ * Kontext-Menu zu den Mails.
+ */
+public class MitgliedMailMenu extends ContextMenu
+{
+
+  public MitgliedMailMenu()
+  {
+    addItem(new CheckedSingleContextMenuItem("Bearbeiten",
+        new PseudoDBObjectEditAction(Mail.class, MailDetailView.class),
+        "text-x-generic.png"));
+    addItem(new CheckedContextMenuItem("Löschen",
+        new PseudoDBObjectDeleteAction(Mail.class), "user-trash-full.png"));
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/server/PseudoDBObject.java
+++ b/src/main/java/de/jost_net/JVerein/server/PseudoDBObject.java
@@ -20,6 +20,8 @@ public class PseudoDBObject extends AbstractDBObject implements DBObject
 
   private static final long serialVersionUID = 1L;
 
+  public static final String ID = "id";
+
   public PseudoDBObject() throws RemoteException
   {
     super();


### PR DESCRIPTION
In der Mail Liste im MitgliedDetailView wurde in der Spalte Versand das Datum aus der Mail angezeigt. Dieses ist aber das Datum des letzten Versand bzw. null wenn die Mail editiert wurde. In Mailempfaenger ist gespeichert wann die Mail an das Mitglied gesendet wurde. Dieses sollte hier angezeigt werden. Eine Mail kann mehrere Empfänger mit unterschiedlichem Versanddatum haben.

Ich habe das korrigiert und das Query so gemacht, dass das Versanddatum und auch die Information über die Anzahl der Anhänge mit einem Query geholt werden. Jetzt sind aber nicht mehr Mails in der Liste sondern PseudoDBObject.

Damit kann man die Edit und Delete Actions so nicht mehr benutzen. Ich habe neue generische Actions erstellt die dazu benutzt werden können. Ein Durchblättern der Liste mit vor und zurück ist mit dem Edit aber nicht möglich und hier auch nicht nötig.