### PR TITLE
Buchungsart nicht änderbar wenn es abgeschlossene Buchungen gibt

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -38,8 +38,6 @@ import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
 import de.jost_net.JVerein.rmi.Steuer;
-import de.jost_net.JVerein.server.ExtendedDBIterator;
-import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -91,19 +89,7 @@ public class BuchungsartControl extends FilterControl implements Savable
     {
       try
       {
-        // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
-        ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
-            "buchung");
-        it.addColumn("buchung.id");
-        it.setLimit(1);
-        it.join("jahresabschluss",
-            "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
-        it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
-        it.addFilter("buchungsart = ?", getBuchungsart().getID());
-        if (it.size() > 0)
-        {
-          isAbgeschlossen = true;
-        }
+        isAbgeschlossen = getBuchungsart().isAbgeschlossen();
       }
       catch (RemoteException e)
       {
@@ -135,6 +121,10 @@ public class BuchungsartControl extends FilterControl implements Savable
       nummer.focus();
     }
     nummer.setMandatory(true);
+    if (isAbgeschlossen)
+    {
+      nummer.disable();
+    }
     return nummer;
   }
 
@@ -146,6 +136,10 @@ public class BuchungsartControl extends FilterControl implements Savable
     }
     bezeichnung = new TextInput(getBuchungsart().getBezeichnung(), 80);
     bezeichnung.setMandatory(true);
+    if (isAbgeschlossen)
+    {
+      bezeichnung.disable();
+    }
     return bezeichnung;
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -197,13 +197,18 @@ public class BuchungsartControl extends FilterControl implements Savable
     }
     spende = new CheckboxInput(getBuchungsart().getSpende());
     spende.addListener(event -> {
-      steuer.setEnabled(!(boolean) spende.getValue());
+      steuer.setEnabled(!(boolean) spende.getValue() && !isAbgeschlossen);
 
       if ((Boolean) spende.getValue())
       {
         steuer.setValue(null);
       }
     });
+    if (getBuchungsart().getSteuer() != null)
+    {
+      spende.setValue(false);
+      spende.disable();
+    }
     return spende;
   }
 
@@ -231,6 +236,9 @@ public class BuchungsartControl extends FilterControl implements Savable
 
     steuer.setAttribute("name");
     steuer.setPleaseChoose("Keine Steuer");
+    steuer.addListener(event -> {
+      spende.setEnabled(steuer.getValue() == null && !isAbgeschlossen);
+    });
 
     // Disable steuer for type spende
     if (getBuchungsart().getSpende())

--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsartControl.java
@@ -38,6 +38,8 @@ import de.jost_net.JVerein.rmi.Buchungsart;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
 import de.jost_net.JVerein.rmi.Steuer;
+import de.jost_net.JVerein.server.ExtendedDBIterator;
+import de.jost_net.JVerein.server.PseudoDBObject;
 import de.jost_net.JVerein.util.VorlageUtil;
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.datasource.pseudo.PseudoIterator;
@@ -80,9 +82,35 @@ public class BuchungsartControl extends FilterControl implements Savable
 
   private CheckboxInput regexp;
 
+  private boolean isAbgeschlossen = false;
+
   public BuchungsartControl(AbstractView view)
   {
     super(view);
+    if (getBuchungsart() != null)
+    {
+      try
+      {
+        // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
+        ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+            "buchung");
+        it.addColumn("buchung.id");
+        it.setLimit(1);
+        it.join("jahresabschluss",
+            "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
+        it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
+        it.addFilter("buchungsart = ?", getBuchungsart().getID());
+        if (it.size() > 0)
+        {
+          isAbgeschlossen = true;
+        }
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Fehler beim Lesen der Datenbank. Siehe system log";
+        Logger.error(fehler, e);
+      }
+    }
   }
 
   private Buchungsart getBuchungsart()
@@ -129,6 +157,10 @@ public class BuchungsartControl extends FilterControl implements Savable
     }
     art = new SelectInput(ArtBuchungsart.getArray(),
         new ArtBuchungsart(getBuchungsart().getArt()));
+    if (isAbgeschlossen)
+    {
+      art.disable();
+    }
     return art;
   }
 
@@ -188,6 +220,10 @@ public class BuchungsartControl extends FilterControl implements Savable
       return abschreibung;
     }
     abschreibung = new CheckboxInput(getBuchungsart().getAbschreibung());
+    if (isAbgeschlossen)
+    {
+      abschreibung.disable();
+    }
     return abschreibung;
   }
 
@@ -206,6 +242,10 @@ public class BuchungsartControl extends FilterControl implements Savable
     if (getBuchungsart().getSpende())
     {
       steuer.setValue(null);
+      steuer.disable();
+    }
+    if (isAbgeschlossen)
+    {
       steuer.disable();
     }
     return steuer;
