### PR TITLE
Abrechnungslauf abschließen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufAbschliessenAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufAbschliessenAction.java
@@ -28,15 +28,21 @@ import java.rmi.RemoteException;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
-import de.willuhn.jameica.gui.dialogs.YesNoDialog;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 /**
- * Löschen eines Abrechnungslaufes
+ * Abschließen eines Abrechnungslaufes
  */
 public class AbrechnungslaufAbschliessenAction implements Action
 {
+  private boolean abschliessen;
+
+  public AbrechnungslaufAbschliessenAction(boolean abschliessen)
+  {
+    this.abschliessen = abschliessen;
+  }
+
   @Override
   public void handleAction(Object context) throws ApplicationException
   {
@@ -51,35 +57,16 @@ public class AbrechnungslaufAbschliessenAction implements Action
       {
         return;
       }
-      if (abrl.getAbgeschlossen())
+      if (!abrl.isJahrAbgeschlossen())
+      {
+        abrl.setAbgeschlossen(abschliessen);
+        abrl.store();
+      }
+      else
       {
         throw new ApplicationException(
-            "Abrechnungsauf ist bereits abgeschlossen.");
+            "Änderung nicht möglich, der Jahresabschluss ist bereits erstellt.");
       }
-
-      YesNoDialog d = new YesNoDialog(YesNoDialog.POSITION_CENTER);
-      d.setTitle(String.format("Abrechnungslauf %s abschließen", abrl.getID()));
-      d.setText(
-          "Wollen Sie diesen Abrechnungslauf wirklich abschließen?\nEin nachträgliches Löschen ist dann nicht mehr möglich.");
-
-      try
-      {
-        Boolean choice = (Boolean) d.open();
-        if (!choice.booleanValue())
-        {
-          return;
-        }
-      }
-      catch (Exception e)
-      {
-        Logger.error("Fehler beim Abschließen eines Abrechnungslaufes", e);
-        return;
-      }
-
-      abrl.setAbgeschlossen(true);
-      abrl.store();
-
-      GUI.getStatusBar().setSuccessText("Abrechnungslauf wurde abgeschlossen.");
     }
     catch (RemoteException e)
     {

--- a/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
@@ -51,6 +51,13 @@ public class AbrechnungslaufDeleteAction extends DeleteAction
     }
     Abrechnungslauf abrl = (Abrechnungslauf) object[0];
 
+    // Prüfen ob der Abrechnungslauf abgeschlossen ist
+    if (abrl.getAbgeschlossen())
+    {
+      throw new ApplicationException(
+          "Abgeschlossene Abrechnungsläufe können nicht gelöscht werden!");
+    }
+
     // Prüfe, ob einer der erzeugten Buchungen bereits abgeschlossen ist
     final DBService service = Einstellungen.getDBService();
     String sql1 = "SELECT jahresabschluss.bis from jahresabschluss "

--- a/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/AbrechnungslaufDeleteAction.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.util.Date;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.JVereinDBObject;
@@ -180,69 +181,80 @@ public class AbrechnungslaufDeleteAction extends DeleteAction
       return;
     }
 
-    DBIterator<Buchung> it = Einstellungen.getDBService()
-        .createList(Buchung.class);
-    it.addFilter("abrechnungslauf = ?", new Object[] { object.getID() });
-    while (it.hasNext())
+    try
     {
-      Buchung bu = it.next();
-      if (bu.getSpendenbescheinigung() != null)
-        bu.getSpendenbescheinigung().delete();
-      try
+      DBTransaction.starten();
+      DBIterator<Buchung> it = Einstellungen.getDBService()
+          .createList(Buchung.class);
+      it.addFilter("abrechnungslauf = ?", new Object[] { object.getID() });
+      while (it.hasNext())
       {
-        bu.delete();
+        Buchung bu = it.next();
+        if (bu.getSpendenbescheinigung() != null)
+          bu.getSpendenbescheinigung().delete();
+        try
+        {
+          bu.delete();
+        }
+        catch (RemoteException ignore)
+        {
+          // Ignorieren, da die Exception auftritt, wenn die Buchung bereits
+          // gelöscht wurde, z. B. bei Splitbuchungen.
+        }
       }
-      catch (RemoteException ignore)
+      DBIterator<Sollbuchung> sollbIt = Einstellungen.getDBService()
+          .createList(Sollbuchung.class);
+      sollbIt.addFilter(Sollbuchung.ABRECHNUNGSLAUF + " = ?",
+          new Object[] { object.getID() });
+      while (sollbIt.hasNext())
       {
-        // Ignorieren, da die Exception auftritt, wenn die Buchung bereits
-        // gelöscht wurde, z. B. bei Splitbuchungen.
+        Sollbuchung sollb = sollbIt.next();
+        if (sollb.getRechnung() != null)
+          sollb.getRechnung().delete();
+        sollb.delete();
       }
+      it = Einstellungen.getDBService()
+          .createList(ZusatzbetragAbrechnungslauf.class);
+      it.addFilter("abrechnungslauf = ?", object.getID());
+      while (it.hasNext())
+      {
+        ZusatzbetragAbrechnungslauf za = (ZusatzbetragAbrechnungslauf) it
+            .next();
+        Zusatzbetrag z = (Zusatzbetrag) Einstellungen.getDBService()
+            .createObject(Zusatzbetrag.class, za.getZusatzbetrag().getID());
+        try
+        {
+          z.vorherigeFaelligkeit();
+        }
+        catch (RemoteException e)
+        {
+          // Ignorieren, da die Exeption auftritt wenn das Fälligkeitsdatum
+          // nicht weiter zurückgesetzt werden kann
+        }
+        z.setAusfuehrung(za.getLetzteAusfuehrung());
+        z.store();
+      }
+      it = Einstellungen.getDBService().createList(Lastschrift.class);
+      it.addFilter("abrechnungslauf = ?", object.getID());
+      while (it.hasNext())
+      {
+        Lastschrift la = (Lastschrift) it.next();
+        Kursteilnehmer kt = la.getKursteilnehmer();
+        if (kt != null)
+        {
+          kt.resetAbbudatum();
+          kt.store();
+        }
+        la.delete();
+      }
+      object.delete();
+      DBTransaction.commit();
     }
