### PR TITLE
Fix Font in Tabs von MitgliedListeView und NichtMitgliedListeView

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/view/MitgliedListeView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/MitgliedListeView.java
@@ -31,6 +31,7 @@ import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.Font;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
@@ -59,6 +60,7 @@ public class MitgliedListeView extends AbstractMitgliedListeView
         SWT.V_SCROLL | SWT.BORDER);
     folder.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
     folder.setBackground(Color.BACKGROUND.getSWTColor());
+    folder.setFont(Font.DEFAULT.getSWTFont());
 
     // Erster Tab
     TabGroup tab1 = new TabGroup(folder, "Allgemein", true, 3);

--- a/src/main/java/de/jost_net/JVerein/gui/view/NichtMitgliedListeView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/NichtMitgliedListeView.java
@@ -31,6 +31,7 @@ import de.willuhn.jameica.gui.input.DialogInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.Color;
+import de.willuhn.jameica.gui.util.Font;
 import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
@@ -58,6 +59,7 @@ public class NichtMitgliedListeView extends AbstractMitgliedListeView
         SWT.V_SCROLL | SWT.BORDER);
     folder.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
     folder.setBackground(Color.BACKGROUND.getSWTColor());
+    folder.setFont(Font.DEFAULT.getSWTFont());
 
     // Erster Tab
     TabGroup tab1 = new TabGroup(folder, "Allgemein", true, 3);


### PR DESCRIPTION
Weil die Tabs der Filter von MitgliedListeView und NichtMitgliedListeView innerhalb einer LabelGroup sind, haben sie die Fettschrift von dieser geerbt. Die Tab Titel sollten aber nicht Fett sein, so wie auch beim BuchungListeView.