### PR TITLE
Fix Spaltenauswahl bei Sollbuchungen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/SollbuchungControl.java
@@ -584,7 +584,6 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     {
       buchungList.setContextMenu(new SollbuchungPositionMenu());
     }
-    buchungList.setTableName("Sollbuchungspositionen");
     buchungList.setMulti(true);
     sollbuchungConsumer = new SollbuchungMessageConsumer();
     Application.getMessagingFactory()
@@ -600,7 +599,6 @@ public class SollbuchungControl extends DruckMailControl implements Savable
     }
     istbuchungList = new BuchungListPart(getSollbuchung().getBuchungList(),
         new BuchungAction(false), new BuchungPartBearbeitenMenu());
-    istbuchungList.setTableName("Buchungen");
     Application.getMessagingFactory()
         .registerMessageConsumer(new MitgliedskontoMessageConsumer());
     return istbuchungList;

--- a/src/main/java/de/jost_net/JVerein/gui/parts/BuchungListPart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/BuchungListPart.java
@@ -48,6 +48,7 @@ public class BuchungListPart extends BuchungListTablePart
   {
     super(list, action);
 
+    setTableName("Buchungen");
     addColumn("Nr", "id-int");
     addColumn("Konto", "konto");
     addColumn("Datum", "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));

--- a/src/main/java/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/SollbuchungPositionListPart.java
@@ -44,6 +44,8 @@ public class SollbuchungPositionListPart extends BetragSummaryTablePart
   {
     super(list, action);
 
+    setTableName("SollbuchungsPositionen");
+
     addColumn("Datum", "datum", new DateFormatter(new JVDateFormatTTMMJJJJ()));
     addColumn("Zweck", "zweck");
     addColumn("Betrag", "betrag",


### PR DESCRIPTION
Die Auswahl der Spalten hat bei SollbuchungDetailView nicht geklappt, da der Name der Tabell zu spät gesetzt wurde.

Hiernach kann ich eine neue Bugfix Version rausgeben