-    DBIterator<Sollbuchung> sollbIt = Einstellungen.getDBService()
-        .createList(Sollbuchung.class);
-    sollbIt.addFilter(Sollbuchung.ABRECHNUNGSLAUF + " = ?",
-        new Object[] { object.getID() });
-    while (sollbIt.hasNext())
+    catch (Exception e)
     {
-      Sollbuchung sollb = sollbIt.next();
-      if (sollb.getRechnung() != null)
-        sollb.getRechnung().delete();
-      sollb.delete();
+      DBTransaction.rollback();
+      throw e;
     }
-    it = Einstellungen.getDBService()
-        .createList(ZusatzbetragAbrechnungslauf.class);
-    it.addFilter("abrechnungslauf = ?", object.getID());
-    while (it.hasNext())
-    {
-      ZusatzbetragAbrechnungslauf za = (ZusatzbetragAbrechnungslauf) it.next();
-      Zusatzbetrag z = (Zusatzbetrag) Einstellungen.getDBService()
-          .createObject(Zusatzbetrag.class, za.getZusatzbetrag().getID());
-      try
-      {
-        z.vorherigeFaelligkeit();
-      }
-      catch (RemoteException e)
-      {
-        // Ignorieren, da die Exeption auftritt wenn das Fälligkeitsdatum
-        // nicht weiter zurückgesetzt werden kann
-      }
-      z.setAusfuehrung(za.getLetzteAusfuehrung());
-      z.store();
-    }
-    it = Einstellungen.getDBService().createList(Lastschrift.class);
-    it.addFilter("abrechnungslauf = ?", object.getID());
-    it.addFilter("kursteilnehmer IS NOT NULL");
-    while (it.hasNext())
-    {
-      Lastschrift la = (Lastschrift) it.next();
-      Kursteilnehmer kt = la.getKursteilnehmer();
-      if (kt != null)
-      {
-        kt.resetAbbudatum();
-        kt.store();
-      }
-    }
-    object.delete();
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -36,6 +36,7 @@ import de.jost_net.JVerein.gui.menu.BuchungAbrechnugslaufMenu;
 import de.jost_net.JVerein.gui.menu.LastschriftMenu;
 import de.jost_net.JVerein.gui.menu.SollbuchungMenu;
 import de.jost_net.JVerein.gui.menu.ZusatzbetraegeMenu;
+import de.jost_net.JVerein.gui.parts.AutoUpdateTablePart;
 import de.jost_net.JVerein.gui.parts.BetragSummaryTablePart;
 import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
@@ -303,9 +304,21 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
       return abrechnungslaufList;
     }
 
