### PR TITLE
Fix Sollbuchung Zuordnen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -599,39 +599,47 @@ public class SplitbuchungsContainer
 
         SplitbuchungsContainer.add(splitBuchung);
       }
-      if (Math.abs(buchung.getBetrag() - zugeordnet) >= 0.01d)
+      if (zugeordnet != 0d)
       {
-        restBuchung = createSplitbuchung(buchung);
-        restBuchung.setBetrag(buchung.getBetrag() - zugeordnet);
-        restBuchung.setSplitTyp(SplitbuchungTyp.SPLIT);
-        restBuchung.setSplitId(Long.parseLong(getMaster().getID()));
-
-        SplitbuchungsContainer.add(restBuchung);
-      }
-      // Wenn es nur eine Splitposition gibt, die Splitbuchung auflösen.
-      // (Haupt- und Gegen-Buchung gibt es immer, daher müssen es 3 sein)
-      if (splitbuchungen.size() == 3)
-      {
-        Buchung split = null;
-        for (Buchung b : splitbuchungen)
+        if (Math.abs(buchung.getBetrag() - zugeordnet) >= 0.01d)
         {
-          if (b.getSplitTyp() == SplitbuchungTyp.SPLIT)
-          {
-            split = b;
-            break;
-          }
-        }
-        Buchung haupt = getMaster();
-        haupt.setSollbuchung(sollb);
-        haupt.setBuchungsartId(split.getBuchungsartId());
-        haupt.setBuchungsklasseId(split.getBuchungsklasseId());
-        haupt.setSteuer(split.getSteuer());
+          restBuchung = createSplitbuchung(buchung);
+          restBuchung.setBetrag(buchung.getBetrag() - zugeordnet);
+          restBuchung.setSplitTyp(SplitbuchungTyp.SPLIT);
+          restBuchung.setSplitId(Long.parseLong(getMaster().getID()));
 
-        SplitbuchungsContainer.aufloesen();
+          SplitbuchungsContainer.add(restBuchung);
+        }
+        // Wenn es nur eine Splitposition gibt, die Splitbuchung auflösen.
+        // (Haupt- und Gegen-Buchung gibt es immer, daher müssen es 3 sein)
+        if (splitbuchungen.size() == 3)
+        {
+          Buchung split = null;
+          for (Buchung b : splitbuchungen)
+          {
+            if (b.getSplitTyp() == SplitbuchungTyp.SPLIT)
+            {
+              split = b;
+              break;
+            }
+          }
+          Buchung haupt = getMaster();
+          haupt.setSollbuchung(sollb);
+          haupt.setBuchungsartId(split.getBuchungsartId());
+          haupt.setBuchungsklasseId(split.getBuchungsklasseId());
+          haupt.setSteuer(split.getSteuer());
+
+          SplitbuchungsContainer.aufloesen();
+        }
+        else
+        {
+          SplitbuchungsContainer.handleStore();
+        }
       }
       else
       {
-        SplitbuchungsContainer.handleStore();
+        SplitbuchungsContainer.aufloesen();
+        restBuchung = buchung;
       }
     }
     catch (ApplicationException e)


### PR DESCRIPTION
Beim Sollbuchung Zuordnen gab es zwei Fehler. Der Grund ist, dass überzahlte Sollbuchungspositionen aus der splitMap entfernt werden. Das kann dazu führen, dass keine Einträge in der splitMap sind.

Ist eine Sollbuchung überzahlt wurde darum beim Zuordnen einer Buchung zwar der Splitbuchungskontainer aufgelöst aber die die Buchung trotzdem zugeordnet. Es wurde auch die restBuchung zurückgegeben welche noch den Splittyp gesetzt hat. Wenn man dann bei der Abfrage ob die Restbuchung zugeordent werden soll auch Ja sagt wird diese auch zugeordnet. Also doppelt.

Beim Zuordnen einer Buchung zu mehreren Sollbuchungen, wobei die älteste überzahlt ist wird die restBuchung mit Splittyp zurückgeliefert, was dann bei der nächsten Sollbuchung zu Exceptions führt.

Ich habe den Code jetzt so geändert, dass wenn über die splitMap keine Zuordnung erfolgt der Splitbuchungskontainer nur aufgelöst wird und nichts zugewiesen wird. Als restBuchung wird die Buchung selbst zurückgeliefert.

Im ersten Fall oben wird nur bei der Abfrage ob der Restbetrag zugewiesen werden soll, entweder die ganze Buchung zugewiesen oder halt nichts automatisch.

Im zweiten Fall oben wird der überzahlen Sollbuchung nichts zugewiesen und dann mit der Buchung bei den anderen Sollbuchungen weiter gemacht.

Ich denke, so ist es akzeptabel.