### PR TITLE
Update Checks bei Mail und Fix Versanddatum

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/MailControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/MailControl.java
@@ -357,6 +357,11 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     ButtonRtoL b = new ButtonRtoL("Senden", context -> {
       try
       {
+        if (getEmpfaenger().getItems().size() == 0)
+        {
+          throw new ApplicationException(
+              "Es sind keine Empfänger eingetragen!");
+        }
         int toBeSentCount = 0;
         for (final MailEmpfaenger empf : (List<MailEmpfaenger>) getEmpfaenger()
             .getItems())
@@ -411,8 +416,10 @@ public class MailControl extends FilterControl implements IMailControl, Savable
       try
       {
         DBTransaction.starten();
-        handleStore(true);
+        doStore();
         sendeMail();
+        getMail().setVersand(new Timestamp(new Date().getTime()));
+        getMail().store();
         updateInputs();
         DBTransaction.commit();
       }
@@ -577,7 +584,6 @@ public class MailControl extends FilterControl implements IMailControl, Savable
               String.format("Anzahl verschickter Mails: %d", sentCount));
           GUI.getStatusBar().setSuccessText(
               "Mail" + (sentCount > 1 ? "s" : "") + " verschickt");
-          getMail().store();
         }
         catch (ApplicationException ae)
         {
@@ -690,7 +696,7 @@ public class MailControl extends FilterControl implements IMailControl, Savable
     try
     {
       DBTransaction.starten();
-      handleStore(false);
+      doStore();
       DBTransaction.commit();
     }
     catch (ApplicationException ae)
@@ -709,26 +715,22 @@ public class MailControl extends FilterControl implements IMailControl, Savable
   /**
    * Speichert die Mail in der DB.
    *
-   * @param mitversand
-   *          wenn true, wird Spalte Versand auf aktuelles Datum gesetzt.
    * @throws ApplicationException
    */
   @SuppressWarnings("unchecked")
-  public void handleStore(boolean mitversand) throws ApplicationException
+  public void doStore() throws ApplicationException
   {
     try
     {
+      Mail m = (Mail) prepareStore();
       if (!hasChanged())
       {
         return;
       }
-      Mail m = (Mail) prepareStore();
+
       m.setBearbeitung(new Timestamp(new Date().getTime()));
-      if (mitversand)
-      {
-        m.setVersand(new Timestamp(new Date().getTime()));
-      }
       m.store();
+
       for (MailEmpfaenger me : (List<MailEmpfaenger>) getEmpfaenger()
           .getItems())
       {

--- a/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailAnhangImpl.java
@@ -51,7 +51,7 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
   {
     try
     {
-      if (getMail().getVersand() != null)
+      if (getMail() != null && getMail().getVersand() != null)
       {
         throw new ApplicationException(
             "Der Mailanhang kann nicht gelöscht werden, die Mail wurde schon versendet!");
@@ -70,6 +70,11 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
   {
     try
     {
+      if (getMail() != null && getMail().getVersand() != null)
+      {
+        throw new ApplicationException(
+            "Mailanhang kann nicht erzeugt werden, die Mail wurde schon versendet!");
+      }
       dateinameCheck(getDateiname());
     }
     catch (RemoteException e)
@@ -95,6 +100,35 @@ public class MailAnhangImpl extends AbstractJVereinDBObject
   protected void updateCheck() throws ApplicationException
   {
     insertCheck();
+    try
+    {
+      // Wenn die Mail an den Empfänger versendet wurde, darf er nicht mehr
+      // verändert werden
+      if (getMail() != null && getMail().getVersand() != null)
+      {
+        if (hasChanged("mail"))
+        {
+          throw new ApplicationException(
+              "Mail darf nicht verändert werden, die Mail wurde schon versendet!");
+        }
+        if (hasChanged("anhang"))
+        {
+          throw new ApplicationException(
+              "Anhang darf nicht verändert werden, die Mail wurde schon versendet!");
+        }
+        if (hasChanged("dateiname"))
+        {
+          throw new ApplicationException(
+              "Dateiname darf nicht verändert werden, die Mail wurde schon versendet!");
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Update check of mail failed", e);
+      throw new ApplicationException(
+          "Mailanhang kann nicht gespeichert werden. Siehe system log");
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/MailEmpfaengerImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailEmpfaengerImpl.java
@@ -75,9 +75,43 @@ public class MailEmpfaengerImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  protected void updateCheck()
+  protected void updateCheck() throws ApplicationException
   {
     insertCheck();
+    try
+    {
+      if (getVersand() == null && hasChanged("versand"))
+      {
+        throw new ApplicationException(
+            "Versanddatum darf nicht gelöscht werden, die Mail wurde schon an den Empfänger versendet!");
+      }
+      // Wenn die Mail an den Empfänger versendet wurde, darf er nicht mehr
+      // verändert werden
+      if (getVersand() != null)
+      {
+        if (hasChanged("email"))
+        {
+          throw new ApplicationException(
+              "Email darf nicht verändert werden, die Mail wurde schon an den Empfänger versendet!");
+        }
+        if (hasChanged("mail"))
+        {
+          throw new ApplicationException(
+              "Mail darf nicht verändert werden, die Mail wurde schon an den Empfänger versendet!");
+        }
+        if (hasChanged("mitglied"))
+        {
+          throw new ApplicationException(
+              "Mitglied darf nicht verändert werden, die Mail wurde schon an den Empfänger versendet!");
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Update check of mail failed", e);
+      throw new ApplicationException(
+          "Mailempfänger kann nicht gespeichert werden. Siehe system log");
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/MailImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/MailImpl.java
@@ -107,6 +107,35 @@ public class MailImpl extends AbstractJVereinDBObject implements Mail
   protected void updateCheck() throws ApplicationException
   {
     insertCheck();
+    try
+    {
+      if (getVersand() == null && hasChanged("versand"))
+      {
+        throw new ApplicationException(
+            "Versanddatum darf nicht gelöscht werden, die Mail wurde schon versendet!");
+      }
+      // Bei bereits versendeten Mails darf Betreff und Text nicht mehr editiert
+      // werden
+      if (getVersand() != null)
+      {
+        if (hasChanged("betreff"))
+        {
+          throw new ApplicationException(
+              "Betreff darf nicht verändert werden, die Mail wurde schon versendet!");
+        }
+        if (hasChanged("txt"))
+        {
+          throw new ApplicationException(
+              "Text darf nicht verändert werden, die Mail wurde schon versendet!");
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Update check of mail failed", e);
+      throw new ApplicationException(
+          "Mail kann nicht gespeichert werden. Siehe system log");
+    }
   }
 
   @Override


### PR DESCRIPTION
Ich habe jetzt Insert Checks bei Mail, Mailempfänger und Mailanhang eingebaut.
Dabei habe ich auch zwei Fehler gefunden die ich eingebaut hatte. Beim speichern wurde auf hasChanged abgefragt. Das funktioniert nur wenn preparestore() vorher aufgerufen wird. Beim grünen Zurück Button mit dem ich getestet habe funktionierte es weil es da aufgerufen wird.
Wenn es beim Senden keine Änderung gab wurde das Sendedatum nicht gesetzt. Ich habe das jetzt aus dem Speichern rausgenommen und beim sende Code hinzugefügt.