-    abrechnungslaufList = new JVereinTablePart(getAbrechnungslaeufe(),
+    abrechnungslaufList = new AutoUpdateTablePart(getAbrechnungslaeufe(),
         new EditAction(AbrechnungslaufDetailView.class));
     abrechnungslaufList.addColumn("Nr", "nr");
+    if ((Boolean) Einstellungen.getEinstellung(Property.ABRLABSCHLIESSEN))
+    {
+      abrechnungslaufList.addColumn("Abgeschlossen", "abgeschlossen",
+          new Formatter()
+          {
+            @Override
+            public String format(Object o)
+            {
+              return (Boolean) o ? "\uD83D\uDD12" : "";
+            }
+          });
+    }
     abrechnungslaufList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));
     abrechnungslaufList.addColumn("Modus", "modus",

--- a/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/AbrechnungslaufControl.java
@@ -310,14 +310,7 @@ public class AbrechnungslaufControl extends FilterControl implements Savable
     if ((Boolean) Einstellungen.getEinstellung(Property.ABRLABSCHLIESSEN))
     {
       abrechnungslaufList.addColumn("Abgeschlossen", "abgeschlossen",
-          new Formatter()
-          {
-            @Override
-            public String format(Object o)
-            {
-              return (Boolean) o ? "\uD83D\uDD12" : "";
-            }
-          });
+          o -> (Boolean) o ? "\uD83D\uDD12" : "");
     }
     abrechnungslaufList.addColumn("Datum", "datum",
         new DateFormatter(new JVDateFormatTTMMJJJJ()));

--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1796,6 +1796,13 @@ public class BuchungsControl extends VorZurueckControl implements Savable
           return editable = false;
         }
       }
+      if (getBuchung().getAbrechnungslauf() != null
+          && getBuchung().getAbrechnungslauf().getAbgeschlossen())
+      {
+        GUI.getStatusBar().setErrorText(
+            "Buchung kann nicht bearbeitet werden. Der zugehörige Abrechnungslauf ist abgeschlossen.");
+        return editable = false;
+      }
     }
     catch (RemoteException e)
     {

--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1795,13 +1795,13 @@ public class BuchungsControl extends VorZurueckControl implements Savable
               "Buchung kann nicht bearbeitet werden. Sie ist einer Splitbuchung zugeordnet.");
           return editable = false;
         }
-      }
-      if (getBuchung().getAbrechnungslauf() != null
-          && getBuchung().getAbrechnungslauf().getAbgeschlossen())
-      {
-        GUI.getStatusBar().setErrorText(
-            "Buchung kann nicht bearbeitet werden. Der zugehörige Abrechnungslauf ist abgeschlossen.");
-        return editable = false;
+        if (getBuchung().getAbrechnungslauf() != null
+            && getBuchung().getAbrechnungslauf().getAbgeschlossen())
+        {
+          GUI.getStatusBar().setErrorText(
+              "Buchung kann nicht bearbeitet werden. Der zugehörige Abrechnungslauf ist abgeschlossen.");
+          return editable = false;
+        }
       }
     }
     catch (RemoteException e)

--- a/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
@@ -579,7 +579,7 @@ public class DbBereinigenControl extends AbstractControl
           }
           try
           {
-            b.delete();
+            b.deleteForced();
           }
           catch (RemoteException e)
           {
@@ -600,7 +600,7 @@ public class DbBereinigenControl extends AbstractControl
           {
             if (sollloeschen && (b.getSollbuchung() != null))
             {
-              b.getSollbuchung().delete();
+              b.getSollbuchung().deleteForced();
               counts++;
             }
           }
@@ -677,7 +677,7 @@ public class DbBereinigenControl extends AbstractControl
         try
         {
           la = it.next();
-          la.delete();
+          la.deleteForced();
           count++;
         }
         catch (OperationCanceledException oce)
@@ -809,7 +809,7 @@ public class DbBereinigenControl extends AbstractControl
             continue;
           }
 
-          al.delete();
+          al.deleteForced();
           count++;
         }
         catch (OperationCanceledException oce)

--- a/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/DbBereinigenControl.java
@@ -30,7 +30,6 @@ import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mail;
 import de.jost_net.JVerein.rmi.Rechnung;
-import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
 import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.datasource.rmi.DBService;
