### PR TITLE
Mail löschen erlauben wenn Geschäftsjahr nicht abgeschlossen ist

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
@@ -912,7 +912,7 @@ public class DbBereinigenControl extends AbstractControl
         try
         {
           mail = it.next();
-          mail.deleteForced();
+          mail.delete();
           count++;
         }
         catch (OperationCanceledException oce)

--- a/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
@@ -71,11 +71,6 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
     try
     {
       dateinameCheck(getDateiname());
-      if (getMail().getVersand() != null)
-      {
-        throw new ApplicationException(
-            "Der Mailanhang kann nicht eingefügt werden, die Mail wurde schon versendet!");
-      }
     }
     catch (RemoteException e)
     {
@@ -83,7 +78,6 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }
-
   }
 
   private void dateinameCheck(String dateiname) throws ApplicationException

--- a/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
@@ -71,6 +71,11 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
     try
     {
       dateinameCheck(getDateiname());
+      if (getMail().getVersand() != null)
+      {
+        throw new ApplicationException(
+            "Der Mailanhang kann nicht eingefügt werden, die Mail wurde schon versendet!");
+      }
     }
     catch (RemoteException e)
     {

--- a/src/main/java/de/jost_net/JVerein/server/MailImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailImpl.java
@@ -19,6 +19,7 @@ package de.jost_net.JVerein.server;
 import java.rmi.RemoteException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
@@ -62,10 +63,19 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
     {
       if (getVersand() != null)
       {
+        Timestamp versand = new Timestamp(new Date().getTime());
+        List<MailEmpfaenger> empfaenger = getEmpfaenger(true);
+        for (MailEmpfaenger me : empfaenger)
+        {
+          if (me.getVersand() != null && me.getVersand().before(versand))
+          {
+            versand = me.getVersand();
+          }
+        }
         DBIterator<Jahresabschluss> it = Einstellungen.getDBService()
             .createList(Jahresabschluss.class);
-        it.addFilter("von <= ?", new Object[] { getVersand() });
-        it.addFilter("bis >= ?", new Object[] { getVersand() });
+        it.addFilter("von <= ?", versand);
+        it.addFilter("bis >= ?", versand);
         if (it.hasNext())
         {
           throw new ApplicationException(
@@ -112,20 +122,6 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
   protected void updateCheck() throws ApplicationException
   {
     insertCheck();
-    try
-    {
-      if (getVersand() != null)
-      {
-        throw new ApplicationException(
-            "Die Mail kann nicht geändert werden, sie wurde schon versendet!");
-      }
-    }
-    catch (RemoteException e)
-    {
-      String fehler = "Mail kann nicht gelöscht werden. Siehe system log";
-      Logger.error(fehler, e);
-      throw new ApplicationException(fehler);
-    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/MailImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailImpl.java
@@ -21,6 +21,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.MailAnhang;
 import de.jost_net.JVerein.rmi.MailEmpfaenger;
@@ -57,22 +58,26 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
   @Override
   protected void deleteCheck() throws ApplicationException
   {
-    if (!forcedDelete)
+    try
     {
-      try
+      if (getVersand() != null)
       {
-        if (getVersand() != null)
+        DBIterator<Jahresabschluss> it = Einstellungen.getDBService()
+            .createList(Jahresabschluss.class);
+        it.addFilter("von <= ?", new Object[] { getVersand() });
+        it.addFilter("bis >= ?", new Object[] { getVersand() });
+        if (it.hasNext())
         {
           throw new ApplicationException(
-              "Die Mail kann nicht gelöscht werden, sie wurde schon versendet!");
+              "Die Mail kann nicht gelöscht werden, das zugehörige Geschäftsjahr ist bereits abgeschlossen!");
         }
       }
-      catch (RemoteException e)
-      {
-        String fehler = "Mail kann nicht gelöscht werden. Siehe system log";
-        Logger.error(fehler, e);
-        throw new ApplicationException(fehler);
-      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Mail kann nicht gelöscht werden. Siehe system log";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
     }
   }
 
@@ -107,6 +112,20 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
   protected void updateCheck() throws ApplicationException
   {
     insertCheck();
+    try
+    {
+      if (getVersand() != null)
+      {
+        throw new ApplicationException(
+            "Die Mail kann nicht geändert werden, sie wurde schon versendet!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Mail kann nicht gelöscht werden. Siehe system log";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
+    }
   }
 
   @Override


### PR DESCRIPTION
Beim Löschen der Mail wird das nur noch verhindert wenn das zugehörige Geschäftsjahr bereits abgeschlossen ist. So kann man wie bei Buchungen Fehler vorher korrigieren und evtl. nicht steuerlich relevante Mails vor dem Abschluss löschen. Damit ist es zumindest konsistent mit den Buchungen.

Ganz GoBD konform werden wir ja nie werden. Das muss anders gehandhabt werden. Vielleicht sollten wir die Möglichkeit schaffen die Mail als Buchungsdokument in PDF zu generieren. Dann kann sie extern revisionssicher archiviert werden. Das war ja auch die Idee bei Rechnungen, Mahnungen und Spendenbescheinigungen.