### PR TITLE
Versendete Rechnungen und Spendenbescheinigungen nicht löschen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
@@ -442,7 +442,7 @@ public class DbBereinigenControl extends AbstractControl
         try
         {
           rechnung = it.next();
-          rechnung.delete();
+          rechnung.deleteForced();
           count++;
         }
         catch (OperationCanceledException oce)
@@ -493,7 +493,7 @@ public class DbBereinigenControl extends AbstractControl
         try
         {
           sp = it.next();
-          sp.delete();
+          sp.deleteForced();
           count++;
         }
         catch (OperationCanceledException oce)

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -44,6 +44,7 @@ import de.jost_net.JVerein.util.StringTool;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.datasource.rmi.ResultSetExtractor;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class RechnungImpl extends AbstractJVereinDBObject
@@ -57,6 +58,28 @@ public class RechnungImpl extends AbstractJVereinDBObject
   public RechnungImpl() throws RemoteException
   {
     super();
+  }
+
+  @Override
+  protected void deleteCheck() throws ApplicationException
+  {
+    if (!forcedDelete)
+    {
+      try
+      {
+        if (getVersanddatum() != null)
+        {
+          throw new ApplicationException(
+              "Rechnung kann nicht gelöscht werden. Sie wurde bereits versendet!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+        String msg = "Rechnung kann nicht gelöscht werden. Siehe system log";
+        throw new ApplicationException(msg);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SpendenbescheinigungImpl.java
@@ -58,9 +58,25 @@ public class SpendenbescheinigungImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  protected void deleteCheck()
+  protected void deleteCheck() throws ApplicationException
   {
-    //
+    if (!forcedDelete)
+    {
+      try
+      {
+        if (getVersanddatum() != null)
+        {
+          throw new ApplicationException(
+              "Spendenbescheinigung kann nicht gelöscht werden. Sie wurde bereits versendet!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        Logger.error("Fehler", e);
+        String msg = "Spendenbescheinigung kann nicht gelöscht werden. Siehe system log";
+        throw new ApplicationException(msg);
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Wie in #1330 gewünscht sollen Rechnungen und Spendenbescheinigungen nicht gelöscht werden können wenn sie schon versendet wurden.