### PR TITLE
Unnötigen Code entfernt

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/AbstractJVereinControl.java
@@ -58,12 +58,6 @@ public abstract class AbstractJVereinControl extends AbstractControl
             {
               ((FilterControl) this).refresh();
             }
-            // TODO BuchungsControl ist noch nicht Teil von FilterControl und
-            // brauch noch eine extra Behandlung
-            else if (this instanceof BuchungsControl)
-            {
-              ((BuchungsControl) this).refreshBuchungsList();
-            }
             getTablePart().export(getTableTitle(), getTableSubtitle(),
                 getTableDateiname(), art);
           }


### PR DESCRIPTION
Weil jetzt auch Buchungen auf FilterControl umgestellt sind braucht man die Sonderbehandlung nicht mehr.