@@ -727,88 +726,6 @@ public class DbBereinigenControl extends AbstractControl
         try
         {
           al = it.next();
-          // Suche Buchung des Abrechnungslaufes
-          final DBService service = Einstellungen.getDBService();
-          String sql = "SELECT buchung.id from buchung "
-              + "WHERE abrechnungslauf = ? ";
-          boolean buchungen = (boolean) service.execute(sql,
-              new Object[] { al.getID() }, new ResultSetExtractor()
-              {
-                @Override
-                public Object extract(ResultSet rs)
-                    throws RemoteException, SQLException
-                {
-                  if (rs.next())
-                  {
-                    return true;
-                  }
-                  return false;
-                }
-              });
-          if (buchungen)
-          {
-            String fehler = "Der Abrechnungslauf mit der Nr " + al.getID()
-                + " wurde nicht gelöscht. Es existieren noch Buchungen"
-                + " zu diesem Abrechnungslauf";
-            monitor.setStatusText(fehler);
-            continue;
-          }
-
-          // Suche Sollbuchung des Abrechnungslaufes
-          final DBService service1 = Einstellungen.getDBService();
-          String sql1 = "SELECT " + Sollbuchung.TABLE_NAME_ID + " from "
-              + Sollbuchung.TABLE_NAME + " WHERE " + Sollbuchung.ABRECHNUNGSLAUF
-              + " = ? ";
-          boolean sollbuchungen = (boolean) service1.execute(sql1,
-              new Object[] { al.getID() }, new ResultSetExtractor()
-              {
-                @Override
-                public Object extract(ResultSet rs)
-                    throws RemoteException, SQLException
-                {
-                  if (rs.next())
-                  {
-                    return true;
-                  }
-                  return false;
-                }
-              });
-          if (sollbuchungen)
-          {
-            String fehler = "Der Abrechnungslauf mit der Nr " + al.getID()
-                + " wurde nicht gelöscht. Es existieren noch Sollbuchungen"
-                + " zu diesem Abrechnungslauf";
-            monitor.setStatusText(fehler);
-            continue;
-          }
-
-          // Suche Lastschriften des Abrechnungslaufes
-          final DBService service2 = Einstellungen.getDBService();
-          String sql2 = "SELECT lastschrift.id from lastschrift "
-              + "WHERE abrechnungslauf = ? ";
-          boolean lastschriften = (boolean) service2.execute(sql2,
-              new Object[] { al.getID() }, new ResultSetExtractor()
-              {
-                @Override
-                public Object extract(ResultSet rs)
-                    throws RemoteException, SQLException
-                {
-                  if (rs.next())
-                  {
-                    return true;
-                  }
-                  return false;
-                }
-              });
-          if (lastschriften)
-          {
-            String fehler = "Der Abrechnungslauf mit der Nr " + al.getID()
-                + " wurde nicht gelöscht. Es existieren noch Lastschriften"
-                + " zu diesem Abrechnungslauf";
-            monitor.setStatusText(fehler);
-            continue;
-          }
-
           al.deleteForced();
           count++;
         }

--- a/src/main/java/de/jost_net/JVerein/gui/control/PreNotificationControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/PreNotificationControl.java
@@ -367,14 +367,6 @@ public class PreNotificationControl extends DruckMailControl
       Lastschrift[] lastschriftarray = (Lastschrift[]) currentObject;
       for (Lastschrift lastschrift : lastschriftarray)
       {
-        Abrechnungslauf abrl = (Abrechnungslauf) lastschrift
-            .getAbrechnungslauf();
-        if (abrl.getAbgeschlossen())
-        {
-          throw new ApplicationException(
-              "Die ausgewählte Lastschrift mit der Nr " + lastschrift.getID()
-                  + " ist bereits abgeschlossen!");
-        }
         lastschriften.add(lastschrift);
       }
     }

--- a/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -870,6 +870,13 @@ public class SollbuchungControl extends DruckMailControl implements Savable
           "Sollbuchung kann nicht bearbeitet werden. Es wurde bereits eine Rechnung über diese Sollbuchung erstellt.");
       return editable = false;
     }
+    if (getSollbuchung().getAbrechnungslauf() != null
+        && getSollbuchung().getAbrechnungslauf().getAbgeschlossen())
+    {
+      GUI.getStatusBar().setErrorText(
+          "Sollbuchung kann nicht bearbeitet werden. Der zugehörige Abrechnungslauf ist abgeschlossen.");
+      return editable = false;
+    }
     return editable = true;
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
+++ b/src/main/java/de/jost_net/JVerein/gui/menu/AbrechnungslaufMenu.java
@@ -50,12 +50,12 @@ public class AbrechnungslaufMenu extends ContextMenu
     addItem(new ContextMenuItem("Bearbeiten",
         new EditAction(AbrechnungslaufDetailView.class, part),
         "text-x-generic.png"));
