### PR TITLE
Fix Spaltenauswahl Dialog

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
@@ -79,7 +79,7 @@ public class TabelleSpaltenAuswahlDialog extends AbstractDialog<Object>
         }
       };
 
-      part.addColumn("Namen", "name");
+      part.addColumn("Spalten", "name");
       part.setCheckable(true);
 
       if (tableMap.size() > 1)

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TabelleSpaltenAuswahlDialog.java
@@ -79,7 +79,7 @@ public class TabelleSpaltenAuswahlDialog extends AbstractDialog<Object>
         }
       };
 
-      part.addColumn("Name", "name");
+      part.addColumn("Namen", "name");
       part.setCheckable(true);
 
       if (tableMap.size() > 1)


### PR DESCRIPTION
Es gab ein Problem beim Spaltenauswahl Dialog. Wenn eine Tabelle eine Spalte mit Namen "Name" hat wie z.B. bei Eigenschaften und man wählt diese Spalte ab, dann werden beim neu Öffnen des Dialogs keine Namen mehr angezeigt, sondern nur die Checkboxen.
Es scheint so, dass das mit der Tabellenspalte mit Namen "Name" kollodiert. Ich habe diese nun umbenannt und es scheint zu funktionieren. Habe es jetzt "Spalten" genannt, das ist es ja was man auswählt.