### PR TITLE
TablePart Export auch mit ausgeblendeten Spalten

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -645,15 +645,14 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     }
   }
 
+  @SuppressWarnings("unchecked")
   void setWidth() throws ApplicationException
   {
     try
     {
-      spaltenList.removeAll();
-      colList = new ArrayList<>();
-      for (Column col : part.getAllColums())
+      for (ExportSpalte e : (List<ExportSpalte>) spaltenList.getItems(true))
       {
-        Item c = getColumn(col.getName());
+        Item c = getColumn(e.getColumn().getName());
         int breite = 0;
         if (c instanceof TreeColumn)
         {
@@ -663,11 +662,8 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
         {
           breite = ((TableColumn) c).getWidth();
         }
-        ExportSpalte item = new ExportSpalte(col, breite);
-        colList.add(item);
-        spaltenList.addItem(item);
-        spaltenList.setChecked(item, settings.getBoolean(
-            settingPrefix + "anzeigen." + col.getName(), breite > 0));
+        e.setBreite(breite);
+        spaltenList.updateItem(e, e);
       }
     }
     catch (RemoteException re)

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -148,7 +148,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
   }
 
   protected void createGui(Composite parent, Action action)
-      throws RemoteException
+      throws RemoteException, ApplicationException
   {
     if (spaltenList != null)
     {
@@ -163,6 +163,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     else if (spaltenList != null)
     {
       spaltenList.paint(parent);
+      spaltenList.setDragDrop();
     }
 
     setChecked();
@@ -179,7 +180,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
   }
 
   protected void zeichnePDF(Composite parent, Action action)
-      throws RemoteException
+      throws RemoteException, ApplicationException
   {
     TabFolder folder = new TabFolder(parent, SWT.BORDER);
     folder.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -190,6 +191,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
       TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
       spaltenList.addColumn("Breite", "breite", null, true);
       tabSpalten.addPart(spaltenList);
+      spaltenList.setDragDrop();
       ButtonArea buttons = new ButtonArea();
       buttons.addButton(new Button("Breiten zurücksetzen", action, null, false,
           "eraser.png"));

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -17,6 +17,8 @@ import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -163,7 +165,6 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     else if (spaltenList != null)
     {
       spaltenList.paint(parent);
-      spaltenList.setDragDrop();
     }
 
     setChecked();
@@ -191,7 +192,6 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
       TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
       spaltenList.addColumn("Breite", "breite", null, true);
       tabSpalten.addPart(spaltenList);
-      spaltenList.setDragDrop();
       ButtonArea buttons = new ButtonArea();
       buttons.addButton(new Button("Breiten zurücksetzen", action, null, false,
           "eraser.png"));
@@ -376,6 +376,10 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
       }
       colList.add(new ExportSpalte(col, breite));
     }
+    String[] spaltenNamen = settings.getString(settingPrefix + "order", "")
+        .split(",");
+    colList.sort(Comparator.comparingInt(
+        obj -> Arrays.asList(spaltenNamen).indexOf(obj.getColumn().getName())));
 
     spaltenList = new JVereinTablePart(colList, null)
     {
@@ -400,12 +404,14 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
       });
     }
     createGui(parent, c -> setWidth());
+    spaltenList.setDragDrop();
   }
 
   @SuppressWarnings("unchecked")
   protected void saveSettings() throws RemoteException
   {
     List<ExportSpalte> itemsChecked = spaltenList.getItems();
+    List<String> spaltenNamen = new ArrayList<>();
     for (ExportSpalte sp : (List<ExportSpalte>) spaltenList.getItems(false))
     {
       settings.setAttribute(
@@ -417,7 +423,10 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
             settingPrefix + "breite." + sp.getColumn().getName(),
             sp.getBreite());
       }
+      spaltenNamen.add(sp.getColumn().getName());
     }
+    settings.setAttribute(settingPrefix + "order",
+        String.join(",", spaltenNamen));
 
     if (art.equals(ExportArt.PDF))
     {

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -146,7 +146,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     this.part = part;
 
     setTitle(dialogTitel);
-    setSize(400, SWT.DEFAULT);
+    setSize(400, 700);
   }
 
   protected void createGui(Composite parent, Action action)
@@ -690,7 +690,8 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   abstract void exportCSV(File file) throws IOException;
 
-  abstract void exportPDF(File file) throws IOException, DocumentException;
+  abstract void exportPDF(File file)
+      throws IOException, DocumentException, ApplicationException;
 
   abstract Item getColumn(String name);
 

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/AbstractPartExportDialog.java
@@ -16,13 +16,19 @@ package de.jost_net.JVerein.gui.dialogs;
 import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.TabFolder;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TreeColumn;
 
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.DocumentException;
@@ -34,6 +40,7 @@ import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.input.FontInput;
 import de.jost_net.JVerein.gui.input.FormularInput;
+import de.jost_net.JVerein.gui.parts.IJVereinPart;
 import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.ExportLayoutParam;
 import de.jost_net.JVerein.keys.FormularArt;
@@ -47,6 +54,7 @@ import de.willuhn.jameica.gui.input.IntegerInput;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.jameica.system.Settings;
@@ -119,9 +127,13 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
 
   private ExportLayoutParam params;
 