-    addItem(new AbgeschlossenDisabledItem("Löschen",
+    addItem(new CheckedSingleContextMenuItem("Löschen",
         new AbrechnungslaufDeleteAction(), "user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new CheckedSingleContextMenuItem("Gutschrift erstellen",
         new GutschriftAction(), "ueberweisung.png"));
-    addItem(new AbgeschlossenDisabledItem("Pre-Notification",
+    addItem(new CheckedSingleContextMenuItem("Pre-Notification",
         new StartViewAction(PreNotificationMailView.class, true),
         "document-print.png"));
     try
@@ -64,7 +64,10 @@ public class AbrechnungslaufMenu extends ContextMenu
       {
         addItem(ContextMenuItem.SEPARATOR);
         addItem(new AbgeschlossenDisabledItem("Abschließen",
-            new AbrechnungslaufAbschliessenAction(), "lock.png"));
+            new AbrechnungslaufAbschliessenAction(true), "locked.png", false));
+        addItem(new AbgeschlossenDisabledItem("Aufschließen",
+            new AbrechnungslaufAbschliessenAction(false), "unlocked.png",
+            true));
       }
     }
     catch (RemoteException e)
@@ -75,10 +78,13 @@ public class AbrechnungslaufMenu extends ContextMenu
 
   private static class AbgeschlossenDisabledItem extends CheckedContextMenuItem
   {
+    boolean abgeschlossen;
 
-    private AbgeschlossenDisabledItem(String text, Action action, String icon)
+    private AbgeschlossenDisabledItem(String text, Action action, String icon,
+        boolean abgeschlossen)
     {
       super(text, action, icon);
+      this.abgeschlossen = abgeschlossen;
     }
 
     @Override
@@ -89,21 +95,15 @@ public class AbrechnungslaufMenu extends ContextMenu
         Abrechnungslauf abrl = (Abrechnungslauf) o;
         try
         {
-          if (abrl.getAbgeschlossen())
-          {
-            return false;
-          }
-          else
-          {
-            return true;
-          }
+          return !abgeschlossen ^ abrl.getAbgeschlossen()
+              && !abrl.isJahrAbgeschlossen();
         }
         catch (RemoteException e)
         {
-          return false;
+          Logger.error("Fehler", e);
         }
       }
-      return super.isEnabledFor(o);
+      return true;
     }
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/view/LastschriftDetailView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/LastschriftDetailView.java
@@ -19,7 +19,6 @@ package de.jost_net.JVerein.gui.view;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
 import de.jost_net.JVerein.gui.control.LastschriftControl;
 import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
-import de.jost_net.JVerein.gui.parts.SaveButton;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.util.ColumnLayout;
@@ -75,7 +74,6 @@ public class LastschriftDetailView extends AbstractView
     buttons.addButton(control.getInfoButton());
     buttons.addButton(control.getVorButton());
     buttons.addButton(control.getDruckUndMailButton());
-    buttons.addButton(new SaveButton(control));
     buttons.paint(this.getParent());
   }
 }

--- a/src/main/java/de/jost_net/JVerein/io/AbstractAusgabe.java
+++ b/src/main/java/de/jost_net/JVerein/io/AbstractAusgabe.java
@@ -121,7 +121,7 @@ public abstract class AbstractAusgabe
           {
             IVersand versand = (IVersand) object;
             versand.setVersanddatum(new Date());
-            versand.store();
+            versand.updateForced();
           }
         }
 
@@ -141,7 +141,7 @@ public abstract class AbstractAusgabe
           {
             IVersand versand = (IVersand) object;
             versand.setVersanddatum(new Date());
-            versand.store();
+            versand.updateForced();
           }
         }
         GUI.getStatusBar()

--- a/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
@@ -328,7 +328,7 @@ public class ZipMailer
                 if (versand != null)
                 {
                   versand.setVersanddatum(new Date());
-                  versand.store();
+                  versand.updateForced();
                 }
               }
               catch (MessagingException me)

--- a/src/main/java/de/jost_net/JVerein/rmi/Abrechnungslauf.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/Abrechnungslauf.java
@@ -79,4 +79,5 @@ public interface Abrechnungslauf extends JVereinDBObject
 
   public void setBemerkung(String bemerkung) throws RemoteException;
 
+  boolean isJahrAbgeschlossen() throws RemoteException;
 }

--- a/src/main/java/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
@@ -21,9 +21,13 @@ import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
+import de.jost_net.JVerein.rmi.Lastschrift;
+import de.jost_net.JVerein.rmi.Sollbuchung;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
 import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class AbrechnungslaufImpl extends AbstractJVereinDBObject
@@ -64,8 +68,50 @@ public class AbrechnungslaufImpl extends AbstractJVereinDBObject
       }
       catch (RemoteException e)
       {
-        throw new ApplicationException(e.getMessage());
+        Logger.error("Fehler", e);
+        String msg = "Abrechnungslauf kann nicht gelöscht werden. Siehe system log";
+        throw new ApplicationException(msg);
       }
