### PR TITLE
Rechnungsnummer konfigurierbar

### DIFF
--- a/src/main/java/de/jost_net/JVerein/Einstellungen.java
+++ b/src/main/java/de/jost_net/JVerein/Einstellungen.java
@@ -314,9 +314,6 @@ public class Einstellungen
 
     // Rechnung
     RECHNUNGSNUMMER("rechnungsnummer", String.class, "$rechnung_id"),
-    // TODO Default-Wert wäre besser der Zähler aus dem Formular, dort kann es
-    // aber verschiedene geben, daher weiß ich nicht, wie man das machen soll.
-    // So muss der Nutzer darauf hingewiesen werden, dass er den zähler manuell
     // festlegen muss
     RECHNUNG_ZAHLER("rechnung_zaehler", Integer.class, "1"),
     RECHNUNGTEXTABBUCHUNG("rechnungtextabbuchung", String.class,

--- a/src/main/java/de/jost_net/JVerein/Einstellungen.java
+++ b/src/main/java/de/jost_net/JVerein/Einstellungen.java
@@ -313,6 +313,12 @@ public class Einstellungen
     GEPRUEFTSYNCHRONISIEREN("geprueftsynchronisieren", Boolean.class, "0"),
 
     // Rechnung
+    RECHNUNGSNUMMER("rechnungsnummer", String.class, "$rechnung_id"),
+    // TODO Default-Wert wäre besser der Zähler aus dem Formular, dort kann es
+    // aber verschiedene geben, daher weiß ich nicht, wie man das machen soll.
+    // So muss der Nutzer darauf hingewiesen werden, dass er den zähler manuell
+    // festlegen muss
+    RECHNUNG_ZAHLER("rechnung_zaehler", Integer.class, "1"),
     RECHNUNGTEXTABBUCHUNG("rechnungtextabbuchung", String.class,
         "Der Betrag wird vom Konto ${IBAN}, (BIC ${BIC}) abgebucht."),
     RECHNUNGTEXTUEBERWEISUNG("rechnungtextueberweisung", String.class,

--- a/src/main/java/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/main/java/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -350,7 +350,8 @@ public class RechnungMap extends AbstractMap
           value = "1234";
           break;
         case RECHNUNG_ZAEHLER:
-          value = Einstellungen.getEinstellung(Property.RECHNUNG_ZAHLER);
+          value = Einstellungen.getEinstellung(Property.RECHNUNG_ZAHLER)
+              .toString();
           break;
         case BUCHUNGSDATUM:
           value = Datum.formatDate(new Date()) + "\n"

--- a/src/main/java/de/jost_net/JVerein/Variable/RechnungMap.java
+++ b/src/main/java/de/jost_net/JVerein/Variable/RechnungMap.java
@@ -111,6 +111,12 @@ public class RechnungMap extends AbstractMap
       Object value = null;
       switch (var)
       {
+        case ID:
+          value = re.getID();
+          break;
+        case RECHNUNG_ZAEHLER:
+          value = Einstellungen.getEinstellung(Property.RECHNUNG_ZAHLER);
+          break;
         case BUCHUNGSDATUM:
         case MK_BUCHUNGSDATUM:
           value = String.join("\n", buchungDatum);
@@ -172,9 +178,7 @@ public class RechnungMap extends AbstractMap
           value = fromDate(re.getDatum());
           break;
         case NUMMER:
-          value = StringTool.lpad(re.getID(),
-              (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE),
-              "0");
+          value = re.getNummer();
           break;
         case PERSONENART:
           value = re.getPersonenart();
@@ -342,6 +346,12 @@ public class RechnungMap extends AbstractMap
       Object value = null;
       switch (var)
       {
+        case ID:
+          value = "1234";
+          break;
+        case RECHNUNG_ZAEHLER:
+          value = Einstellungen.getEinstellung(Property.RECHNUNG_ZAHLER);
+          break;
         case BUCHUNGSDATUM:
           value = Datum.formatDate(new Date()) + "\n"
               + Datum.formatDate(new Date());

--- a/src/main/java/de/jost_net/JVerein/Variable/RechnungVar.java
+++ b/src/main/java/de/jost_net/JVerein/Variable/RechnungVar.java
@@ -85,7 +85,9 @@ public enum RechnungVar
   ZAHLUNGSWEG("rechnung_zahlungsweg"),
   KOMMENTAR("rechnung_kommentar"),
   // Muss der letzt Eintrag sein, da hier die Map selbst verwendet wird
-  ZAHLUNGSWEGTEXT("rechnung_zahlungsweg_text");
+  ZAHLUNGSWEGTEXT("rechnung_zahlungsweg_text"),
+  ID("rechnung_id"),
+  RECHNUNG_ZAEHLER("rechnung_zaehler");
 
   private String name;
 

--- a/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -504,7 +504,7 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     if ((Boolean) Einstellungen.getEinstellung(Property.RECHNUNGENANZEIGEN))
     {
-      sollbuchungList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
+      sollbuchungList.addColumn("Rechnung", "rechnung.nummer");
     }
     sollbuchungList.setContextMenu(new SollbuchungMenu(null));
     sollbuchungList.setMulti(true);

--- a/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -2545,8 +2545,11 @@ public class EinstellungControl extends AbstractControl
           (Boolean) arbeitseinsatz.getValue());
       Einstellungen.setEinstellung(Property.DOKUMENTENSPEICHERUNG,
           (Boolean) dokumentenspeicherung.getValue());
-      Einstellungen.setEinstellung(Property.DOKUMENTSPEICHERUNG_MESSAGING,
-          (Boolean) dokumentenspeicherung_messaging.getValue());
+      if (dokumentenspeicherung_messaging != null)
+      {
+        Einstellungen.setEinstellung(Property.DOKUMENTSPEICHERUNG_MESSAGING,
+            (Boolean) dokumentenspeicherung_messaging.getValue());
+      }
       Einstellungen.setEinstellung(Property.INDIVIDUELLEBEITRAEGE,
           (Boolean) individuellebeitraege.getValue());
       Einstellungen.setEinstellung(Property.EXTERNEMITGLIEDSNUMMER,

--- a/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -426,6 +426,10 @@ public class EinstellungControl extends AbstractControl
 
   private DirectoryInput buchungsDokumentVerzeichnis;
 
+  private TextInput rechnungsnummer;
+
+  private IntegerInput rechnungZaehler;
+
   public EinstellungControl(AbstractView view)
   {
     super(view);
@@ -943,6 +947,28 @@ public class EinstellungControl extends AbstractControl
     individuellebeitraege = new CheckboxInput(
         (Boolean) Einstellungen.getEinstellung(Property.INDIVIDUELLEBEITRAEGE));
     return individuellebeitraege;
+  }
+
+  public TextInput getRechnungNummer() throws RemoteException
+  {
+    if (rechnungsnummer != null)
+    {
+      return rechnungsnummer;
+    }
+    rechnungsnummer = new TextInput(
+        (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER), 500);
+    return rechnungsnummer;
+  }
+
+  public IntegerInput getRechnungZaehler() throws RemoteException
+  {
+    if (rechnungZaehler != null)
+    {
+      return rechnungZaehler;
+    }
+    rechnungZaehler = new IntegerInput(
+        (Integer) Einstellungen.getEinstellung(Property.RECHNUNG_ZAHLER));
+    return rechnungZaehler;
   }
 
   public TextInput getRechnungTextAbbuchung() throws RemoteException
@@ -2882,6 +2908,10 @@ public class EinstellungControl extends AbstractControl
     {
       DBTransaction.starten();
 
+      Einstellungen.setEinstellung(Property.RECHNUNGSNUMMER,
+          (String) rechnungsnummer.getValue());
+      Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER,
+          (Integer) rechnungZaehler.getValue());
       Einstellungen.setEinstellung(Property.RECHNUNGTEXTABBUCHUNG,
           (String) rechnungtextabbuchung.getValue());
       Einstellungen.setEinstellung(Property.RECHNUNGTEXTUEBERWEISUNG,

--- a/src/main/java/de/jost_net/JVerein/gui/control/RechnungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/RechnungControl.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import de.jost_net.JVerein.Einstellungen;
-import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.action.EditAction;
 import de.jost_net.JVerein.gui.dialogs.TabelleSpaltenAuswahlDialog;
 import de.jost_net.JVerein.gui.formatter.IBANFormatter;
@@ -63,7 +62,6 @@ import de.jost_net.JVerein.server.ExtendedDBIterator;
 import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.Datum;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
-import de.jost_net.JVerein.util.StringTool;
 import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.GenericIterator;
 import de.willuhn.datasource.GenericObject;
@@ -168,7 +166,7 @@ public class RechnungControl extends DruckMailControl implements Savable
     }
     GenericIterator<Rechnung> rechnungen = getRechnungIterator();
     rechnungList = new BetragSummaryTablePart(rechnungen, null);
-    rechnungList.addColumn("Nr", "id-int");
+    rechnungList.addColumn("Nr", "nummer");
     rechnungList.addColumn("Versanddatum", "versanddatum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     rechnungList.addColumn("Rechnungsdatum", "datum",
@@ -497,8 +495,7 @@ public class RechnungControl extends DruckMailControl implements Savable
       return nummer;
     }
 
-    nummer = new TextInput(StringTool.lpad(getRechnung().getID(),
-        (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE), "0"));
+    nummer = new TextInput(getRechnung().getNummer());
     nummer.setName("Rechnungsnummer");
     nummer.disable();
 

--- a/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -427,7 +427,7 @@ public class SollbuchungControl extends DruckMailControl implements Savable
         new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
     if ((Boolean) Einstellungen.getEinstellung(Property.RECHNUNGENANZEIGEN))
     {
-      sollbuchungenList.addColumn("Rechnung", Sollbuchung.RECHNUNG);
+      sollbuchungenList.addColumn("Rechnung", "rechnung.nummer");
     }
     sollbuchungenList.setMulti(multi);
     if (action == null)

--- a/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenRechnungenView.java
@@ -41,6 +41,8 @@ public class EinstellungenRechnungenView extends AbstractView
 
     ScrolledContainer cont = new ScrolledContainer(getParent());
 
+    cont.addLabelPair("Rechnung Nummer", control.getRechnungNummer());
+    cont.addLabelPair("Rechnung Zähler", control.getRechnungZaehler());
     cont.addLabelPair("Text Abbuchung", control.getRechnungTextAbbuchung());
     cont.addLabelPair("Text Überweisung",
         control.getRechnungTextUeberweisung());

--- a/src/main/java/de/jost_net/JVerein/io/FormularAufbereitung.java
+++ b/src/main/java/de/jost_net/JVerein/io/FormularAufbereitung.java
@@ -274,7 +274,7 @@ public class FormularAufbereitung
       }
       if (rechnungNummer)
       {
-        sb.append(fieldsMap.get(AllgemeineVar.ZAEHLER.getName()));
+        sb.append(fieldsMap.get(RechnungVar.NUMMER.getName()));
         if (rechnungDatum)
         {
           sb.append(" ");

--- a/src/main/java/de/jost_net/JVerein/io/SEPASupport.java
+++ b/src/main/java/de/jost_net/JVerein/io/SEPASupport.java
@@ -17,6 +17,7 @@ import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.rmi.AbstractDokument;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.Formular;
 import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.util.VorlageUtil;
@@ -60,7 +61,10 @@ public class SEPASupport
         File file = File.createTempFile(dateiname, ".pdf");
         FormularAufbereitung aufbereitung = new FormularAufbereitung(file, true,
             false);
-        aufbereitung.writeForm(re.getFormular(), map);
+        Formular formular = re.getFormular();
+        aufbereitung.writeForm(formular, map);
+        // ggf. hochgezählten Zähler speichern
+        formular.store();
         aufbereitung.closeFormular();
 
         AbstractDokument doc = Einstellungen.getDBService()

--- a/src/main/java/de/jost_net/JVerein/rmi/Rechnung.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/Rechnung.java
@@ -151,5 +151,9 @@ public interface Rechnung extends JVereinDBObject, IAdresse, IGutschriftProvider
 
   public Long getReferenzrechnungID() throws RemoteException;
 
-  void setReferenzrechnungID(Long referenz) throws RemoteException;
+  public void setReferenzrechnungID(Long referenz) throws RemoteException;
+
+  public String getNummer() throws RemoteException;
+
+  public void setNummer(String nummer) throws RemoteException;
 }

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -15,6 +15,7 @@ package de.jost_net.JVerein.server.DDLTool.Updates;
 
 import java.sql.Connection;
 
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
 import de.jost_net.JVerein.server.DDLTool.Column;
 import de.willuhn.util.ApplicationException;
@@ -33,8 +34,16 @@ public class Update0510 extends AbstractDDLUpdate
     execute(addColumn("rechnung",
         new Column("nummer", COLTYPE.VARCHAR, 500, null, false, false)));
 
-    // TODO hier sollten auch mit Nullen aufgefüllt werden, so wie es in den
-    // Einstellungen eingestellt ist
-    execute("UPDATE rechnung SET nummer = id");
+    // Nummer in Rechnung eintragen, dabei so vilee führende Nullen wie
+    // eingestellt verwenden
+    // concat ist nötig, damit es bei H2 funktioniert
+    execute("UPDATE rechnung SET nummer = case when CHAR_LENGTH(id)>"
+        + "(SELECT COALESCE(max(wert),5) FROM einstellungneu WHERE name = '"
+        + Property.ZAEHLERLAENGE.getKey()
+        + "') then concat(id,'') else lpad(id, (SELECT COALESCE(max(wert),5) FROM einstellungneu WHERE name = '"
+        + Property.ZAEHLERLAENGE.getKey() + "'),0) end");
+
+    execute("INSERT INTO einstellungneu (name,wert) SELECT '"
+        + Property.RECHNUNG_ZAHLER.getKey() + "', max(id)+1 FROM rechnung");
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0510 extends AbstractDDLUpdate
+{
+  public Update0510(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+    execute(addColumn("rechnung",
+        new Column("nummer", COLTYPE.VARCHAR, 500, null, false, false)));
+
+    // TODO hier sollten auch mit Nullen aufgefüllt werden, so wie es in den
+    // Einstellungen eingestellt ist
+    execute("UPDATE rechnung SET nummer = id");
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -45,7 +45,8 @@ public class Update0510 extends AbstractDDLUpdate
         + Property.ZAEHLERLAENGE.getKey() + "'),0) end");
 
     execute("INSERT INTO einstellungneu (name,wert) SELECT '"
-        + Property.RECHNUNG_ZAHLER.getKey() + "', max(id)+1 FROM rechnung");
+        + Property.RECHNUNG_ZAHLER.getKey()
+        + "', COALESCE(max(id),0)+1 FROM rechnung");
 
     execute("ALTER TABLE rechnung ADD UNIQUE INDEX `nummer` (`nummer`)");
 

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -34,8 +34,8 @@ public class Update0510 extends AbstractDDLUpdate
     execute(addColumn("rechnung",
         new Column("nummer", COLTYPE.VARCHAR, 500, null, false, false)));
 
-    // Nummer in Rechnung eintragen, dabei so vilee führende Nullen wie
-    // eingestellt verwenden
+    // Nummer in Rechnung eintragen, dabei so viele führende Nullen wie
+    // eingestellt verwenden.
     // concat ist nötig, damit es bei H2 funktioniert
     execute("UPDATE rechnung SET nummer = case when CHAR_LENGTH(id)>"
         + "(SELECT COALESCE(max(wert),5) FROM einstellungneu WHERE name = '"

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -52,10 +52,10 @@ public class Update0510 extends AbstractDDLUpdate
     // Fehler aus Update0509 nochmal korrigieren, falls jemand die
     // NigthlyVersion verwendet hat und es somit noch nicht in der Korrekten
     // Form ausgeführt wurde
-    alterColumnDropNotNull("buchungdokument",
-        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false));
+    execute(alterColumnDropNotNull("buchungdokument",
+        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false)));
 
-    alterColumnDropNotNull("mitglieddokument",
-        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false));
+    execute(alterColumnDropNotNull("mitglieddokument",
+        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false)));
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -33,7 +33,7 @@ public class Update0510 extends AbstractDDLUpdate
   {
 
     execute(addColumn("rechnung",
-        new Column("nummer", COLTYPE.VARCHAR, 500, null, false, false)));
+        new Column("nummer", COLTYPE.VARCHAR, 50, null, false, false)));
 
     // Nummer in Rechnung eintragen, dabei so viele führende Nullen wie
     // eingestellt verwenden.

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0510.java
@@ -31,6 +31,7 @@ public class Update0510 extends AbstractDDLUpdate
   @Override
   public void run() throws ApplicationException
   {
+
     execute(addColumn("rechnung",
         new Column("nummer", COLTYPE.VARCHAR, 500, null, false, false)));
 
@@ -45,5 +46,16 @@ public class Update0510 extends AbstractDDLUpdate
 
     execute("INSERT INTO einstellungneu (name,wert) SELECT '"
         + Property.RECHNUNG_ZAHLER.getKey() + "', max(id)+1 FROM rechnung");
+
+    execute("ALTER TABLE rechnung ADD UNIQUE INDEX `nummer` (`nummer`)");
+
+    // Fehler aus Update0509 nochmal korrigieren, falls jemand die
+    // NigthlyVersion verwendet hat und es somit noch nicht in der Korrekten
+    // Form ausgeführt wurde
+    alterColumnDropNotNull("buchungdokument",
+        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false));
+
+    alterColumnDropNotNull("mitglieddokument",
+        new Column("uuid", COLTYPE.VARCHAR, 50, null, false, false));
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -678,6 +678,15 @@ public class RechnungImpl extends AbstractJVereinDBObject
           (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
       setNummer(nummer);
 
+      // Prüfen, ob es schon eine Rechnung mit dieser Nummer gibt
+      DBIterator<?> it = getList();
+      it.addFilter("nummer = ?", nummer);
+      if (it.hasNext())
+      {
+        throw new ApplicationException(
+            "Rechnung mit dieser Nummer existiert bereits. Rechnungsnummer in Einstellungen korrigieren!");
+      }
+
       super.store();
     }
     else

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -689,9 +689,10 @@ public class RechnungImpl extends AbstractJVereinDBObject
               "Rechnung mit dieser Nummer existiert bereits. Rechnungsnummer in Einstellungen korrigieren!");
         }
 