+  private IJVereinPart part;
+
+  private List<ExportSpalte> colList;
+
   public AbstractPartExportDialog(String settingPrefix, ExportArt art,
-      String title, String subtitle, String filename, String dialogTitel)
-      throws ApplicationException
+      String title, String subtitle, String filename, String dialogTitel,
+      IJVereinPart part) throws ApplicationException
   {
     super(AbstractPartExportDialog.POSITION_CENTER);
     this.title = title;
@@ -129,6 +141,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     this.filename = filename;
     this.art = art;
     this.settingPrefix = settingPrefix + art.toString() + ".";
+    this.part = part;
 
     setTitle(dialogTitel);
     setSize(400, SWT.DEFAULT);
@@ -139,7 +152,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
   {
     if (spaltenList != null)
     {
-      spaltenList.addColumn("Name", "text");
+      spaltenList.addColumn("Spalten", "column.name");
       spaltenList.setCheckable(true);
     }
 
@@ -155,7 +168,8 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     setChecked();
 
     ButtonArea b = new ButtonArea();
-    b.addButton("Speichern", c -> export(), null, true, "ok.png");
+
+    b.addButton("Starten", c -> export(), null, true, "walking.png");
 
     b.addButton("Abbrechen", c -> {
       throw new OperationCanceledException();
@@ -174,7 +188,7 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     if (spaltenList != null)
     {
       TabGroup tabSpalten = new TabGroup(folder, "Spalten", true, 1);
-      spaltenList.addColumn("Breite", "data", null, true);
+      spaltenList.addColumn("Breite", "breite", null, true);
       tabSpalten.addPart(spaltenList);
       ButtonArea buttons = new ButtonArea();
       buttons.addButton(new Button("Breiten zurücksetzen", action, null, false,
@@ -337,8 +351,72 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     }
   }
 
+  @Override
+  protected void paint(Composite parent)
+      throws ApplicationException, RemoteException
+  {
+    colList = new ArrayList<>();
+    for (Column col : part.getAllColums())
+    {
+      int breite = settings.getInt(settingPrefix + "breite." + col.getName(),
+          0);
+      if (breite == 0)
+      {
+        Item i = getColumn(col.getName());
+        if (i instanceof TreeColumn)
+        {
+          breite = ((TreeColumn) i).getWidth();
+        }
+        else if (i instanceof TableColumn)
+        {
+          breite = ((TableColumn) i).getWidth();
+        }
+      }
+      colList.add(new ExportSpalte(col, breite));
+    }
+
+    spaltenList = new JVereinTablePart(colList, null)
+    {
+      // Sortieren verhindern
+      @Override
+      protected void orderBy(int index)
+      {
+        return;
+      }
+    };
+    if (art.equals(ExportArt.PDF))
+    {
+      spaltenList.addChangeListener((object, attribute, newValue) -> {
+        try
+        {
+          ((ExportSpalte) object).setBreite(Integer.parseInt(newValue));
+        }
+        catch (Exception e)
+        {
+          throw new ApplicationException("Ungültiger Wert");
+        }
+      });
+    }
+    createGui(parent, c -> setWidth());
+  }
+
+  @SuppressWarnings("unchecked")
   protected void saveSettings() throws RemoteException
   {
+    List<ExportSpalte> itemsChecked = spaltenList.getItems();
+    for (ExportSpalte sp : (List<ExportSpalte>) spaltenList.getItems(false))
+    {
+      settings.setAttribute(
+          settingPrefix + "anzeigen." + sp.getColumn().getName(),
+          itemsChecked.contains(sp));
+      if (art.equals(ExportArt.PDF))
+      {
+        settings.setAttribute(
+            settingPrefix + "breite." + sp.getColumn().getName(),
+            sp.getBreite());
+      }
+    }
+
     if (art.equals(ExportArt.PDF))
     {
       settings.setAttribute(settingPrefix + "links",
@@ -525,10 +603,126 @@ public abstract class AbstractPartExportDialog extends AbstractDialog<Boolean>
     return success;
   }
 
-  abstract void setChecked();
+  void resetSpalten() throws ApplicationException
+  {
+    try
+    {
+      spaltenList.removeAll();
+      colList = new ArrayList<>();
+      for (Column i : part.getAllColums())
+      {
+        Item c = getColumn(i.getName());
+        int breite = 0;
+        if (c instanceof TreeColumn)
+        {
+          breite = ((TreeColumn) c).getWidth();
+        }
+        else if (c instanceof TableColumn)
+        {
+          breite = ((TableColumn) c).getWidth();
+        }
+        colList.add(new ExportSpalte(i, breite));
+        ExportSpalte item = new ExportSpalte(i, breite);
+        spaltenList.addItem(item);
+        spaltenList.setChecked(item, breite > 0);
+      }
+    }
+    catch (RemoteException re)
+    {
+      Logger.error("Fehler beim zurücksetzen der Spalten", re);
+      throw new ApplicationException("Fehler beim zurücksetzen der Spalten");
+    }
+  }
+
+  void setWidth() throws ApplicationException
+  {
+    try
+    {
+      spaltenList.removeAll();
+      colList = new ArrayList<>();
+      for (Column col : part.getAllColums())
+      {
+        Item c = getColumn(col.getName());
+        int breite = 0;
+        if (c instanceof TreeColumn)
+        {
+          breite = ((TreeColumn) c).getWidth();
+        }
+        else if (c instanceof TableColumn)
+        {
+          breite = ((TableColumn) c).getWidth();
+        }
+        ExportSpalte item = new ExportSpalte(col, breite);
+        colList.add(item);
+        spaltenList.addItem(item);
+        spaltenList.setChecked(item, settings.getBoolean(
+            settingPrefix + "anzeigen." + col.getName(), breite > 0));
+      }
+    }
+    catch (RemoteException re)
+    {
+      Logger.error("Fehler beim zurücksetzen der Breiten", re);
+      throw new ApplicationException("Fehler beim zurücksetzen der Breiten");
+    }
+  }
+
+  void setChecked()
+  {
+    for (ExportSpalte sp : colList)
+    {
+      spaltenList.setChecked(sp,
+          settings.getBoolean(
+              settingPrefix + "anzeigen." + sp.getColumn().getName(),
+              part.getColums().contains(sp.getColumn())));
+    }
+  }
 
   abstract void exportCSV(File file) throws IOException;
 
   abstract void exportPDF(File file) throws IOException, DocumentException;
 
+  abstract Item getColumn(String name);
+
+  /**
+   * Hilfsklasse für die Spalten inkl. Breite
+   */
+  public class ExportSpalte
+  {
+    private int breite;
+
+    private Column column;
+
+    private int align;
+
+    public ExportSpalte(Column column, int breite)
+    {
+      this.column = column;
+      this.breite = breite;
+    }
+
+    public void setBreite(int breite)
+    {
+      this.breite = breite;
+    }
+
+    public int getBreite()
+    {
+      return breite;
+    }
+
+    public void setAlign(int align)
+    {
+      this.align = align;
+    }
+
+    public int getAlign()
+    {
+      return align;
+    }
+
+    public Column getColumn()
+    {
+      return column;
+    }
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/ExporterExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/ExporterExportDialog.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Item;
 
 import com.itextpdf.text.DocumentException;
 
@@ -32,7 +33,8 @@ public class ExporterExportDialog extends AbstractPartExportDialog
       ExportArt art, String title, String subtitle, String filename)
       throws ApplicationException
   {
-    super(settingPrefix, art, title, subtitle, filename, "Report generieren");
+    super(settingPrefix, art, title, subtitle, filename, "Report generieren",
+        null);
     supportTable2 = hasColortable2;
     settings = new Settings(this.getClass());
   }
@@ -85,4 +87,16 @@ public class ExporterExportDialog extends AbstractPartExportDialog
     // Kein Spalten Tab
   }
 
+  @Override
+  void resetSpalten()
+  {
+    // Kein Spalten Tab
+  }
+
+  @Override
+  Item getColumn(String name)
+  {
+    // hier nicht nötig
+    return null;
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/SaldoPartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/SaldoPartExportDialog.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Item;
 
 import com.itextpdf.text.DocumentException;
 import de.jost_net.JVerein.io.ISaldoExport;
@@ -40,7 +41,7 @@ public class SaldoPartExportDialog extends AbstractPartExportDialog
       throws ApplicationException
   {
     super(settingPrefix, art, title, subtitle, filename,
-        "Saldo Report generieren");
+        "Saldo Report generieren", null);
     this.export = export;
     this.zeile = zeile;
     settings = new Settings(this.getClass());
@@ -92,4 +93,16 @@ public class SaldoPartExportDialog extends AbstractPartExportDialog
     // Kein Spalten Tab
   }
 
+  @Override
+  void resetSpalten()
+  {
+    // Kein Spalten Tab
+  }
+
+  @Override
+  Item getColumn(String name)
+  {
+    // hier nicht nötig
+    return null;
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -117,7 +117,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
   }
 
   @Override
-  protected void exportPDF(File file) throws IOException, DocumentException
+  protected void exportPDF(File file)
+      throws IOException, DocumentException, ApplicationException
   {
     try (FileOutputStream fos = new FileOutputStream(file);
         Reporter reporter = new Reporter(fos, title, subtitle,
@@ -129,12 +130,16 @@ public class TablePartExportDialog extends AbstractPartExportDialog
             (Boolean) zellenTransparent.getValue());)
     {
       @SuppressWarnings("unchecked")
-      // TODO sortierung
       List<ExportSpalte> listeAuswahl = spaltenList.getItems();
 
       Object testObject = tablePart.getItems().get(0);
       for (ExportSpalte col : listeAuswahl)
       {
+        if (col.getBreite() <= 0)
+        {
+          throw new ApplicationException(
+              col.getColumn().getName() + ": Breite muss größer 0 sein!");
+        }
         switch (col.getColumn().getAlign())
         {
           case Column.ALIGN_LEFT:

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TablePartExportDialog.java
@@ -17,15 +17,12 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.rmi.RemoteException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
@@ -46,21 +43,23 @@ import de.jost_net.JVerein.gui.parts.JVereinTablePart;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.Action;
+import de.willuhn.datasource.BeanUtil;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.system.Settings;
-import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class TablePartExportDialog extends AbstractPartExportDialog
 {
   private Table table;
 
+  private JVereinTablePart tablePart;
+
   public TablePartExportDialog(Table table, String settingPrefix, ExportArt art,
-      String title, String subtitle, String filename)
-      throws ApplicationException
+      String title, String subtitle, String filename,
+      JVereinTablePart tablePart) throws ApplicationException
   {
-    super(settingPrefix, art, title, subtitle, filename, "Tabelle exportieren");
+    super(settingPrefix, art, title, subtitle, filename, "Tabelle exportieren",
+        tablePart);
 
     if (table == null || table.isDisposed() || !(table instanceof Table))
     {
@@ -72,81 +71,8 @@ public class TablePartExportDialog extends AbstractPartExportDialog
     }
 
     this.table = table;
+    this.tablePart = tablePart;
     settings = new Settings(this.getClass());
-  }
-
-  @Override
-  protected void paint(Composite parent)
-      throws ApplicationException, RemoteException
-  {
-    // Spalten so wie angezeigt sortieren
-    List<TableColumn> listeSortiert = new ArrayList<>();
-    int[] order = table.getColumnOrder();
-    for (int i = 0; i < table.getColumnCount(); i++)
-    {
-      TableColumn col = table.getColumn(order[i]);
-      // Leere Dummy-Spalte am Ende überspringen
-      if (col.getText().isBlank())
-      {
-        continue;
-      }
-      col.setData(settings.getInt(settingPrefix + "breite." + col.getText(),
-          col.getWidth()));
-      listeSortiert.add(col);
-    }
-
-    spaltenList = new JVereinTablePart(listeSortiert, null)
-    {
-      // Sortieren verhindern
-      @Override
-      protected void orderBy(int index)
-      {
-        return;
-      }
-    };
-    if (art.equals(ExportArt.PDF))
-    {
-      spaltenList.addChangeListener((object, attribute, newValue) -> {
-        try
-        {
-          ((TableColumn) object).setData(Integer.parseInt(newValue));
-        }
-        catch (Exception e)
-        {
-          throw new ApplicationException("Ungültiger Wert");
-        }
-      });
-    }
-    createGui(parent, new Action()
-    {
-
-      // Action zum Reset der Spaltenbreiten
-      @SuppressWarnings("unchecked")
-      @Override
-      public void handleAction(Object context) throws ApplicationException
-      {
-        try
-        {
-          for (TableColumn col : (List<TableColumn>) spaltenList.getItems())
-          {
-            col.setData(col.getWidth());
-          }
-          spaltenList.removeAll();
-          for (TableColumn col : listeSortiert)
-          {
-            spaltenList.addItem(col);
-            spaltenList.setChecked(col, settings
-                .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-          }
-        }
-        catch (RemoteException re)
-        {
-          Logger.error("Fehler beim zurücksetzen der Breiten", re);
-          throw new ApplicationException(
-              "Fehler beim zurücksetzen der Breiten");
-        }
-      }
-    });
   }
 
   @Override
@@ -156,29 +82,27 @@ public class TablePartExportDialog extends AbstractPartExportDialog
         CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE))
     {
       @SuppressWarnings("unchecked")
-      List<TableColumn> listeAuswahl = spaltenList.getItems();
-      List<TableColumn> listeOrig = Arrays.asList(table.getColumns());
-      TableItem[] rows = table.getItems();
+      List<ExportSpalte> spalten = spaltenList.getItems();
 
-      CellProcessor[] cellProcessor = new CellProcessor[listeAuswahl.size()];
-      String[] header = new String[listeAuswahl.size()];
+      CellProcessor[] cellProcessor = new CellProcessor[spalten.size()];
+      String[] header = new String[spalten.size()];
 
       int n = 0;
-      for (TableColumn col : listeAuswahl)
+      for (ExportSpalte col : spalten)
       {
-        header[n] = col.getText();
+        header[n] = col.getColumn().getName();
         cellProcessor[n++] = new ConvertNullTo("");
       }
       writer.writeHeader(header);
 
-      for (TableItem row : rows)
+      for (Object item : tablePart.getItems())
       {
         Map<String, Object> csvzeile = new HashMap<>();
         int i = 0;
-        for (TableColumn col : listeAuswahl)
+        for (ExportSpalte col : spalten)
         {
-          int index = listeOrig.indexOf(col);
-          String text = row.getText(index);
+          Object o = BeanUtil.get(item, col.getColumn().getColumnId());
+          String text = col.getColumn().getFormattedValue(o, col);
           // Haken "Geprüft" und Schloß "Abgeschlossen" Icons ersetzen
           if (text.equals("\u2705") || text.equals("\uD83D\uDD12"))
           {
@@ -205,30 +129,51 @@ public class TablePartExportDialog extends AbstractPartExportDialog
             (Boolean) zellenTransparent.getValue());)
     {
       @SuppressWarnings("unchecked")
-      List<TableColumn> listeAuswahl = spaltenList.getItems();
-      List<TableColumn> listeOrig = Arrays.asList(table.getColumns());
-      TableItem[] rows = table.getItems();
+      // TODO sortierung
+      List<ExportSpalte> listeAuswahl = spaltenList.getItems();
 
-      for (TableColumn col : listeAuswahl)
+      Object testObject = tablePart.getItems().get(0);
+      for (ExportSpalte col : listeAuswahl)
       {
-        reporter.addHeaderColumn(col.getText(),
-            col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                : Element.ALIGN_RIGHT,
-            (int) col.getData(), getHintergrundHeader(),
+        switch (col.getColumn().getAlign())
+        {
+          case Column.ALIGN_LEFT:
+            col.setAlign(Element.ALIGN_LEFT);
+            break;
+          case Column.ALIGN_RIGHT:
+            col.setAlign(Element.ALIGN_RIGHT);
+            break;
+          case Column.ALIGN_CENTER:
+            col.setAlign(Element.ALIGN_CENTER);
+            break;
+          case Column.ALIGN_AUTO:
+            // Ansonsten Testobjekt laden für automatische Ausrichtung von
+            // Spalten
+            Object value = BeanUtil.get(testObject,
+                col.getColumn().getColumnId());
+            col.setAlign(value instanceof Number ? Element.ALIGN_RIGHT
+                : Element.ALIGN_LEFT);
+            break;
+        }
+
+        reporter.addHeaderColumn(col.getColumn().getName(), col.getAlign(),
+            col.getBreite(), getHintergrundHeader(),
             getFontHeader(BaseColor.BLACK));
       }
       reporter.createHeader();
 
-      for (TableItem row : rows)
+      for (Object origObj : tablePart.getItems())
       {
-        for (TableColumn col : listeAuswahl)
+        TableItem tItem = getItem(table.getItems(), origObj);
+        for (ExportSpalte spalte : listeAuswahl)
         {
-          int index = listeOrig.indexOf(col);
-          String text = row.getText(index);
+          Object o = BeanUtil.get(origObj, spalte.getColumn().getColumnId());
+          String text = spalte.getColumn().getFormattedValue(o, spalte);
+
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
-          Color bg = (Color) row.getData("background");
-          Font font = getFont(text, row.getFont(index).getFontData());
+          Color bg = (Color) tItem.getData("background");
+          Font font = getFont(text, tItem.getFont().getFontData());
 
           // Icons ersetzen die in den Standard Fonts nicht enthalten sind
           Font iconfont = FontFactory.getFont("/fonts/fontawesome-webfont.ttf",
@@ -248,17 +193,12 @@ public class TablePartExportDialog extends AbstractPartExportDialog
 
           if (bg == null)
           {
-            reporter.addColumn(text,
-                col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                    : Element.ALIGN_RIGHT,
-                font);
+            reporter.addColumn(text, spalte.getAlign(), font);
           }
           else
           {
-            reporter.addColumn(text,
-                col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                    : Element.ALIGN_RIGHT,
-                getHintergrundTabelle(), font);
+            reporter.addColumn(text, spalte.getAlign(), getHintergrundTabelle(),
+                font);
           }
         }
       }
@@ -266,32 +206,29 @@ public class TablePartExportDialog extends AbstractPartExportDialog
     }
   }
 
-  @SuppressWarnings("unchecked")
-  @Override
-  protected void saveSettings() throws RemoteException
+  private TableItem getItem(TableItem[] treeItems, Object o)
   {
-    List<TableColumn> itemsChecked = spaltenList.getItems();
-    for (TableColumn col : (List<TableColumn>) spaltenList.getItems(false))
+    for (TableItem i : treeItems)
     {
-      settings.setAttribute(settingPrefix + "anzeigen." + col.getText(),
-          itemsChecked.contains(col));
-      if (art.equals(ExportArt.PDF))
+      if (i.getData().equals(o))
       {
-        settings.setAttribute(settingPrefix + "breite." + col.getText(),
-            (Integer) col.getData());
+        return i;
       }
     }
-    super.saveSettings();
+    return null;
   }
 
   @Override
-  void setChecked()
+  Item getColumn(String name)
   {
-    for (TableColumn col : table.getColumns())
+    for (TableColumn c : table.getColumns())
     {
-      spaltenList.setChecked(col, settings
-          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-    }
-  }
+      if (c.getText().equals(name))
 
+      {
+        return c;
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -159,7 +159,8 @@ public class TreePartExportDialog extends AbstractPartExportDialog
 
   @SuppressWarnings("unchecked")
   @Override
-  protected void exportPDF(File file) throws IOException, DocumentException
+  protected void exportPDF(File file)
+      throws IOException, DocumentException, ApplicationException
   {
     try (FileOutputStream fos = new FileOutputStream(file);
         Reporter reporter = new Reporter(fos, title, subtitle,
@@ -183,6 +184,11 @@ public class TreePartExportDialog extends AbstractPartExportDialog
       Object testObject = treePart.getItems().get(0);
       for (ExportSpalte col : listeAuswahl)
       {
+        if (col.getBreite() <= 0)
+        {
+          throw new ApplicationException(
+              col.getColumn().getName() + ": Breite muss größer 0 sein!");
+        }
         switch (col.getColumn().getAlign())
         {
           case Column.ALIGN_LEFT:

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/TreePartExportDialog.java
@@ -19,13 +19,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
@@ -40,14 +39,15 @@ import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
 import com.itextpdf.text.Font;
 
-import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.gui.parts.JVereinTreePart;
 import de.jost_net.JVerein.io.FileViewer;
 import de.jost_net.JVerein.io.Reporter;
 import de.jost_net.JVerein.rmi.Formular;
-import de.willuhn.jameica.gui.Action;
+import de.willuhn.datasource.BeanUtil;
+import de.willuhn.datasource.GenericObjectNode;
+import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.system.Settings;
-import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class TreePartExportDialog extends AbstractPartExportDialog
@@ -55,22 +55,20 @@ public class TreePartExportDialog extends AbstractPartExportDialog
 
   private Tree tree;
 
+  private JVereinTreePart treePart;
+
   public TreePartExportDialog(Tree tree, String settingPrefix, ExportArt art,
-      String title, String subtitle, String filename)
+      String title, String subtitle, String filename, JVereinTreePart treePart)
       throws ApplicationException
   {
-    super(settingPrefix, art, title, subtitle, filename, "Baum exportieren");
+    super(settingPrefix, art, title, subtitle, filename, "Baum exportieren",
+        treePart);
 
     if (tree == null || tree.isDisposed() || !(tree instanceof Tree))
     {
       throw new ApplicationException("Tabelle nicht geladen");
     }
     TreeItem[] rootItems = tree.getItems();
-    if (rootItems.length == 0)
-    {
-      throw new ApplicationException("Tabelle enthält keine Daten");
-    }
-    // Wir haben immer den Root Node, darum prüfen wir die Childs
     boolean leer = true;
     for (TreeItem item : rootItems)
     {
@@ -86,152 +84,71 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     }
 
     this.tree = tree;
+    this.treePart = treePart;
     settings = new Settings(this.getClass());
   }
 
-  @Override
-  protected void paint(Composite parent)
-      throws ApplicationException, RemoteException
-  {
-    // Spalten so wie angezeigt sortieren
-    List<TreeColumn> listeSortiert = new ArrayList<>();
-    int[] order = tree.getColumnOrder();
-    for (int i = 0; i < tree.getColumnCount(); i++)
-    {
-      TreeColumn col = tree.getColumn(order[i]);
-      // Leere Dummy-Spalte am Ende überspringen
-      if (col.getText().isBlank())
-      {
-        continue;
-      }
-      col.setData(settings.getInt(settingPrefix + "breite." + col.getText(),
-          col.getWidth()));
-      listeSortiert.add(col);
-    }
-
-    spaltenList = new JVereinTablePart(listeSortiert, null)
-    {
-      // Sortieren verhindern
-      @Override
-      protected void orderBy(int index)
-      {
-        return;
-      }
-    };
-    if (art.equals(ExportArt.PDF))
-    {
-      spaltenList.addChangeListener((object, attribute, newValue) -> {
-        try
-        {
-          ((TreeColumn) object).setData(Integer.parseInt(newValue));
-        }
-        catch (Exception e)
-        {
-          throw new ApplicationException("Ungültiger Wert");
-        }
-      });
-    }
-    createGui(parent, new Action()
-    {
-
-      // Action zum Reset der Spaltenbreiten
-      @SuppressWarnings("unchecked")
-      @Override
-      public void handleAction(Object context) throws ApplicationException
-      {
-        try
-        {
-          for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems())
-          {
-            col.setData(col.getWidth());
-          }
-          spaltenList.removeAll();
-          for (TreeColumn col : listeSortiert)
-          {
-            spaltenList.addItem(col);
-            spaltenList.setChecked(col, settings
-                .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-          }
-        }
-        catch (RemoteException re)
-        {
-          Logger.error("Fehler beim zurücksetzen der Breiten", re);
-          throw new ApplicationException(
-              "Fehler beim zurücksetzen der Breiten");
-        }
-      }
-    });
-  }
-
+  @SuppressWarnings("unchecked")
   @Override
   protected void exportCSV(File file) throws IOException
   {
     try (ICsvMapWriter writer = new CsvMapWriter(new FileWriter(file),
         CsvPreference.EXCEL_NORTH_EUROPE_PREFERENCE))
     {
-      @SuppressWarnings("unchecked")
-      List<TreeColumn> listeAuswahl = spaltenList.getItems();
-      List<TreeColumn> listeOrig = Arrays.asList(tree.getColumns());
-      List<MyTreeItem> rows = new ArrayList<>();
+      List<ExportSpalte> spalten = spaltenList.getItems();
+      List<MyItem> rows = new ArrayList<>();
 
-      for (TreeItem item : tree.getItems())
+      for (GenericObjectNode item : (List<GenericObjectNode>) treePart
+          .getItems())
       {
         // Die Root Ebene geben wir nicht aus
         getItemRekursiv(rows, item, 0);
       }
+
       int ebenen = 0;
-      for (MyTreeItem item : rows)
+      for (MyItem item : rows)
       {
         ebenen = Math.max(ebenen, item.getEbene());
       }
-      int size = listeAuswahl.size();
-      if (listeOrig.indexOf(listeAuswahl.get(0)) == 0)
-      {
-        size += ebenen;
-      }
-      else
-      {
-        ebenen = 0;
-      }
+      int size = spalten.size() + ebenen;
 
       CellProcessor[] cellProcessor = new CellProcessor[size];
       String[] header = new String[size];
 
       int n = 0;
-      for (TreeColumn col : listeAuswahl)
+      for (ExportSpalte col : spalten)
       {
-        if (listeOrig.indexOf(col) == 0)
+        if (n == 0)
         {
           for (int i = 0; i <= ebenen; i++)
           {
-            header[n] = col.getText() + " - " + (i + 1);
+            header[n] = col.getColumn().getName() + " - " + (i + 1);
             cellProcessor[n++] = new ConvertNullTo("");
           }
         }
         else
         {
-          header[n] = col.getText();
+          header[n] = col.getColumn().getName();
           cellProcessor[n++] = new ConvertNullTo("");
         }
       }
       writer.writeHeader(header);
 
-      for (MyTreeItem row : rows)
+      for (MyItem row : rows)
       {
         Map<String, Object> csvzeile = new HashMap<>();
         int i = 0;
-        for (TreeColumn col : listeAuswahl)
+        for (ExportSpalte col : spalten)
         {
-          int index = listeOrig.indexOf(col);
-          if (index == 0)
+          Object o = BeanUtil.get(row.getItem(), col.getColumn().getColumnId());
+          String text = col.getColumn().getFormattedValue(o, col);
+          if (i == 0)
           {
-            csvzeile.put(header[row.getEbene() + i++],
-                row.getTreeItem().getText(index));
+            csvzeile.put(header[row.getEbene() + i++], text);
           }
           else
           {
-            csvzeile.put(header[ebenen + i++],
-                row.getTreeItem().getText(index));
+            csvzeile.put(header[ebenen + i++], text);
           }
         }
         writer.write(csvzeile, header, cellProcessor);
@@ -240,6 +157,7 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     }
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   protected void exportPDF(File file) throws IOException, DocumentException
   {
@@ -252,43 +170,62 @@ public class TreePartExportDialog extends AbstractPartExportDialog
             (Boolean) headerTransparent.getValue(),
             (Boolean) zellenTransparent.getValue());)
     {
-      @SuppressWarnings("unchecked")
-      List<TreeColumn> listeAuswahl = spaltenList.getItems();
-      List<TreeColumn> listeOrig = Arrays.asList(tree.getColumns());
-      List<MyTreeItem> rows = new ArrayList<>();
+      List<ExportSpalte> listeAuswahl = spaltenList.getItems();
+      List<MyItem> rows = new ArrayList<>();
 
-      for (TreeItem item : tree.getItems())
+      for (GenericObjectNode item : (List<GenericObjectNode>) treePart
+          .getItems())
       {
         // Die Root Ebene geben wir nicht aus
         getItemRekursiv(rows, item, 0);
       }
 
-      for (TreeColumn col : listeAuswahl)
+      Object testObject = treePart.getItems().get(0);
+      for (ExportSpalte col : listeAuswahl)
       {
-        reporter.addHeaderColumn(col.getText(),
-            col.getAlignment() == Column.ALIGN_LEFT ? Element.ALIGN_LEFT
-                : Element.ALIGN_RIGHT,
-            (int) col.getData(), getHintergrundHeader(),
+        switch (col.getColumn().getAlign())
+        {
+          case Column.ALIGN_LEFT:
+            col.setAlign(Element.ALIGN_LEFT);
+            break;
+          case Column.ALIGN_RIGHT:
+            col.setAlign(Element.ALIGN_RIGHT);
+            break;
+          case Column.ALIGN_CENTER:
+            col.setAlign(Element.ALIGN_CENTER);
+            break;
+          case Column.ALIGN_AUTO:
+            // Ansonsten Testobjekt laden für automatische Ausrichtung von
+            // Spalten
+            Object value = BeanUtil.get(testObject,
+                col.getColumn().getColumnId());
+            col.setAlign(value instanceof Number ? Element.ALIGN_RIGHT
+                : Element.ALIGN_LEFT);
+            break;
+        }
+        reporter.addHeaderColumn(col.getColumn().getName(), col.getAlign(),
+            col.getBreite(), getHintergrundHeader(),
             getFontHeader(BaseColor.BLACK));
       }
       reporter.createHeader();
 
-      for (MyTreeItem row : rows)
+      for (MyItem row : rows)
       {
-        for (TreeColumn col : listeAuswahl)
+        Item tItem = getItem(tree.getItems(), row.getItem());
+        int n = 0;
+        for (ExportSpalte spalte : listeAuswahl)
         {
-          int index = listeOrig.indexOf(col);
-          String text = row.getTreeItem().getText(index);
+          Object o = BeanUtil.get(row.getItem(),
+              spalte.getColumn().getColumnId());
+          String text = spalte.getColumn().getFormattedValue(o, spalte);
+
           // Die Hintergrundfarbe muss in Data gespeichert sein, sonst hängt sie
           // vom verwendeten Theme ab.
-          Color bg = (Color) row.getTreeItem().getData("background");
-          Font font = getFont(text,
-              row.getTreeItem().getFont(index).getFontData());
+          Color bg = (Color) tItem.getData("background");
+          Font font = getFont(text, ((TreeItem) tItem).getFont().getFontData());
 
-          int alignment = col.getAlignment() == Column.ALIGN_LEFT
-              ? Element.ALIGN_LEFT
-              : Element.ALIGN_RIGHT;
-          if (row.getEbene() == 1 && index == 0)
+          int alignment = spalte.getAlign();
+          if (row.getEbene() == 1 && n++ == 0)
           {
             alignment = Element.ALIGN_RIGHT;
           }
@@ -306,31 +243,57 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     }
   }
 
-  private void getItemRekursiv(List<MyTreeItem> rows, TreeItem item, int ebene)
+  private TreeItem getItem(TreeItem[] treeItems, Object o)
+  {
+    for (TreeItem i : treeItems)
+    {
+      if (i.getData().equals(o))
+      {
+        return i;
+      }
+      TreeItem found = getItem(i.getItems(), o);
+      if (found != null)
+      {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private void getItemRekursiv(List<MyItem> rows, GenericObjectNode item,
+      int ebene)
   {
     // Unterelemente durchlaufen
-    for (TreeItem child : item.getItems())
+    try
     {
-      rows.add(new MyTreeItem(child, ebene));
-      getItemRekursiv(rows, child, ebene + 1);
+      for (Object o : PseudoIterator.asList(item.getChildren()))
+      {
+        GenericObjectNode child = (GenericObjectNode) o;
+        rows.add(new MyItem(child, ebene));
+        getItemRekursiv(rows, child, ebene + 1);
+      }
+    }
+    catch (RemoteException e)
+    {
+      // kann bei PseudoIterator nicht pssieren
     }
   }
 
-  private class MyTreeItem
+  private class MyItem
   {
-    private TreeItem treeItem;
+    private GenericObjectNode obj;
 
     private int ebene;
 
-    private MyTreeItem(TreeItem treeItem, int ebene)
+    private MyItem(GenericObjectNode obj, int ebene)
     {
-      this.treeItem = treeItem;
+      this.obj = obj;
       this.ebene = ebene;
     }
 
-    public TreeItem getTreeItem()
+    public GenericObjectNode getItem()
     {
-      return treeItem;
+      return obj;
     }
 
     public int getEbene()
@@ -339,31 +302,16 @@ public class TreePartExportDialog extends AbstractPartExportDialog
     }
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  protected void saveSettings() throws RemoteException
+  Item getColumn(String name)
   {
-    List<TreeColumn> itemsChecked = spaltenList.getItems();
-    for (TreeColumn col : (List<TreeColumn>) spaltenList.getItems(false))
+    for (TreeColumn c : tree.getColumns())
     {
-      settings.setAttribute(settingPrefix + "anzeigen." + col.getText(),
-          itemsChecked.contains(col));
-      if (art.equals(ExportArt.PDF))
+      if (c.getText().equals(name))
       {
-        settings.setAttribute(settingPrefix + "breite." + col.getText(),
-            (Integer) col.getData());
+        return c;
       }
     }
-    super.saveSettings();
-  }
-
-  @Override
-  void setChecked()
-  {
-    for (TreeColumn col : tree.getColumns())
-    {
-      spaltenList.setChecked(col, settings
-          .getBoolean(settingPrefix + "anzeigen." + col.getText(), true));
-    }
+    return null;
   }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
@@ -19,10 +19,20 @@ package de.jost_net.JVerein.gui.parts;
 import java.rmi.RemoteException;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DragSource;
+import org.eclipse.swt.dnd.DragSourceAdapter;
+import org.eclipse.swt.dnd.DragSourceEvent;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetAdapter;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
 
 import de.jost_net.JVerein.gui.dialogs.TablePartExportDialog;
 import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
@@ -253,6 +263,71 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
       Logger.error("Fehler beim Erstellen der Auswertung.", e);
       throw new ApplicationException("Fehler beim Erstellen der Auswertung.");
     }
+  }
+
+  /**
+   * Ermöglich drag'n'drop beim TablePart.
+   * 
+   * @throws ApplicationException
+   */
+  public void setDragDrop() throws ApplicationException
+  {
+    Table table = (Table) tableControl;
+    if (table == null)
+    {
+      Logger.error(
+          "setDragDrop nicht möglich, Tabelle wurde noch nicht gezeichnet");
+      throw new ApplicationException(
+          "setDragDrop nicht möglich, Tabelle wurde noch nicht gezeichnet");
+    }
+    DragSource dragSource = new DragSource(table, DND.DROP_MOVE);
+    dragSource.setTransfer(TextTransfer.getInstance());
+    dragSource.addDragListener(new DragSourceAdapter()
+    {
+      @Override
+      public void dragSetData(DragSourceEvent event)
+      {
+        if (table.getSelection().length == 1)
+        {
+          event.data = table.getSelection()[0].getText();
+        }
+      }
+
+      @Override
+      public void dragStart(DragSourceEvent event)
+      {
+        event.doit = table.getSelectionCount() == 1;
+      }
+    });
+    DropTarget dropTarget = new DropTarget(table, DND.DROP_MOVE);
+    dropTarget.setTransfer(TextTransfer.getInstance());
+    dropTarget.addDropListener(new DropTargetAdapter()
+    {
+      @Override
+      public void drop(DropTargetEvent event)
+      {
+        int targetIndex;
+        if (event.item == null)
+        {
+          targetIndex = table.getItemCount();
+        }
+        else
+        {
+          targetIndex = table.indexOf((TableItem) event.item);
+        }
+        try
+        {
+          Object o = table.getSelection()[0].getData();
+          boolean checked = table.getSelection()[0].getChecked();
+          JVereinTablePart.this.removeItem(o);
+          JVereinTablePart.this.addItem(o, targetIndex, checked);
+        }
+        catch (RemoteException e)
+        {
+          Logger.error("Fehler beim Datenzugriff", e);
+        }
+      }
+    });
   }
 
   public void setTableName(String name)

--- a/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTablePart.java
@@ -239,7 +239,7 @@ public class JVereinTablePart extends TablePart implements IJVereinPart
     {
       if (!new TablePartExportDialog((Table) tableControl,
           getTablePartID(tablePartId, tableName), art, title, subtitle,
-          filename).open())
+          filename, this).open())
       {
         throw new OperationCanceledException();
       }

--- a/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/JVereinTreePart.java
@@ -168,7 +168,7 @@ public class JVereinTreePart extends TreePart implements IJVereinPart
     {
       if (!new TreePartExportDialog((Tree) treeControl,
           getTablePartID(tablePartId, tableName), art, title, subtitle,
-          filename).open())
+          filename, this).open())
       {
         throw new OperationCanceledException();
       }


### PR DESCRIPTION
Ich hab den Part-Export-Dialog so umgebaut, dass auch ausgeblendete Spalten exportiert werden können.
Die Spalten können im Export-Dialog per Drag'n'Drop sortiert werden. Die Reihenfolge wird auch in den Settings gespeichert.