+    }
+
+    try
+    {
+      // Suche Buchung des Abrechnungslaufes
+      DBIterator<Buchung> bit = Einstellungen.getDBService()
+          .createList(Buchung.class);
+      bit.addFilter("abrechnungslauf = ?", getID());
+      bit.setLimit(1);
+      if (bit.hasNext())
+      {
+        throw new ApplicationException(
+            "Abrechnungslauf kann nicht gelöscht werden, er hat noch Buchungen!");
+      }
+      // Suche Sollbuchung des Abrechnungslaufes
+      DBIterator<Sollbuchung> sit = Einstellungen.getDBService()
+          .createList(Sollbuchung.class);
+      sit.addFilter("abrechnungslauf = ?", getID());
+      sit.setLimit(1);
+      if (sit.hasNext())
+      {
+        throw new ApplicationException(
+            "Abrechnungslauf kann nicht gelöscht werden, er hat noch Sollbuchungen!");
+      }
+      // Suche Lastschriften des Abrechnungslaufes
+      DBIterator<Lastschrift> lit = Einstellungen.getDBService()
+          .createList(Lastschrift.class);
+      lit.addFilter("abrechnungslauf = ?", getID());
+      lit.setLimit(1);
+      if (lit.hasNext())
+      {
+        throw new ApplicationException(
+            "Abrechnungslauf kann nicht gelöscht werden, er hat noch Lastschriften!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      String msg = "Abrechnungslauf kann nicht gelöscht werden. Siehe system log";
+      throw new ApplicationException(msg);
     }
   }
 

--- a/src/main/java/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/AbrechnungslaufImpl.java
@@ -19,8 +19,11 @@ package de.jost_net.JVerein.server;
 import java.rmi.RemoteException;
 import java.util.Date;
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.datasource.rmi.DBIterator;
 import de.willuhn.util.ApplicationException;
 
 public class AbrechnungslaufImpl extends AbstractJVereinDBObject
@@ -49,17 +52,20 @@ public class AbrechnungslaufImpl extends AbstractJVereinDBObject
   @Override
   protected void deleteCheck() throws ApplicationException
   {
-    try
+    if (!forcedDelete)
     {
-      if (getAbgeschlossen())
+      try
       {
-        throw new ApplicationException(
-            "Abgeschlossene Abrechnungsläufe können nicht gelöscht werden!");
+        if (getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Abgeschlossene Abrechnungsläufe können nicht gelöscht werden!");
+        }
       }
-    }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException(e.getMessage());
+      catch (RemoteException e)
+      {
+        throw new ApplicationException(e.getMessage());
+      }
     }
   }
 
@@ -253,7 +259,13 @@ public class AbrechnungslaufImpl extends AbstractJVereinDBObject
    */
   public String getIDText() throws RemoteException
   {
-    return getID() + " " + "vom" + " "
+    String prefix = "";
+    if ((Boolean) Einstellungen.getEinstellung(Property.ABRLABSCHLIESSEN)
+        && getAbgeschlossen())
+    {
+      prefix = "\uD83D\uDD12 ";
+    }
+    return prefix + getID() + " " + "vom" + " "
         + new JVDateFormatTTMMJJJJ().format(getDatum()) + " ("
         + getZahlungsgrund() + ")";
   }
@@ -318,6 +330,17 @@ public class AbrechnungslaufImpl extends AbstractJVereinDBObject
   public String getObjektNameMehrzahl()
   {
     return "Abrechnungsläufe";
+  }
+
+  @Override
+  public boolean isJahrAbgeschlossen() throws RemoteException
+  {
+    DBIterator<Jahresabschluss> it = Einstellungen.getDBService()
+        .createList(Jahresabschluss.class);
+    it.addFilter("von <= ?", new Object[] { getFaelligkeit() });
+    it.addFilter("bis >= ?", new Object[] { getFaelligkeit() });
+    it.setLimit(1);
+    return it.hasNext();
   }
 
 }

--- a/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
@@ -89,6 +89,13 @@ public class BuchungImpl extends AbstractJVereinDBObject
             "Buchung kann nicht gelöscht werden weil sie zu einer "
                 + "Spendenbescheinigung gehört");
       }