@@ -273,6 +313,10 @@ public class BuchungsartControl extends FilterControl implements Savable
     buchungsklasse.setValue(getBuchungsart().getBuchungsklasse());
     buchungsklasse.setAttribute(getBuchungartAttribute());
     buchungsklasse.setPleaseChoose("Bitte auswählen");
+    if (isAbgeschlossen)
+    {
+      buchungsklasse.disable();
+    }
     return buchungsklasse;
   }
 

--- a/src/main/java/de/jost_net/JVerein/rmi/Buchungsart.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/Buchungsart.java
@@ -68,4 +68,6 @@ public interface Buchungsart extends JVereinDBObject
 
   boolean hasBuchungen() throws RemoteException;
 
+  boolean isAbgeschlossen() throws RemoteException;
+
 }

--- a/src/main/java/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -158,22 +158,43 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
     insertCheck();
     try
     {
+      boolean isAbgeschlossen = false;
+      // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
+      ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+          "buchung");
+      it.addColumn("buchung.id");
+      it.setLimit(1);
+      it.join("jahresabschluss",
+          "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
+      it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
+      it.addFilter("buchungsart.id = ?", getID());
+      if (it.hasNext())
+      {
+        isAbgeschlossen = true;
+      }
+
+      if (hasChanged("art") && isAbgeschlossen)
+      {
+        throw new ApplicationException(
+            "Art kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");
+      }
+
+      if (hasChanged("buchungsklasse") && isAbgeschlossen)
+      {
+        throw new ApplicationException(
+            "Buchungsklasse kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");
+      }
+
+      if (hasChanged("abschreibung") && isAbgeschlossen)
+      {
+        throw new ApplicationException(
+            "Abschreibung kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");
+      }
+
       if (hasChanged("steuer")
           && !(Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))
       {
-
-        // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
-        ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
-            "buchung");
-        it.addColumn("buchung.id");
-        it.setLimit(1);
-
-        it.join("jahresabschluss",
-            "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
-
-        it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
-        it.addFilter("buchungsart.id = ?", getID());
-        if (it.hasNext())
+        if (isAbgeschlossen)
         {
           throw new ApplicationException(
               "Steuer kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");

--- a/src/main/java/de/jost_net/JVerein/server/BuchungsartImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungsartImpl.java
@@ -158,19 +158,18 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
     insertCheck();
     try
     {
-      boolean isAbgeschlossen = false;
-      // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
-      ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
-          "buchung");
-      it.addColumn("buchung.id");
-      it.setLimit(1);
-      it.join("jahresabschluss",
-          "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
-      it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
-      it.addFilter("buchungsart.id = ?", getID());
-      if (it.hasNext())
+      boolean isAbgeschlossen = isAbgeschlossen();
+
+      if (hasChanged("nummer") && isAbgeschlossen)
       {
-        isAbgeschlossen = true;
+        throw new ApplicationException(
+            "Nummer kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");
+      }
+
+      if (hasChanged("bezeichnung") && isAbgeschlossen)
+      {
+        throw new ApplicationException(
+            "Bezeichnung kann nicht geändert werden, es gibt abgeschlossene Buchungen mit dieser Buchungsart.");
       }
 
       if (hasChanged("art") && isAbgeschlossen)
@@ -201,7 +200,8 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
         }
 
         // Prüfen ob es eine Rechnung mit dieser Buchungsart gibt
-        it = new ExtendedDBIterator<>(Sollbuchung.TABLE_NAME);
+        ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>(
+            Sollbuchung.TABLE_NAME);
         it.addColumn(Sollbuchung.TABLE_NAME_ID);
         it.setLimit(1);
 
@@ -506,5 +506,23 @@ public class BuchungsartImpl extends AbstractJVereinDBObject
     // Alte Steuerbuchungen zählen nicht
     it.addFilter("dependencyid is NUll OR dependencyid = -1");
     return it.hasNext();
+  }
+
+  @Override
+  public boolean isAbgeschlossen() throws RemoteException
+  {
+    // Prüfen ob es abgeschlossene Buchungen mit der Buchungsart gibt
+    ExtendedDBIterator<PseudoDBObject> it = new ExtendedDBIterator<>("buchung");
+    it.addColumn("buchung.id");
+    it.setLimit(1);
+    it.join("jahresabschluss",
+        "jahresabschluss.von <= buchung.datum and jahresabschluss.bis >= buchung.datum");
+    it.join("buchungsart", "buchungsart.id = buchung.buchungsart");
+    it.addFilter("buchungsart.id = ?", getID());
+    if (it.hasNext())
+    {
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Wie in #1330 gewünscht ist es nicht erlaubt Art, Buchungsklasse, Steuer und Abschreibung einer Buchungsart zu ändern wenn sie von abgeschlossenen Buchungen Verwendet wird.
Es werden die Felder am GUI disabled aber zusätzlich auch im updateCheck geprüft.