### PR TITLE
LizenzView wiederhergestellt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ releases-test
 nbproject/private/
 .DS_Store
 *.zip
+THIRD-PARTY.txt
 
 jverein.iml
 target

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ releases-test
 nbproject/private/
 .DS_Store
 *.zip
-THIRD-PARTY.txt
 
 jverein.iml
 target

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,11 @@
       <item name="Über"
             action="de.jost_net.JVerein.gui.action.AboutAction" 
             icon="gtk-info.png" />
+      <item name="Lizenzinformationen"
+            action="de.jost_net.JVerein.gui.action.LizenzAction"
+            icon="text-x-generic.png" />
     </item>
+    
   </menu>
   <classfinder>
     <include>jverein\.jar</include>

--- a/pom.xml
+++ b/pom.xml
@@ -487,14 +487,26 @@
 				<version>2.7.1</version>
 				<executions>
 					<execution>
+						<id>add-third-party-for-view</id>
+						<goals>
+							<goal>add-third-party</goal>
+						</goals>
+						<configuration>
+							<excludedScopes>test,provided</excludedScopes>
+							<fileTemplate>${project.basedir}/third-party-license.ftl</fileTemplate>
+							<thirdPartyFilename>third-party-view.txt</thirdPartyFilename>
+							<outputDirectory>${project.build.directory}/assembly-lib</outputDirectory>
+							<excludedArtifacts>de.willuhn*|jameica|hibiscus</excludedArtifacts>
+						</configuration>
+					</execution>
+					<execution>
 						<id>add-third-party</id>
 						<goals>
 							<goal>add-third-party</goal>
 						</goals>
 						<configuration>
 							<excludedScopes>test,provided</excludedScopes>
-							<fileTemplate>./third-party-license.ftl</fileTemplate>
-							<outputDirectory>./</outputDirectory>
+							<outputDirectory>${project.build.directory}/assembly-lib</outputDirectory>
 							<excludedArtifacts>de.willuhn*|jameica|hibiscus</excludedArtifacts>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,25 @@
           </execution>
         </executions>
       </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.7.1</version>
+				<executions>
+					<execution>
+						<id>add-third-party</id>
+						<goals>
+							<goal>add-third-party</goal>
+						</goals>
+						<configuration>
+							<excludedScopes>test,provided</excludedScopes>
+							<fileTemplate>./third-party-license.ftl</fileTemplate>
+							<outputDirectory>./</outputDirectory>
+							<excludedArtifacts>de.willuhn*|jameica|hibiscus</excludedArtifacts>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
     </plugins>
   </build>
 

--- a/src/main/java/de/jost_net/JVerein/gui/action/LizenzAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/LizenzAction.java
@@ -1,0 +1,33 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.LizenzView;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.util.ApplicationException;
+
+public class LizenzAction implements Action
+{
+
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    GUI.startView(LizenzView.class, null);
+  }
+
+}

--- a/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
@@ -15,6 +15,7 @@ package de.jost_net.JVerein.gui.control;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
@@ -39,7 +40,7 @@ public class LizenzControl extends AbstractControl
       {
         throw new ApplicationException("Fehler beim lesen der Lizenz-Datei");
       }