+      if (!forcedDelete && getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Buchung kann nicht gelöscht werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
     }
     catch (ObjectNotFoundException e)
     {
@@ -762,6 +769,11 @@ public class BuchungImpl extends AbstractJVereinDBObject
 
     if ("steuer".equals(fieldName))
       return getSteuer();
+
+    if (fieldName.equals("abrechnungslauf"))
+    {
+      return getAbrechnungslauf();
+    }
 
     if ("document".equals(fieldName))
     {

--- a/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
@@ -265,6 +265,31 @@ public class BuchungImpl extends AbstractJVereinDBObject
   @Override
   protected void updateCheck() throws ApplicationException
   {
+    if (!forcedUpdate)
+    {
+      try
+      {
+        Jahresabschluss ja = getJahresabschluss();
+        if (ja != null)
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht gespeichert werden. Zeitraum ist bereits abgeschlossen!");
+        }
+        if (getAbrechnungslauf() != null
+            && getAbrechnungslauf().getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Buchung kann nicht kann nicht geändert werden weil der zugehörige "
+                  + "Abrechnungslauf abgeschlossen ist!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Buchung kann nicht gespeichert werden. Siehe system log.";
+        Logger.error(fehler, e);
+        throw new ApplicationException(fehler);
+      }
+    }
     insertCheck();
   }
 

--- a/src/main/java/de/jost_net/JVerein/server/LastschriftImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/LastschriftImpl.java
@@ -74,13 +74,32 @@ public class LastschriftImpl extends AbstractJVereinDBObject
   @Override
   protected void insertCheck()
   {
-    updateCheck();
+    //
   }
 
   @Override
-  protected void updateCheck()
+  protected void updateCheck() throws ApplicationException
   {
-    //
+    if (!forcedUpdate)
+    {
+      try
+      {
+        if (getAbrechnungslauf() != null
+            && getAbrechnungslauf().getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Lastschrift kann nicht geändert werden weil der zugehörige "
+                  + "Abrechnungslauf abgeschlossen ist!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Lastschrift kann nicht gespeichert werden. Siehe system log.";
+        Logger.error(fehler, e);
+        throw new ApplicationException(fehler);
+      }
+    }
+    insertCheck();
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/LastschriftImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/LastschriftImpl.java
@@ -24,6 +24,8 @@ import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Kursteilnehmer;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Mitglied;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class LastschriftImpl extends AbstractJVereinDBObject
     implements Lastschrift, IBetrag, IVersand, IMitglied
@@ -49,9 +51,24 @@ public class LastschriftImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  protected void deleteCheck()
+  protected void deleteCheck() throws ApplicationException
   {
-    //
+    try
+    {
+      if (!forcedDelete && getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Lastschrift kann nicht gelöscht werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      throw new ApplicationException(
+          "Lastschrift kann nicht gelöscht werden. Siehe system log.");
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -144,6 +144,13 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
           throw new ApplicationException(
               "Sollbuchung kann nicht geändert werden weil sie zu einer Rechnung gehört");
         }
+        if (getAbrechnungslauf() != null
+            && getAbrechnungslauf().getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Sollbuchung kann nicht geändert werden weil der zugehörige "
+                  + "Abrechnungslauf abgeschlossen ist!");
+        }
       }
       catch (ObjectNotFoundException e)
       {

--- a/src/main/java/de/jost_net/JVerein/server/SollbuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SollbuchungImpl.java
@@ -73,6 +73,13 @@ public class SollbuchungImpl extends AbstractJVereinDBObject
             "Sollbuchung kann nicht gelöscht werden weil sie zu einer "
                 + "Rechnung gehört!");
       }
+      if (!forcedDelete && getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Sollbuchung kann nicht gelöscht werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
     }
     catch (ObjectNotFoundException e)
     {

--- a/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
@@ -67,6 +67,22 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
   {
     try
     {
+      try
+      {
+        if (getSollbuchung().getAbrechnungslauf() != null
+            && getSollbuchung().getAbrechnungslauf().getAbgeschlossen())
+        {
+          throw new ApplicationException(
+              "Sollbuchungsposition kann nicht eingefügt werden weil der Abrechnungslauf "
+                  + "der Sollbuchung abgeschlossen ist!");
+        }
+      }
+      catch (RemoteException e)
+      {
+        String fehler = "Lastschrift kann nicht gespeichert werden. Siehe system log.";
+        Logger.error(fehler, e);
+        throw new ApplicationException(fehler);
+      }
       plausi();
     }
     catch (RemoteException e)
@@ -128,6 +144,22 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
   @Override
   protected void updateCheck() throws ApplicationException
   {
+    try
+    {
+      if (getSollbuchung().getAbrechnungslauf() != null
+          && getSollbuchung().getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Sollbuchungsposition kann nicht geändert werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Lastschrift kann nicht gespeichert werden. Siehe system log.";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler);
+    }
     insertCheck();
   }
 

--- a/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
@@ -79,7 +79,7 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
       }
       catch (RemoteException e)
       {
-        String fehler = "Lastschrift kann nicht gespeichert werden. Siehe system log.";
+        String fehler = "Sollbuchungsposition kann nicht gespeichert werden. Siehe system log.";
         Logger.error(fehler, e);
         throw new ApplicationException(fehler);
       }
@@ -89,7 +89,7 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
     {
       Logger.error("Fehler", e);
       throw new ApplicationException(
-          "Buchung kann nicht gespeichert werden. Siehe system log");
+          "Sollbuchungsposition kann nicht gespeichert werden. Siehe system log");
     }
   }
 
@@ -156,7 +156,7 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
     }
     catch (RemoteException e)
     {
-      String fehler = "Lastschrift kann nicht gespeichert werden. Siehe system log.";
+      String fehler = "Sollbuchungsposition kann nicht gespeichert werden. Siehe system log.";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler);
     }

--- a/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/SollbuchungPositionImpl.java
@@ -42,6 +42,27 @@ public class SollbuchungPositionImpl extends AbstractJVereinDBObject
   }
 
   @Override
