### PR TITLE
Personalbogen nicht null ausgeben

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
+++ b/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
@@ -24,7 +24,6 @@ import java.rmi.RemoteException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -109,8 +108,7 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
   }
 
   @Override
-  protected String getDateiname(DBObject object)
-      throws RemoteException
+  protected String getDateiname(DBObject object) throws RemoteException
   {
     if (object != null)
     {
@@ -465,7 +463,8 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
         + Einstellungen.DECIMALFORMAT.format(BeitragsUtil.getBeitrag(
             Beitragsmodel.getByKey(
                 (Integer) Einstellungen.getEinstellung(Property.BEITRAGSMODEL)),
-            m.getZahlungstermin(), m.getZahlungsrhythmus(), bg, new Date(), m))
+            m.getZahlungstermin(), m.getZahlungsrhythmus(), bg, m.getEintritt(),
+            m))
         + " EUR";
     rpt.addColumn(beitragsgruppe, Element.ALIGN_LEFT);
   }
@@ -663,7 +662,8 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
         if (it2.size() > 0)
         {
           Zusatzfelder zf = it2.next();
-          rpt.addColumn(zf.getString(), Element.ALIGN_LEFT);
+          rpt.addColumn(zf.getString() == null ? "" : zf.getString(),
+              Element.ALIGN_LEFT);
         }
         else
         {

--- a/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
+++ b/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
@@ -41,6 +41,7 @@ import de.jost_net.JVerein.gui.control.PersonalbogenControl;
 import de.jost_net.JVerein.io.Adressbuch.Adressaufbereitung;
 import de.jost_net.JVerein.keys.ArtBeitragsart;
 import de.jost_net.JVerein.keys.Beitragsmodel;
+import de.jost_net.JVerein.keys.Datentyp;
 import de.jost_net.JVerein.keys.Spendenart;
 import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.keys.Zahlungsweg;
@@ -668,7 +669,8 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
         }
         else
         {
-          rpt.addColumn("", Element.ALIGN_LEFT);
+          rpt.addColumn(fd.getDatentyp() == Datentyp.JANEIN ? "nein" : "",
+              Element.ALIGN_LEFT);
         }
       }
       rpt.closeTable();

--- a/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
+++ b/src/main/java/de/jost_net/JVerein/io/PersonalbogenAusgabe.java
@@ -24,6 +24,7 @@ import java.rmi.RemoteException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -463,8 +464,8 @@ public class PersonalbogenAusgabe extends AbstractAusgabe
         + Einstellungen.DECIMALFORMAT.format(BeitragsUtil.getBeitrag(
             Beitragsmodel.getByKey(
                 (Integer) Einstellungen.getEinstellung(Property.BEITRAGSMODEL)),
-            m.getZahlungstermin(), m.getZahlungsrhythmus(), bg, m.getEintritt(),
-            m))
+            m.getZahlungstermin(), m.getZahlungsrhythmus(), bg,
+            m.getEintritt() == null ? new Date() : m.getEintritt(), m))
         + " EUR";
     rpt.addColumn(beitragsgruppe, Element.ALIGN_LEFT);
   }

--- a/src/main/java/de/jost_net/JVerein/server/ZusatzfelderImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/ZusatzfelderImpl.java
@@ -214,8 +214,16 @@ public class ZusatzfelderImpl extends AbstractDBObject implements Zusatzfelder
             return "";
           }
         case Datentyp.GANZZAHL:
-          return getFeldGanzzahl() + "";
+          if (getFeldGanzzahl() == null)
+          {
+            return "";
+          }
+          return getFeldGanzzahl().toString();
         case Datentyp.JANEIN:
+          if (getFeldJaNein() == null)
+          {
+            return "";
+          }
           return getFeldJaNein() ? "ja" : "nein";
         case Datentyp.WAEHRUNG:
           if (getFeldWaehrung() != null)

--- a/src/main/java/de/jost_net/JVerein/server/ZusatzfelderImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/ZusatzfelderImpl.java
@@ -220,10 +220,6 @@ public class ZusatzfelderImpl extends AbstractDBObject implements Zusatzfelder
           }
           return getFeldGanzzahl().toString();
         case Datentyp.JANEIN:
-          if (getFeldJaNein() == null)
-          {
-            return "";
-          }
           return getFeldJaNein() ? "ja" : "nein";
         case Datentyp.WAEHRUNG:
           if (getFeldWaehrung() != null)


### PR DESCRIPTION
Beim Personalbogen wurde "null" ausgegeben, wenn es bei Zusatzfeldern keinen Eintrag gab.