+        super.store();
+
         Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
 
-        super.store();
         transactionCommit();
       }
       catch (Exception e)

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -22,9 +22,16 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.MitgliedMap;
+import de.jost_net.JVerein.Variable.RechnungMap;
+import de.jost_net.JVerein.Variable.RechnungVar;
 import de.jost_net.JVerein.io.IAdresse;
+import de.jost_net.JVerein.io.VelocityTool;
 import de.jost_net.JVerein.keys.Staat;
 import de.jost_net.JVerein.keys.Zahlungsweg;
 import de.jost_net.JVerein.rmi.Buchung;
@@ -33,6 +40,7 @@ import de.jost_net.JVerein.rmi.Mitglied;
 import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.rmi.SollbuchungPosition;
+import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
@@ -42,9 +50,6 @@ public class RechnungImpl extends AbstractJVereinDBObject
     implements Rechnung, IAdresse, UnreadCounter, IBetrag, IVersand, IMitglied
 {
 
-  /**
-   * 
-   */
   private static final long serialVersionUID = -286067581211521888L;
 
   private Double ist;
@@ -631,5 +636,53 @@ public class RechnungImpl extends AbstractJVereinDBObject
   {
     // Wegen Interface IAdresse
     return null;
+  }
+
+  @Override
+  public String getNummer() throws RemoteException
+  {
+    return (String) getAttribute("nummer");
+  }
+
+  @Override
+  public void setNummer(String nummer) throws RemoteException
+  {
+    setAttribute("nummer", nummer);
+  }
+
+  @Override
+  public void store() throws RemoteException, ApplicationException
+  {
+    if (isNewObject())
+    {
+      // Speichern, damit es schon eine ID gibt
+      super.store();
+
+      // Rechnungsnummer erstellen
+      Map<String, Object> map = new AllgemeineMap().getMap(null);
+      new RechnungMap().getMap(this, map);
+      if (getMitglied() != null)
+      {
+        map = new MitgliedMap().getMap(getMitglied(), map);
+      }
+      Integer nr = (Integer) Einstellungen
+          .getEinstellung(Property.RECHNUNG_ZAHLER);
+      map.put(RechnungVar.RECHNUNG_ZAEHLER.getName(),
+          StringTool.lpad(nr.toString(),
+              (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE),
+              "0"));
+
+      Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
+
+      String nummer = VelocityTool.eval(map,
+          (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
+      setNummer(nummer);
+
+      super.store();
+    }
+    else
+    {
+      super.store();
+    }
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -655,39 +655,50 @@ public class RechnungImpl extends AbstractJVereinDBObject
   {
     if (isNewObject())
     {
-      // Speichern, damit es schon eine ID gibt
-      super.store();
-
-      // Rechnungsnummer erstellen
-      Map<String, Object> map = new AllgemeineMap().getMap(null);
-      new RechnungMap().getMap(this, map);
-      if (getMitglied() != null)
+      try
       {
-        map = new MitgliedMap().getMap(getMitglied(), map);
+        transactionBegin();
+
+        // Speichern, damit es schon eine ID gibt
+        super.store();
+
+        // Rechnungsnummer erstellen
+        Map<String, Object> map = new AllgemeineMap().getMap(null);
+        new RechnungMap().getMap(this, map);
+        if (getMitglied() != null)
+        {
+          map = new MitgliedMap().getMap(getMitglied(), map);
+        }
+        Integer nr = (Integer) Einstellungen
+            .getEinstellung(Property.RECHNUNG_ZAHLER);
+        map.put(RechnungVar.RECHNUNG_ZAEHLER.getName(),
+            StringTool.lpad(nr.toString(),
+                (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE),
+                "0"));
+
+        Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
+
+        String nummer = VelocityTool.eval(map,
+            (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
+        setNummer(nummer);
+
+        // Prüfen, ob es schon eine Rechnung mit dieser Nummer gibt
+        DBIterator<?> it = getList();
+        it.addFilter("nummer = ?", nummer);
+        if (it.hasNext())
+        {
+          throw new ApplicationException(
+              "Rechnung mit dieser Nummer existiert bereits. Rechnungsnummer in Einstellungen korrigieren!");
+        }
+
+        super.store();
+        transactionCommit();
       }
-      Integer nr = (Integer) Einstellungen
-          .getEinstellung(Property.RECHNUNG_ZAHLER);
-      map.put(RechnungVar.RECHNUNG_ZAEHLER.getName(),
-          StringTool.lpad(nr.toString(),
-              (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE),
-              "0"));
-
-      Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
-
-      String nummer = VelocityTool.eval(map,
-          (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
-      setNummer(nummer);
-
-      // Prüfen, ob es schon eine Rechnung mit dieser Nummer gibt
-      DBIterator<?> it = getList();
-      it.addFilter("nummer = ?", nummer);
-      if (it.hasNext())
+      catch (Exception e)
       {
-        throw new ApplicationException(
-            "Rechnung mit dieser Nummer existiert bereits. Rechnungsnummer in Einstellungen korrigieren!");
+        transactionRollback();
+        throw e;
       }
-
-      super.store();
     }
     else
     {

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -678,6 +678,12 @@ public class RechnungImpl extends AbstractJVereinDBObject
 
         String nummer = VelocityTool.eval(map,
             (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
+
+        if (nummer.length() > 50)
+        {
+          throw new ApplicationException(
+              "Rechnungsnummer zu lang, maximal 50 Zeichen erlaubt!");
+        }
         setNummer(nummer);
 
         // Prüfen, ob es schon eine Rechnung mit dieser Nummer gibt

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -676,8 +676,6 @@ public class RechnungImpl extends AbstractJVereinDBObject
                 (Integer) Einstellungen.getEinstellung(Property.ZAEHLERLAENGE),
                 "0"));
 
-        Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
-
         String nummer = VelocityTool.eval(map,
             (String) Einstellungen.getEinstellung(Property.RECHNUNGSNUMMER));
         setNummer(nummer);
@@ -690,6 +688,8 @@ public class RechnungImpl extends AbstractJVereinDBObject
           throw new ApplicationException(
               "Rechnung mit dieser Nummer existiert bereits. Rechnungsnummer in Einstellungen korrigieren!");
         }
+
+        Einstellungen.setEinstellung(Property.RECHNUNG_ZAHLER, nr + 1);
 
         super.store();
         transactionCommit();


### PR DESCRIPTION
Ich hab die Rechnungsnummer konfigurierbar gemacht. In Den Einstellungen gibt es jetzt ein Feld wo der Aufbau der Rechnungsnummer angegeben werden kann. Außerdem wird in den Einstellungen der Zähler gespeichert. Beim Speichern der Rechnung wird der Zähler automatisch hochgezählt. Man kann ihn jedoch manuell ändern, wenn man zB. jedes Jahr wieder bei 1 starten möchte.
Bisher gab es schon zwei verschiedene Konzepte. Früher gab es den Zähler, der wird jedoch bei jedem Formularerstellen hochgezählt. Den habe ich auch einfach so belassen, meiner Meinung nach wird der nicht mehr gebraucht, aber vielleicht will Irgendjemand ihn noch verwenden.
Seitdem Rechnungen in der DB stehen, wird die ID als Rechnungsnummer verwendet. Daher habe ich bei der Migration auch die ID als Rechnungsnummer verwendet.
Als Zähler habe ich die Maximale Rechnungs-ID genommen, so kann es ohne Änderung weiter genutzt werden.
Auch im QR-Code wird nun die neue Nummer verwendet.

Dann habe ich noch einen NPE Fehler bei den Einstellungen behoben, wenn Messaging nicht installiert ist.