+  protected void deleteCheck() throws ApplicationException
+  {
+    try
+    {
+      if (getSollbuchung().getAbrechnungslauf() != null
+          && getSollbuchung().getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Sollbuchungsposition kann nicht gelöscht werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      String msg = "Sollbuchungsposition kann nicht gelöscht werden. Siehe system log";
+      throw new ApplicationException(msg);
+    }
+  }
+
+  @Override
   protected void insertCheck() throws ApplicationException
   {
     try

--- a/src/main/java/de/jost_net/JVerein/server/ZusatzbetragAbrechnungslaufImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/ZusatzbetragAbrechnungslaufImpl.java
@@ -23,6 +23,8 @@ import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Zusatzbetrag;
 import de.jost_net.JVerein.rmi.ZusatzbetragAbrechnungslauf;
 import de.willuhn.datasource.db.AbstractDBObject;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
 
 public class ZusatzbetragAbrechnungslaufImpl extends AbstractDBObject
     implements ZusatzbetragAbrechnungslauf
@@ -48,9 +50,24 @@ public class ZusatzbetragAbrechnungslaufImpl extends AbstractDBObject
   }
 
   @Override
-  protected void deleteCheck()
+  protected void deleteCheck() throws ApplicationException
   {
-    //
+    try
+    {
+      if (getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Zusatzbetragabrechnungslauf kann nicht gelöscht werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      String msg = "Zusatzbetragabrechnungslauf kann nicht gelöscht werden. Siehe system log";
+      throw new ApplicationException(msg);
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/ZusatzbetragAbrechnungslaufImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/ZusatzbetragAbrechnungslaufImpl.java
@@ -71,15 +71,45 @@ public class ZusatzbetragAbrechnungslaufImpl extends AbstractDBObject
   }
 
   @Override
-  protected void insertCheck()
+  protected void insertCheck() throws ApplicationException
   {
-    //
+    try
+    {
+      if (getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Zusatzbetragabrechnungslauf kann nicht erzeugt werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      String msg = "Zusatzbetragabrechnungslauf kann nicht erzeugt werden. Siehe system log";
+      throw new ApplicationException(msg);
+    }
   }
 
   @Override
-  protected void updateCheck()
+  protected void updateCheck() throws ApplicationException
   {
-    insertCheck();
+    try
+    {
+      if (getAbrechnungslauf() != null
+          && getAbrechnungslauf().getAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Zusatzbetragabrechnungslauf kann nicht geändert werden weil der zugehörige "
+                + "Abrechnungslauf abgeschlossen ist!");
+      }
+    }
+    catch (RemoteException e)
+    {
+      Logger.error("Fehler", e);
+      String msg = "Zusatzbetragabrechnungslauf kann nicht geändert werden. Siehe system log";
+      throw new ApplicationException(msg);
+    }
   }
 
   @Override


### PR DESCRIPTION
Ich habe an #406 gearbeitet und folgendes geändert:

* Ein abgeschlossener Abrechnungslauf kann wieder aufgeschlossen werden
* Die Menüeinträge haben Icons
* Die Tabelle der Abrechnungsläufe hat eine Spalte für Abgeschlossen
* In Abrechnungslauf Tabellenspalten bei Buchung, Sollbuchung und Lastschrift wird im Text ein Icon eingeblendet wenn der Abrechnungslauf abgeschlossen ist und es in den Einstellungen aktiviert ist
* Abschließen und Aufschließen sind ausgegraut wenn das Fälligkeitsdatum in einem Jahresabschluß liegt
* Prenotification wird nicht mehr blockiert
* Löschen wird bei abgeschlossenen Abrechnungsläufen nicht ausgegraut, es gibt aber eine Fehlermeldung. Wenn man in den Einstellungen den Haken wieder weg macht, würde man sich sonst wundern, warum Löschen ausgegraut ist
* Buchungen, Sollbuchungen und Lastschriften von abgeschlossenen Abrechnungsläufen können nicht mehr gelöscht oder editiert werden
* In DBBereinigen können Buchungen, Sollbuchungen und Lastschriften forced gelöscht werden, auch wenn sie einem abgeschlossen Abrechnungslauf angehören
* Ein abgeschlossener Abrechnungslauf kann in DBBereinigen gelöscht werden. PS: Das war bisher eine Fehler weil es nicht ging

Menü Update und Spalte in der Abrechnungslauf Tabelle:
<img width="249" height="223" alt="Bildschirmfoto_20260806_151136" src="https://github.com/user-attachments/assets/d8645fd1-87bf-4f04-9028-015b03577d36" />

Lastschrift, Sollbuchung und Buchung Tabelle:
<img width="136" height="86" alt="Bildschirmfoto_20260806_151228" src="https://github.com/user-attachments/assets/bcc8a361-7ca8-44dc-abbc-91ae8ffd326b" />