-      text = new String(fis.readAllBytes());
+      text = new String(fis.readAllBytes(), StandardCharsets.UTF_8);
     }
     catch (IOException e)
     {

--- a/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
@@ -13,15 +13,14 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.control;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
-import de.jost_net.JVerein.JVereinPlugin;
 import de.willuhn.jameica.gui.AbstractControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.parts.FormTextPart;
-import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class LizenzControl extends AbstractControl
 {
@@ -30,22 +29,22 @@ public class LizenzControl extends AbstractControl
     super(view);
   }
 
-  public FormTextPart getLibList()
+  public FormTextPart getLibList() throws ApplicationException
   {
-    String path = Application.getPluginLoader().getPlugin(JVereinPlugin.class)
-        .getManifest().getPluginDir();
-
-    File file = new File(path + "/THIRD-PARTY.txt");
-
     String text;
-    try (FileInputStream fis = new FileInputStream(file))
+    try (InputStream fis = getClass().getClassLoader()
+        .getResourceAsStream("third-party-view.txt");)
     {
+      if (fis == null)
+      {
+        throw new ApplicationException("Fehler beim lesen der Lizenz-Datei");
+      }
       text = new String(fis.readAllBytes());
     }
-    catch (Exception e)
+    catch (IOException e)
     {
-      Logger.error("Fehler beim lesen der Datei", e);
-      text = "Fehler beim lesen der Datei";
+      Logger.error("Fehler beim lesen der Lizenz-Datei", e);
+      text = "Fehler beim lesen der Lizenz-Datei";
     }
     return new FormTextPart(text);
   }

--- a/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/LizenzControl.java
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import de.jost_net.JVerein.JVereinPlugin;
+import de.willuhn.jameica.gui.AbstractControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.parts.FormTextPart;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+
+public class LizenzControl extends AbstractControl
+{
+  public LizenzControl(AbstractView view)
+  {
+    super(view);
+  }
+
+  public FormTextPart getLibList()
+  {
+    String path = Application.getPluginLoader().getPlugin(JVereinPlugin.class)
+        .getManifest().getPluginDir();
+
+    File file = new File(path + "/THIRD-PARTY.txt");
+
+    String text;
+    try (FileInputStream fis = new FileInputStream(file))
+    {
+      text = new String(fis.readAllBytes());
+    }
+    catch (Exception e)
+    {
+      Logger.error("Fehler beim lesen der Datei", e);
+      text = "Fehler beim lesen der Datei";
+    }
+    return new FormTextPart(text);
+  }
+
+}

--- a/src/main/java/de/jost_net/JVerein/gui/view/LizenzView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/LizenzView.java
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.gui.control.LizenzControl;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.FormTextPart;
+
+/**
+ * View fuer die Lizenz-Informationen
+ */
+public class LizenzView extends AbstractView
+{
+
+  /**
+   * @see de.willuhn.jameica.gui.AbstractView#bind()
+   */
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Lizenzinformationen JVerein");
+
+    LizenzControl control = new LizenzControl(this);
+
+    FormTextPart libs = control.getLibList();
+    libs.paint(getParent());
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.AbstractView#canBookmark()
+   */
+  @Override
+  public boolean canBookmark()
+  {
+    return false;
+  }
+
+}

--- a/third-party-license.ftl
+++ b/third-party-license.ftl
@@ -32,7 +32,7 @@
 -->
 <form>
 <p><span color="header" font="header">JVerein</span>
-<br/>Vereinsverwaltung-Plugin fuer Jameica
+<br/>Vereinsverwaltung-Plugin für Jameica
 <br/>https://openjverein.github.io
 <br/>GPL 3 http://www.gnu.org/licenses/LICENSE-3.0.txt
 </p>

--- a/third-party-license.ftl
+++ b/third-party-license.ftl
@@ -45,7 +45,7 @@
         <#-- bsh brauch extrabehandlung, da es nicht von maven stammt -->
         <#if project.name == "bsh">
          <p><b>${project.name}(${project.version})</b>
-         <br/>${project.description}
+         <br/>BeanShell - Simple Java Scripting
          <br/>${project.groupId} : ${project.artifactId}
          <br/>https://github.com/beanshell/beanshell/
          <br/>Apache-2.0 license - http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/third-party-license.ftl
+++ b/third-party-license.ftl
@@ -1,0 +1,66 @@
+<#--
+  #%L
+  License Maven Plugin
+  %%
+  Copyright (C) 2012 Codehaus, Tony Chemit
+  %%
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation, either version 3 of the
+  License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Lesser Public License for more details.
+
+  You should have received a copy of the GNU General Lesser Public
+  License along with this program.  If not, see
+  <http://www.gnu.org/licenses/lgpl-3.0.html>.
+  #L%
+  -->
+<#-- To render the third-party file.
+ Available context :
+
+ - dependencyMap a collection of Map.Entry with
+   key are dependencies (as a MavenProject) (from the maven project)
+   values are licenses of each dependency (array of string)
+
+ - licenseMap a collection of Map.Entry with
+   key are licenses of each dependency (array of string)
+   values are all dependencies using this license
+-->
+<form>
+<p><span color="header" font="header">JVerein</span>
+<br/>Vereinsverwaltung-Plugin fuer Jameica
+<br/>https://openjverein.github.io
+<br/>GPL 3 http://www.gnu.org/licenses/LICENSE-3.0.txt
+</p>
+<p><span color="header" font="header">Verwendete Komponenten</span></p>
+<#if dependencyMap?size == 0>
+<p>Keine Bibliotheken gefunden</p>
+<#else>
+    <#list dependencyMap as e>
+        <#assign project = e.getKey()/>
+        <#-- bsh brauch extrabehandlung, da es nicht von maven stammt -->
+        <#if project.name == "bsh">
+         <p><b>${project.name}(${project.version})</b>
+         <br/>${project.description}
+         <br/>${project.groupId} : ${project.artifactId}
+         <br/>https://github.com/beanshell/beanshell/
+         <br/>Apache-2.0 license - http://www.apache.org/licenses/LICENSE-2.0.txt
+         </p>
+        <#else>
+         <p><b>${project.name}(${project.version})</b>
+         <br/>${project.description}
+         <br/>${project.groupId} : ${project.artifactId}
+         <br/>${(project.url!"")}
+         <#list project.licenses as l>
+         	<br/>${l.name} - ${(l.url!"")}
+         </#list>
+         </p>
+         </#if>
+    </#list>
+</#if>
+<p><br/></p>
+</form>


### PR DESCRIPTION
Ich habe die Lizenz-View wiederhergestellt. Beim Build mit Maven wirt automatisch eine Datei mit allen Lizenzinformationen erstellt. Einmal für den Sourcecode zum "so lesen" und einmal fertig für JVerein geparst, so dass sie direkt in der View ausgegeben werden kann.
Zum testen muss mann einmal `mvn package` aufrufen, dann von eclipse wird die Datei sonst nicht erstellt.