### PR TITLE
Fix Versanddatum Anhang

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
@@ -322,7 +322,8 @@ public class ZipMailer
                     ma.store();
                   }
 
-                  // Versanddatum erst hier speichern,
+                  // Versanddatum erst hier speichern, sonst ist kann der Anhang
+                  // nicht gepeichert werden (da Mail schon versendet).
                   ml.setVersand(new Timestamp(new Date().getTime()));
                   ml.store();
                 }

--- a/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
+++ b/src/main/java/de/jost_net/JVerein/io/ZipMailer.java
@@ -305,7 +305,6 @@ public class ZipMailer
                   ml.setBetreff(betr);
                   ml.setTxt(text);
                   ml.setBearbeitung(new Timestamp(new Date().getTime()));
-                  ml.setVersand(new Timestamp(new Date().getTime()));
                   ml.store();
 
                   MailEmpfaenger me = (MailEmpfaenger) Einstellungen
@@ -322,6 +321,10 @@ public class ZipMailer
                     ma.setMail(ml);
                     ma.store();
                   }
+
+                  // Versanddatum erst hier speichern,
+                  ml.setVersand(new Timestamp(new Date().getTime()));
+                  ml.store();
                 }
 
                 // Als versendet markieren


### PR DESCRIPTION
Bei Versand von Dokumenten (Rechnungen etc) kam jetzt ein Fehler, da erst das Versanddatum gespeichert wurde, und dann der Anhang.