### PR TITLE
Belege für mehrere Buchungen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/Einstellungen.java
+++ b/src/main/java/de/jost_net/JVerein/Einstellungen.java
@@ -302,7 +302,7 @@ public class Einstellungen
     AUTOBUCHUNGUEBERNAHME("autobuchunguebernahme", Boolean.class, "1"),
     AUTOMATISCHEBUCHUNGSKORREKTURHIBISCUS("autobuchungskorrekturhibiscus",
         Boolean.class, "1"),
-    BELEG_ZAEHLER("buchung_zaehler", Integer.class, "1"),
+    BELEG_ZAEHLER("beleg_zaehler", Integer.class, "1"),
     BELEGNUMMER("belegnummer", String.class, "$beleg_zaehler"),
 
     KONTONUMMERINBUCHUNGSLISTE("kontonummer_in_buchungsliste", Boolean.class,

--- a/src/main/java/de/jost_net/JVerein/Einstellungen.java
+++ b/src/main/java/de/jost_net/JVerein/Einstellungen.java
@@ -302,6 +302,8 @@ public class Einstellungen
     AUTOBUCHUNGUEBERNAHME("autobuchunguebernahme", Boolean.class, "1"),
     AUTOMATISCHEBUCHUNGSKORREKTURHIBISCUS("autobuchungskorrekturhibiscus",
         Boolean.class, "1"),
+    BELEG_ZAEHLER("buchung_zaehler", Integer.class, "1"),
+    BELEGNUMMER("belegnummer", String.class, "$beleg_zaehler"),
 
     KONTONUMMERINBUCHUNGSLISTE("kontonummer_in_buchungsliste", Boolean.class,
         "0"),

--- a/src/main/java/de/jost_net/JVerein/Messaging/BelegRemoveMessage.java
+++ b/src/main/java/de/jost_net/JVerein/Messaging/BelegRemoveMessage.java
@@ -14,13 +14,19 @@
  * heiner@jverein.de
  * www.jverein.de
  **********************************************************************/
-package de.jost_net.JVerein.rmi;
 
-import java.rmi.RemoteException;
+package de.jost_net.JVerein.Messaging;
 
-public interface BuchungDokument extends AbstractDokument
+import de.willuhn.datasource.GenericObject;
+import de.willuhn.jameica.hbci.messaging.ObjectMessage;
+
+/**
+ * Wird versendet, wenn eine Beleg gelöscht wird.
+ */
+public class BelegRemoveMessage extends ObjectMessage
 {
-  public String getBelegnummer() throws RemoteException;
-
-  public void setBelegnummer(String belegnummer) throws RemoteException;
+  public BelegRemoveMessage(GenericObject object)
+  {
+    super(object);
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/Variable/BelegMap.java
+++ b/src/main/java/de/jost_net/JVerein/Variable/BelegMap.java
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.Variable;
+
+import java.rmi.RemoteException;
+import java.util.HashMap;
+import java.util.Map;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+
+public class BelegMap extends AbstractMap
+{
+  public Map<String, Object> getMap(BuchungDokument beleg,
+      Map<String, Object> inma) throws RemoteException
+  {
+    Map<String, Object> map = null;
+    if (inma == null)
+    {
+      map = new HashMap<>();
+    }
+    else
+    {
+      map = inma;
+    }
+
+    for (BelegVar var : BelegVar.values())
+    {
+      Object value = null;
+      switch (var)
+      {
+        case BELEG_ZAEHLER:
+          value = Einstellungen.getEinstellung(Property.BELEG_ZAEHLER)
+              .toString();
+          break;
+      }
+      map.put(var.getName(), value);
+    }
+
+    return map;
+  }
+
+  public static Map<String, Object> getDummyMap(Map<String, Object> inMap)
+      throws RemoteException
+  {
+    Map<String, Object> map = null;
+    if (inMap == null)
+    {
+      map = new HashMap<>();
+    }
+    else
+    {
+      map = inMap;
+    }
+    for (BelegVar var : BelegVar.values())
+    {
+      Object value = null;
+      switch (var)
+      {
+        case BELEG_ZAEHLER:
+          value = Einstellungen.getEinstellung(Property.BELEG_ZAEHLER)
+              .toString();
+          break;
+      }
+      map.put(var.getName(), value);
+    }
+
+    return map;
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/Variable/BelegVar.java
+++ b/src/main/java/de/jost_net/JVerein/Variable/BelegVar.java
@@ -14,13 +14,21 @@
  * heiner@jverein.de
  * www.jverein.de
  **********************************************************************/
-package de.jost_net.JVerein.rmi;
+package de.jost_net.JVerein.Variable;
 
-import java.rmi.RemoteException;
-
-public interface BuchungDokument extends AbstractDokument
+public enum BelegVar
 {
-  public String getBelegnummer() throws RemoteException;
+  BELEG_ZAEHLER("beleg_zaehler");
 
-  public void setBelegnummer(String belegnummer) throws RemoteException;
+  private String name;
+
+  BelegVar(String name)
+  {
+    this.name = name;
+  }
+
+  public String getName()
+  {
+    return name;
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/action/BelegEntfernenAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/BelegEntfernenAction.java
@@ -1,0 +1,70 @@
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.Messaging.BelegRemoveMessage;
+import de.jost_net.JVerein.gui.dialogs.JVereinYesNoDialog;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.dialogs.YesNoDialog;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class BelegEntfernenAction implements Action
+{
+
+  private IBeleg belegContext;
+
+  public BelegEntfernenAction(IBeleg belegContext)
+  {
+    this.belegContext = belegContext;
+  }
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    JVereinYesNoDialog d = new JVereinYesNoDialog(YesNoDialog.POSITION_CENTER);
+
+    d.setTitle("Beleg entfernen");
+    String text = "";
+    BuchungDokument[] belege;
+    if (context instanceof BuchungDokument[])
+    {
+      belege = (BuchungDokument[]) context;
+      text = "Sollen die Dokumente wirklich entfernt werden?";
+    }
+    else if (context instanceof BuchungDokument)
+    {
+      belege = new BuchungDokument[] { (BuchungDokument) context };
+      text = "Soll das Dokument wirklich entfernt werden?";
+    }
+    else
+    {
+      throw new ApplicationException("Falscher Kontext");
+    }
+    d.setText(text);
+    try
+    {
+      if ((boolean) d.open())
+      {
+        for (BuchungDokument beleg : belege)
+        {
+          belegContext.removeBeleg((BuchungDokument) beleg);
+          Application.getMessagingFactory()
+              .sendMessage(new BelegRemoveMessage(beleg));
+        }
+        GUI.getStatusBar().setSuccessText("Erfolgreich entfernt");
+      }
+    }
+    catch (ApplicationException e)
+    {
+      throw e;
+    }
+    catch (Exception e)
+    {
+      Logger.error("Fehler beim entfernen", e);
+      throw new ApplicationException("Fehler beim entfernen");
+    }
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/action/BelegNewAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/BelegNewAction.java
@@ -1,0 +1,38 @@
+package de.jost_net.JVerein.gui.action;
+
+import de.jost_net.JVerein.gui.view.BelegDetailView;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.util.ApplicationException;
+
+public class BelegNewAction extends NewAction
+{
+
+  private IBeleg belegObject;
+
+  public BelegNewAction()
+  {
+    super(BelegDetailView.class, BuchungDokument.class);
+  }
+
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if (!(context instanceof IBeleg))
+    {
+      throw new ApplicationException("Falsches Kontextobjekt");
+    }
+    this.belegObject = (IBeleg) context;
+    super.handleAction(context);
+  }
+
+  @Override
+  protected void startView(Class<? extends AbstractView> viewClass,
+      DBObject context)
+  {
+    GUI.startView(new BelegDetailView(belegObject), context);
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/action/BelegZuordnenAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/BelegZuordnenAction.java
@@ -1,0 +1,91 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.action;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.dialogs.BelegAuswahlDialog;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class BelegZuordnenAction implements Action
+{
+  private TablePart part;
+
+  public BelegZuordnenAction(TablePart tablePart)
+  {
+    this.part = tablePart;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    try
+    {
+      BelegAuswahlDialog d = new BelegAuswahlDialog();
+      BuchungDokument[] belege = d.open();
+      if (belege != null)
+      {
+        try
+        {
+          DBTransaction.starten();
+          for (BuchungDokument b : belege)
+          {
+            ((IBeleg) context).addBeleg(b);
+          }
+          DBTransaction.commit();
+        }
+        catch (RemoteException | ApplicationException e)
+        {
+          DBTransaction.rollback();
+          throw e;
+        }
+        // Erst jetzt Dokumente anzeigen, falls bei einem Beleg ein Fehler
+        // passiert
+        for (BuchungDokument b : belege)
+        {
+          part.addItem(b);
+        }
+        GUI.getStatusBar().setSuccessText("Beleg(e) erfolgreich zugeordnet");
+      }
+    }
+    catch (OperationCanceledException oce)
+    {
+      return;
+    }
+    catch (ApplicationException ae)
+    {
+      throw ae;
+    }
+    catch (Exception e)
+    {
+      Logger.error("Fehler beim Öffnen des Dialogs", e);
+      GUI.getStatusBar().setErrorText("Fehler beim Öffnen des Dialogs");
+    }
+  }
+
+}

--- a/src/main/java/de/jost_net/JVerein/gui/action/NewAction.java
+++ b/src/main/java/de/jost_net/JVerein/gui/action/NewAction.java
@@ -70,8 +70,7 @@ public class NewAction implements Action
   {
     try
     {
-      DBObject object = Einstellungen.getDBService().createObject(objectClass,
-          null);
+      DBObject object = createObject(objectClass);
       if (mitglied != null)
       {
         if (mitglied.getID() == null)
@@ -96,7 +95,7 @@ public class NewAction implements Action
           GUI.getCurrentView().setCurrentObject(object);
         }
       }
-      GUI.startView(viewClass, object);
+      startView(viewClass, object);
     }
     catch (RemoteException e)
     {
@@ -104,5 +103,31 @@ public class NewAction implements Action
           "Fehler bei der Erzeugung eines neuen " + objectClass.getSimpleName(),
           e);
     }
+  }
+
+  /**
+   * Erstellt ein neues Objekt der angegebenen Klasse
+   * 
+   * @param clazz
+   * @return
+   * @throws RemoteException
+   * @throws ApplicationException
+   */
+  protected DBObject createObject(Class<? extends DBObject> clazz)
+      throws RemoteException, ApplicationException
+  {
+    return Einstellungen.getDBService().createObject(clazz, null);
+  }
+
+  /**
+   * Öffnet die View
+   * 
+   * @param viewClass
+   * @param context
+   */
+  protected void startView(Class<? extends AbstractView> viewClass,
+      DBObject context)
+  {
+    GUI.startView(viewClass, context);
   }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
@@ -1,0 +1,290 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import org.eclipse.swt.widgets.FileDialog;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.gui.action.BuchungAction;
+import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
+import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
+import de.jost_net.JVerein.gui.formatter.IBANFormatter;
+import de.jost_net.JVerein.gui.formatter.SollbuchungFormatter;
+import de.jost_net.JVerein.gui.menu.BuchungAbrechnugslaufMenu;
+import de.jost_net.JVerein.gui.parts.AutoUpdateTablePart;
+import de.jost_net.JVerein.gui.parts.BuchungListTablePart;
+import de.jost_net.JVerein.gui.parts.IJVereinPart;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.keys.SplitbuchungTyp;
+import de.jost_net.JVerein.keys.VorlageTyp;
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.formatter.CurrencyFormatter;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.input.FileInput;
+import de.willuhn.jameica.gui.input.Input;
+import de.willuhn.jameica.gui.input.TextInput;
+import de.willuhn.jameica.gui.parts.Column;
+import de.willuhn.jameica.system.Settings;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class BelegControl extends VorZurueckControl implements Savable
+{
+  private TextInput bezeichnung;
+
+  private FileInput datei;
+
+  private Settings settings;
+
+  private AutoUpdateTablePart buchungList;
+
+  public final static int TAB_BUCHUNGEN = 0;
+
+  private int selectedTab = TAB_BUCHUNGEN;
+
+  private IBeleg belegObject;
+
+  private BuchungDokument beleg;
+
+  public BelegControl(AbstractView view, IBeleg belegObject)
+  {
+    super(view);
+    this.belegObject = belegObject;
+    settings = new de.willuhn.jameica.system.Settings(this.getClass());
+  }
+
+  private BuchungDokument getBeleg() throws RemoteException
+  {
+    if (beleg != null)
+    {
+      return beleg;
+    }
+    beleg = (BuchungDokument) getCurrentObject();
+    return beleg;
+  }
+
+  @Override
+  public BuchungDokument prepareStore()
+      throws RemoteException, ApplicationException
+  {
+    BuchungDokument beleg = getBeleg();
+    beleg.setBemerkung((String) getBezeichnung().getValue());
+
+    if (datei != null)
+    {
+      File file = new File((String) datei.getValue());
+      settings.setAttribute("lastdir", file.getParent());
+      beleg.setFile(file);
+    }
+    return beleg;
+  }
+
+  @Override
+  public void handleStore() throws ApplicationException
+  {
+    try
+    {
+      BuchungDokument beleg = prepareStore();
+      beleg.store();
+      if (belegObject != null)
+      {
+        belegObject.addBeleg(beleg);
+      }
+    }
+    catch (RemoteException e)
+    {
+      String fehler = "Fehler bei speichern des Belegs";
+      Logger.error(fehler, e);
+      throw new ApplicationException(fehler, e);
+    }
+  }
+
+  public TextInput getBezeichnung() throws RemoteException
+  {
+    if (bezeichnung != null)
+    {
+      return bezeichnung;
+    }
+    bezeichnung = new TextInput(getBeleg().getBemerkung(), 50);
+    bezeichnung.setName("Bezeichnung");
+    return bezeichnung;
+  }
+
+  public Input getDatei()
+  {
+    if (datei != null)
+    {
+      return datei;
+    }
+    datei = new FileInput("", false)
+    {
+      @Override
+      protected void customize(FileDialog fd)
+      {
+        fd.setFilterPath(settings.getString("lastdir", ""));
+      }
+    };
+    datei.setMandatory(true);
+    datei.setName("Datei");
+    return datei;
+  }
+
+  public Input getPfad() throws RemoteException
+  {
+    Input pfad = new TextInput(getBeleg().getRootDir() + getBeleg().getPfad());
+    pfad.disable();
+    return pfad;
+  }
+
+  @SuppressWarnings("unchecked")
+  public JVereinTablePart getBuchungList()
+      throws RemoteException, ApplicationException
+  {
+    if (buchungList != null)
+    {
+      return buchungList;
+    }
+    DBIterator<Buchung> it = Einstellungen.getDBService()
+        .createList(Buchung.class);
+    it.join("buchungsdokumentbuchung");
+    it.addFilter("buchungsdokumentbuchung.buchung = buchung.id");
+    it.addFilter("buchungsdokumentbuchung.dokument = ?", getBeleg().getID());
+
+    buchungList = new BuchungListTablePart(PseudoIterator.asList(it),
+        new BuchungAction(false, null));
+    buchungList.setTableName("Buchungen");
+    buchungList.addColumn("Nr", "id-int");
+    buchungList.addColumn("Geprüft", "geprueft",
+        o -> (Boolean) o ? "\u2705" : "");
+    if ((Boolean) Einstellungen.getEinstellung(Property.DOKUMENTENSPEICHERUNG))
+    {
+      buchungList.addColumn("D", "document");
+    }
+    buchungList.addColumn("S", "splittyp",
+        o -> SplitbuchungTyp.get((Integer) o).substring(0, 1));
+
+    buchungList.addColumn("Konto", "konto");
+    buchungList.addColumn("Datum", "datum",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+
+    buchungList.addColumn("Name", "name");
+    buchungList.addColumn("IBAN oder Kontonummer", "iban", new IBANFormatter());
+    buchungList.addColumn("Verwendungszweck", "zweck", o -> {
+      if (o == null)
+      {
+        return null;
+      }
+      String s = o.toString();
+      s = s.replaceAll("\r\n", " ");
+      s = s.replaceAll("\r", " ");
+      s = s.replaceAll("\n", " ");
+      return s;
+    });
+    if ((Boolean) Einstellungen
+        .getEinstellung(Property.BUCHUNGSKLASSEINBUCHUNG))
+    {
+      buchungList.addColumn("Buchungsklasse", "buchungsklasse",
+          new BuchungsklasseFormatter());
+    }
+
+    buchungList.addColumn("Buchungsart", "buchungsart",
+        new BuchungsartFormatter());
+    buchungList.addColumn("Betrag", "betrag",
+        new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+    if ((Boolean) Einstellungen.getEinstellung(Property.OPTIERT))
+    {
+      buchungList.addColumn("Netto", "netto",
+          new CurrencyFormatter("", Einstellungen.DECIMALFORMAT));
+      if ((Boolean) Einstellungen.getEinstellung(Property.STEUERINBUCHUNG))
+      {
+        buchungList.addColumn("Steuer", "steuer.name", null, false,
+            Column.ALIGN_RIGHT);
+      }
+    }
+    buchungList.addColumn(new Column(Buchung.SOLLBUCHUNG,
+        "Mitglied - Sollbuchung", new SollbuchungFormatter(), false,
+        Column.ALIGN_AUTO, Column.SORT_BY_DISPLAY));
+    buchungList.setMulti(true);
+
+    buchungList.setContextMenu(new BuchungAbrechnugslaufMenu());
+    return buchungList;
+  }
+
+  public void setFolderSelection(int selection)
+  {
+    selectedTab = selection;
+  }
+
+  @Override
+  protected IJVereinPart getTablePart()
+      throws RemoteException, ApplicationException
+  {
+    switch (selectedTab)
+    {
+      case TAB_BUCHUNGEN:
+        return getBuchungList();
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  protected String getTableTitle()
+  {
+    switch (selectedTab)
+    {
+      case TAB_BUCHUNGEN:
+        return VorlageUtil.getName(VorlageTyp.BUCHUNGEN_TITEL, this);
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  protected String getTableSubtitle()
+  {
+    switch (selectedTab)
+    {
+      case TAB_BUCHUNGEN:
+        return VorlageUtil.getName(VorlageTyp.BUCHUNGEN_SUBTITEL, this);
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  protected String getTableDateiname()
+  {
+    switch (selectedTab)
+    {
+      case TAB_BUCHUNGEN:
+        return VorlageUtil.getName(VorlageTyp.BUCHUNGEN_DATEINAME, this);
+      default:
+        return null;
+    }
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.FileDialog;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.DBTools.DBTransaction;
 import de.jost_net.JVerein.gui.action.BuchungAction;
 import de.jost_net.JVerein.gui.formatter.BuchungsartFormatter;
 import de.jost_net.JVerein.gui.formatter.BuchungsklasseFormatter;
@@ -106,6 +107,7 @@ public class BelegControl extends VorZurueckControl implements Savable
   @Override
   public void handleStore() throws ApplicationException
   {
+    DBTransaction.starten();
     try
     {
       BuchungDokument beleg = prepareStore();
@@ -117,12 +119,19 @@ public class BelegControl extends VorZurueckControl implements Savable
         // nich nochmal passiert, auf null setzen
         belegObject = null;
       }
+      DBTransaction.commit();
     }
     catch (RemoteException e)
     {
+      DBTransaction.rollback();
       String fehler = "Fehler bei speichern des Belegs";
       Logger.error(fehler, e);
       throw new ApplicationException(fehler, e);
+    }
+    catch (ApplicationException e)
+    {
+      DBTransaction.rollback();
+      throw e;
     }
   }
 

--- a/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BelegControl.java
@@ -113,6 +113,9 @@ public class BelegControl extends VorZurueckControl implements Savable
       if (belegObject != null)
       {
         belegObject.addBeleg(beleg);
+        // belegObject wird nur hier für das hinzufügen gebraucht, damit das
+        // nich nochmal passiert, auf null setzen
+        belegObject = null;
       }
     }
     catch (RemoteException e)

--- a/src/main/java/de/jost_net/JVerein/gui/control/BelegListControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BelegListControl.java
@@ -1,0 +1,187 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.control;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.Map.Entry;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.menu.BelegMenu;
+import de.jost_net.JVerein.gui.parts.AutoUpdateTablePart;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.gui.view.BelegDetailView;
+import de.jost_net.JVerein.keys.Filter;
+import de.jost_net.JVerein.keys.VorlageTyp;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+
+public class BelegListControl extends FilterControl
+{
+  private JVereinTablePart docsList;
+
+  public BelegListControl(AbstractView view)
+  {
+    super(view);
+  }
+
+  @Override
+  public JVereinTablePart getTablePart()
+      throws RemoteException, ApplicationException
+  {
+    if (docsList != null)
+    {
+      return docsList;
+    }
+    docsList = new AutoUpdateTablePart(getList(), null);
+    docsList.setTableName("Dokumente");
+    docsList.addColumn("Belegnummer", "belegnummer");
+    docsList.addColumn("Datum", "datum",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    docsList.addColumn("Bemerkung", "bemerkung");
+    docsList.addColumn("Pfad", "vollpfad");
+    docsList.setContextMenu(new BelegMenu(docsList));
+    docsList.setMulti(true);
+    // Nur in der View, nicht im Dialog
+    if (this.view != null)
+    {
+      docsList.setAction(new EditAction(BelegDetailView.class, docsList));
+      VorZurueckControl.setObjektListe(null, null);
+    }
+    return docsList;
+  }
+
+  /**
+   * Erstellt einen Neuen Beleg mit der angegebenen Datei. Datum und Bemerkung
+   * werden automatisch bestimmt.
+   * 
+   * @param filename
+   */
+  public void addFile(String filename)
+  {
+    try
+    {
+      DBTransaction.starten();
+
+      BuchungDokument document = Einstellungen.getDBService()
+          .createObject(BuchungDokument.class, null);
+      File file = new File(filename);
+
+      document.setBemerkung(file.getName());
+      document.setDatum(new Date());
+
+      document.setFile(file);
+      document.store();
+
+      getTablePart().addItem(document);
+
+      DBTransaction.commit();
+    }
+    catch (RemoteException | ApplicationException e)
+    {
+      DBTransaction.rollback();
+      GUI.getStatusBar()
+          .setErrorText("Fehler beim Hinzufügen der Datei:" + e.getMessage());
+    }
+    catch (Exception e)
+    {
+      DBTransaction.rollback();
+      throw e;
+    }
+  }
+
+  public DBIterator<BuchungDokument> getList()
+      throws RemoteException, ApplicationException
+  {
+    DBIterator<BuchungDokument> docs = Einstellungen.getDBService()
+        .createList(BuchungDokument.class);
+    for (Entry<Filter, Object> entry : getFilter().entrySet())
+    {
+      Object value = entry.getValue();
+      switch (entry.getKey())
+      {
+        case NUMMER:
+          docs.addFilter("(lower(belegnummer) like ?)",
+              "%" + ((String) value).toLowerCase() + "%");
+          break;
+        case BEZEICHNUNG:
+          docs.addFilter("(lower(bemerkung) like ?)",
+              "%" + ((String) value).toLowerCase() + "%");
+          break;
+        case NICHT_ZUGEORDNET:
+          if ((boolean) value)
+          {
+            docs.addFilter("NOT EXISTS "
+                + "(SELECT * FROM buchungsdokumentbuchung "
+                + "WHERE buchungsdokumentbuchung.dokument = buchungdokument.id)");
+          }
+          break;
+        default:
+          throw new ApplicationException(
+              "Filter nicht implementiert: " + entry.getKey().getAnzeigeText());
+      }
+    }
+    docs.setOrder("ORDER BY datum desc");
+    return docs;
+  }
+
+  @Override
+  protected void TabRefresh() throws ApplicationException
+  {
+    try
+    {
+      docsList.removeAll();
+      DBIterator<BuchungDokument> it = getList();
+      while (it.hasNext())
+      {
+        docsList.addItem(it.next());
+      }
+    }
+    catch (RemoteException e1)
+    {
+      Logger.error("Fehler bei Datenbankzugriff", e1);
+    }
+  }
+
+  @Override
+  protected String getTableTitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.BELEG_TITEL);
+  }
+
+  @Override
+  protected String getTableSubtitle()
+  {
+    return VorlageUtil.getName(VorlageTyp.BELEG_SUBTITEL);
+  }
+
+  @Override
+  protected String getTableDateiname()
+  {
+    return VorlageUtil.getName(VorlageTyp.BELEG_DATEINAME);
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/BuchungsControl.java
@@ -1040,6 +1040,7 @@ public class BuchungsControl extends FilterControl implements Savable
     {
       buchungsList.addColumn("D", "document");
     }
+    buchungsList.addColumn("Belegnummern", "belegnummern");
     buchungsList.addColumn("S", "splittyp", new Formatter()
     {
       @Override

--- a/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
+++ b/src/main/java/de/jost_net/JVerein/gui/control/EinstellungControl.java
@@ -430,6 +430,10 @@ public class EinstellungControl extends AbstractControl
 
   private IntegerInput rechnungZaehler;
 
+  private TextInput belegnummer;
+
+  private IntegerInput belegZaehler;
+
   public EinstellungControl(AbstractView view)
   {
     super(view);
@@ -2258,6 +2262,30 @@ public class EinstellungControl extends AbstractControl
     return afaort;
   }
 
+  public TextInput getBelegNummer() throws RemoteException
+  {
+    if (belegnummer != null)
+    {
+      return belegnummer;
+    }
+    belegnummer = new TextInput(
+        (String) Einstellungen.getEinstellung(Property.BELEGNUMMER), 500);
+    belegnummer.setName("Belegnummer");
+    return belegnummer;
+  }
+
+  public IntegerInput getBelegZaehler() throws RemoteException
+  {
+    if (belegZaehler != null)
+    {
+      return belegZaehler;
+    }
+    belegZaehler = new IntegerInput(
+        (Integer) Einstellungen.getEinstellung(Property.BELEG_ZAEHLER));
+    belegZaehler.setName("Beleg Zaehler");
+    return belegZaehler;
+  }
+
   public CheckboxInput getMitgliedsnummerAnzeigen() throws RemoteException
   {
     if (nummeranzeigen != null)
@@ -2890,6 +2918,16 @@ public class EinstellungControl extends AbstractControl
           (Boolean) getSplitPositionZweck().getValue());
       Einstellungen.setEinstellung(Property.GEPRUEFTSYNCHRONISIEREN,
           (Boolean) getGeprueftSynchronisieren().getValue());
+      if (belegnummer != null)
+      {
+        Einstellungen.setEinstellung(Property.BELEGNUMMER,
+            (String) belegnummer.getValue());
+      }
+      if (belegZaehler != null)
+      {
+        Einstellungen.setEinstellung(Property.BELEG_ZAEHLER,
+            (Integer) belegZaehler.getValue());
+      }
       DBTransaction.commit();
 
       reloadNavigation();

--- a/src/main/java/de/jost_net/JVerein/gui/dialogs/BelegAuswahlDialog.java
+++ b/src/main/java/de/jost_net/JVerein/gui/dialogs/BelegAuswahlDialog.java
@@ -1,0 +1,112 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.dialogs;
+
+import java.rmi.RemoteException;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.gui.control.BelegListControl;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.keys.Filter;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.willuhn.jameica.gui.dialogs.AbstractDialog;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.util.ApplicationException;
+
+public class BelegAuswahlDialog extends AbstractDialog<BuchungDokument[]>
+{
+  private BuchungDokument[] data;
+
+  private BuchungDokument[] auswahl;
+
+  public BelegAuswahlDialog()
+  {
+    super(BelegAuswahlDialog.POSITION_CENTER);
+    super.setSize(1200, 400);
+    setTitle("Belege");
+  }
+
+  @Override
+  protected void paint(Composite parent)
+      throws RemoteException, ApplicationException
+  {
+    final BelegListControl control = new BelegListControl(null);
+
+    LabelGroup group = new LabelGroup(parent, "Filter");
+    group.addInput(control.getFilterInput(Filter.NUMMER));
+    group.addInput(control.getFilterInput(Filter.BEZEICHNUNG));
+    group.addLabelPair("Nicht zugeordnet",
+        control.getFilterInput(Filter.NICHT_ZUGEORDNET));
+
+    ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getResetButton());
+    fbuttons.addButton(control.getSuchenButton());
+    group.addButtonArea(fbuttons);
+
+    JVereinTablePart table = control.getTablePart();
+    table.paint(parent);
+    table.addSelectionListener(e -> {
+      if (e.data instanceof BuchungDokument)
+      {
+        auswahl = new BuchungDokument[] { (BuchungDokument) e.data };
+      }
+      else
+      {
+        auswahl = (BuchungDokument[]) e.data;
+      }
+    });
+    table.setAction(context -> {
+      if (context instanceof BuchungDokument)
+      {
+        data = new BuchungDokument[] { (BuchungDokument) context };
+      }
+      else
+      {
+        data = (BuchungDokument[]) context;
+      }
+      close();
+    });
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Abbrechen", e -> close(), null, false,
+        "process-stop.png");
+    buttons.addButton("Auswahl Zuordnen", e -> {
+      if (auswahl == null)
+      {
+        throw new ApplicationException("Kein Beleg ausgewählt");
+      }
+      data = auswahl;
+      close();
+    }, null, true, "document-save.png");
+    buttons.paint(parent);
+  }
+
+  @Override
+  protected void onEscape()
+  {
+    // Keine Oce werfen
+    close();
+  }
+
+  @Override
+  protected BuchungDokument[] getData() throws Exception
+  {
+    return this.data;
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/menu/BelegMenu.java
+++ b/src/main/java/de/jost_net/JVerein/gui/menu/BelegMenu.java
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.menu;
+
+import de.jost_net.JVerein.gui.action.BelegEntfernenAction;
+import de.jost_net.JVerein.gui.action.DeleteAction;
+import de.jost_net.JVerein.gui.action.DokumentShowAction;
+import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.parts.JVereinTablePart;
+import de.jost_net.JVerein.gui.view.BelegDetailView;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.willuhn.jameica.gui.parts.CheckedContextMenuItem;
+import de.willuhn.jameica.gui.parts.CheckedSingleContextMenuItem;
+import de.willuhn.jameica.gui.parts.ContextMenu;
+import de.willuhn.jameica.gui.parts.ContextMenuItem;
+
+public class BelegMenu extends ContextMenu
+{
+  public BelegMenu(JVereinTablePart part)
+  {
+    this(part, null);
+  }
+
+  public BelegMenu(JVereinTablePart part, IBeleg belegContext)
+  {
+    addItem(new CheckedSingleContextMenuItem("Bearbeiten",
+        new EditAction(BelegDetailView.class, part), "text-x-generic.png"));
+    addItem(new CheckedSingleContextMenuItem("Anzeigen",
+        new DokumentShowAction(), "eye.png"));
+    addItem(ContextMenuItem.SEPARATOR);
+    if (belegContext != null)
+    {
+      addItem(new CheckedContextMenuItem("Beleg aus Buchung Entfernen",
+          new BelegEntfernenAction(belegContext), "user-trash-full.png"));
+    }
+    addItem(new CheckedContextMenuItem("Löschen", new DeleteAction(),
+        "user-trash-full.png"));
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/navigation/MyExtension.java
+++ b/src/main/java/de/jost_net/JVerein/gui/navigation/MyExtension.java
@@ -33,6 +33,7 @@ import de.jost_net.JVerein.gui.view.AnlagenbuchungListeView;
 import de.jost_net.JVerein.gui.view.AnlagenverzeichnisView;
 import de.jost_net.JVerein.gui.view.ArbeitseinsatzListeView;
 import de.jost_net.JVerein.gui.view.BeitragsgruppeListeView;
+import de.jost_net.JVerein.gui.view.BelegListeView;
 import de.jost_net.JVerein.gui.view.BuchungListeView;
 import de.jost_net.JVerein.gui.view.BuchungsartListeView;
 import de.jost_net.JVerein.gui.view.BuchungsklasseListeView;
@@ -185,6 +186,8 @@ public class MyExtension implements Extension
       // Buchungen
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungen",
           new StartViewAction(BuchungListeView.class), "emblem-documents.png"));
+      buchfuehrung.addChild(new MyItem(buchfuehrung, "Belege",
+          new StartViewAction(BelegListeView.class), "emblem-documents.png"));
       buchfuehrung.addChild(new MyItem(buchfuehrung, "Buchungsklassensaldo",
           new StartViewAction(BuchungsklasseSaldoView.class),
           "emblem-documents.png"));

--- a/src/main/java/de/jost_net/JVerein/gui/parts/BelegPart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/BelegPart.java
@@ -1,0 +1,188 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.parts;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.Date;
+
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.Messaging.BelegRemoveMessage;
+import de.jost_net.JVerein.gui.action.BelegNewAction;
+import de.jost_net.JVerein.gui.action.BelegZuordnenAction;
+import de.jost_net.JVerein.gui.action.EditAction;
+import de.jost_net.JVerein.gui.menu.BelegMenu;
+import de.jost_net.JVerein.gui.util.DragnDropUtil;
+import de.jost_net.JVerein.gui.view.BelegDetailView;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.JVereinDBObject;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.jost_net.JVerein.util.JVDateFormatTTMMJJJJ;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.gui.formatter.DateFormatter;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.messaging.Message;
+import de.willuhn.jameica.messaging.MessageConsumer;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.ApplicationException;
+
+public class BelegPart implements Part
+{
+  private AutoUpdateTablePart docsList;
+
+  private IBeleg currentObject;
+
+  private BelegMessageConsumer consumer = new BelegMessageConsumer();
+
+  @Override
+  public void paint(Composite parent) throws RemoteException
+  {
+    LabelGroup grDokument = new LabelGroup(parent, "Dokumente", true);
+
+    grDokument.getComposite().setLayout(new GridLayout(1, false));
+
+    ButtonArea butts = new ButtonArea();
+    butts.addButton("Beleg zuordnen", new BelegZuordnenAction(getTablePart()),
+        getCurrentObject(), false, "document-new.png");
+    butts.addButton("Neu", new BelegNewAction(), getCurrentObject(), false,
+        "document-new.png");
+    butts.paint(grDokument.getComposite());
+    grDokument.addPart(getTablePart());
+
+    grDokument.getComposite().addDisposeListener(e -> {
+      Application.getMessagingFactory().unRegisterMessageConsumer(consumer);
+    });
+
+    DragnDropUtil.setDragDrop(grDokument.getComposite(), f -> addFile(f));
+
+    GridData gridData = new GridData(GridData.FILL_BOTH);
+    gridData.heightHint = 150;
+    grDokument.getComposite().setLayoutData(gridData);
+
+    Application.getMessagingFactory().registerMessageConsumer(consumer);
+  }
+
+  private IBeleg getCurrentObject()
+  {
+    if (currentObject != null)
+    {
+      return currentObject;
+    }
+    currentObject = (IBeleg) GUI.getCurrentView().getCurrentObject();
+    return currentObject;
+  }
+
+  public TablePart getTablePart() throws RemoteException
+  {
+    if (docsList != null)
+    {
+      return docsList;
+    }
+    docsList = new AutoUpdateTablePart(getCurrentObject().getBelegList(), null);
+    docsList.setTableName("Dokumente");
+    docsList.addColumn("Belegnummer", "belegnummer");
+    docsList.addColumn("Datum", "datum",
+        new DateFormatter(new JVDateFormatTTMMJJJJ()));
+    docsList.addColumn("Bemerkung", "bemerkung");
+    docsList.addColumn("Pfad", "vollpfad");
+    docsList.addColumn("Buchungen", "buchungsdokumentbuchung.size");
+    docsList.setContextMenu(new BelegMenu(docsList, getCurrentObject()));
+    docsList.setMulti(true);
+    docsList.setAction(new EditAction(BelegDetailView.class, docsList));
+
+    return docsList;
+  }
+
+  private void addFile(String filename)
+  {
+    try
+    {
+      if (getCurrentObject() instanceof JVereinDBObject
+          && ((JVereinDBObject) getCurrentObject()).isNewObject())
+      {
+        throw new ApplicationException(
+            ((JVereinDBObject) getCurrentObject()).getObjektName()
+                + " bitte erst speichern.");
+      }
+
+      DBTransaction.starten();
+      BuchungDokument document = Einstellungen.getDBService()
+          .createObject(BuchungDokument.class, null);
+      File file = new File(filename);
+
+      document.setBemerkung(file.getName());
+      document.setDatum(new Date());
+
+      document.setFile(file);
+      document.store();
+      getCurrentObject().addBeleg(document);
+
+      DBTransaction.commit();
+      docsList.addItem(document);
+    }
+    catch (RemoteException e)
+    {
+      DBTransaction.rollback();
+      GUI.getStatusBar()
+          .setErrorText("Fehler beim Hinzufügen der Datei: " + e.getMessage());
+    }
+    catch (ApplicationException e)
+    {
+      DBTransaction.rollback();
+      GUI.getStatusBar().setErrorText(e.getMessage());
+    }
+  }
+
+  /**
+   * Wird benachrichtigt um die Anzeige zu aktualisieren.
+   */
+  private class BelegMessageConsumer implements MessageConsumer
+  {
+
+    @Override
+    public Class<?>[] getExpectedMessageTypes()
+    {
+      return new Class<?>[] { BelegRemoveMessage.class };
+    }
+
+    @Override
+    public void handleMessage(Message message) throws Exception
+    {
+      GUI.getDisplay().syncExec(() -> {
+        if (docsList != null)
+        {
+          BelegRemoveMessage m = (BelegRemoveMessage) message;
+          docsList.removeItem(m.getObject());
+        }
+      });
+    }
+
+    @Override
+    public boolean autoRegister()
+    {
+      return false;
+    }
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/parts/BuchungPart.java
+++ b/src/main/java/de/jost_net/JVerein/gui/parts/BuchungPart.java
@@ -18,21 +18,15 @@ package de.jost_net.JVerein.gui.parts;
 
 import java.rmi.RemoteException;
 
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 
 import de.jost_net.JVerein.Einstellungen;
 import de.jost_net.JVerein.Einstellungen.Property;
 import de.jost_net.JVerein.gui.control.BuchungsControl;
-import de.jost_net.JVerein.gui.control.DokumentControl;
-import de.jost_net.JVerein.rmi.BuchungDokument;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.Part;
 import de.willuhn.jameica.gui.input.DateInput;
-import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.ColumnLayout;
-import de.willuhn.jameica.gui.util.LabelGroup;
 import de.willuhn.jameica.gui.util.ScrolledContainer;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 
@@ -40,14 +34,9 @@ public class BuchungPart implements Part
 {
   private BuchungsControl control;
 
-  private DokumentControl dcontrol;
-
-  private boolean buchungabgeschlossen;
-
-  public BuchungPart(BuchungsControl control, boolean buchungabgeschlossen)
+  public BuchungPart(BuchungsControl control)
   {
     this.control = control;
-    this.buchungabgeschlossen = buchungabgeschlossen;
   }
 
   @Override
@@ -117,23 +106,7 @@ public class BuchungPart implements Part
 
     if ((Boolean) Einstellungen.getEinstellung(Property.DOKUMENTENSPEICHERUNG))
     {
-      LabelGroup grDokument = new LabelGroup(scrolled.getComposite(),
-          "Dokumente", true);
-
-      dcontrol = new DokumentControl(!buchungabgeschlossen,
-          BuchungDokument.class);
-
-      grDokument.getComposite().setLayout(new GridLayout(1, false));
-      ButtonArea butts = new ButtonArea();
-      butts.addButton(dcontrol.getNeuButton());
-      butts.paint(grDokument.getComposite());
-
-      grDokument.addPart(dcontrol.getDokumenteList());
-      dcontrol.setDragDrop(grDokument.getComposite());
-
-      GridData gridData = new GridData(GridData.FILL_BOTH);
-      gridData.heightHint = 150;
-      grDokument.getComposite().setLayoutData(gridData);
+      new BelegPart().paint(scrolled.getComposite());
     }
   }
 }

--- a/src/main/java/de/jost_net/JVerein/gui/util/DragnDropUtil.java
+++ b/src/main/java/de/jost_net/JVerein/gui/util/DragnDropUtil.java
@@ -1,0 +1,97 @@
+package de.jost_net.JVerein.gui.util;
+
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.DropTargetListener;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.widgets.Composite;
+
+import de.willuhn.jameica.gui.GUI;
+
+public class DragnDropUtil
+{
+  public interface SaveAction
+  {
+    public void save(String filename);
+  }
+
+  /**
+   * DEm composit wird drag'n'drop Funktionalität hinzuzugefügt
+   * 
+   * @param composit
+   * @param action
+   *          Aktion die für jede Datei ausgeführt werden soll
+   */
+  public static void setDragDrop(Composite composit, SaveAction action)
+  {
+    DropTarget target = new DropTarget(composit,
+        DND.DROP_MOVE | DND.DROP_COPY | DND.DROP_DEFAULT);
+    final FileTransfer fileTransfer = FileTransfer.getInstance();
+    Transfer[] types = new Transfer[] { fileTransfer };
+    target.setTransfer(types);
+
+    target.addDropListener(new DropTargetListener()
+    {
+      @Override
+      public void dragEnter(DropTargetEvent event)
+      {
+        if (event.detail == DND.DROP_DEFAULT)
+        {
+          if ((event.operations & DND.DROP_COPY) != 0)
+            event.detail = DND.DROP_COPY;
+          else
+            event.detail = DND.DROP_NONE;
+        }
+        for (int i = 0; i < event.dataTypes.length; i++)
+        {
+          if (fileTransfer.isSupportedType(event.dataTypes[i]))
+          {
+            event.currentDataType = event.dataTypes[i];
+            // files should only be copied
+            if (event.detail != DND.DROP_COPY)
+              event.detail = DND.DROP_NONE;
+            break;
+          }
+        }
+      }
+
+      @Override
+      public void drop(DropTargetEvent event)
+      {
+        if (event.data == null)
+        {
+          event.detail = DND.DROP_NONE;
+          GUI.getStatusBar().setErrorText("Fehler beim Hinzufügen der Datei");
+          return;
+        }
+
+        for (String filename : (String[]) event.data)
+        {
+          action.save(filename);
+        }
+      }
+
+      @Override
+      public void dragLeave(DropTargetEvent event)
+      {
+      }
+
+      @Override
+      public void dragOperationChanged(DropTargetEvent event)
+      {
+      }
+
+      @Override
+      public void dragOver(DropTargetEvent event)
+      {
+      }
+
+      @Override
+      public void dropAccept(DropTargetEvent event)
+      {
+      }
+    });
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/view/BelegDetailView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/BelegDetailView.java
@@ -1,0 +1,101 @@
+package de.jost_net.JVerein.gui.view;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.TabFolder;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.control.BelegControl;
+import de.jost_net.JVerein.gui.control.Savable;
+import de.jost_net.JVerein.gui.parts.ButtonAreaRtoL;
+import de.jost_net.JVerein.gui.parts.SaveButton;
+import de.jost_net.JVerein.gui.parts.SaveNeuButton;
+import de.jost_net.JVerein.rmi.IBeleg;
+import de.willuhn.datasource.rmi.Changeable;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.util.LabelGroup;
+import de.willuhn.jameica.gui.util.TabGroup;
+
+public class BelegDetailView extends AbstractDetailView
+{
+
+  private IBeleg belegObject;
+
+  public BelegDetailView()
+  {
+  }
+
+  public BelegDetailView(IBeleg belegObject)
+  {
+    this.belegObject = belegObject;
+  }
+
+  // Statische Variable, die den zuletzt ausgewählten Tab speichert.
+  private static int tabindex = -1;
+
+  private BelegControl control;
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Beleg");
+
+    control = new BelegControl(this, belegObject);
+
+    LabelGroup group = new LabelGroup(getParent(), "Beleg");
+    group.addInput(control.getBezeichnung());
+    if (((Changeable) getCurrentObject()).isNewObject())
+    {
+      group.addInput(control.getDatei());
+    }
+    else
+    {
+      group.addInput(control.getPfad());
+
+      TabFolder folder = new TabFolder(getParent(), SWT.BORDER);
+      folder.setLayoutData(new GridData(GridData.FILL_BOTH));
+
+      TabGroup tabBuchung = new TabGroup(folder, "Buchungen", true, 1);
+      control.getBuchungList().paint(tabBuchung.getComposite());
+
+      // Aktiver zuletzt ausgewählter Tab.
+      if (tabindex != -1)
+      {
+        folder.setSelection(tabindex);
+        control.setFolderSelection(tabindex);
+      }
+      folder.addSelectionListener(new SelectionListener()
+      {
+        @Override
+        public void widgetSelected(SelectionEvent evt)
+        {
+          tabindex = folder.getSelectionIndex();
+          control.setFolderSelection(tabindex);
+        }
+
+        @Override
+        public void widgetDefaultSelected(SelectionEvent e)
+        {
+        }
+      });
+    }
+
+    ButtonAreaRtoL buttons = new ButtonAreaRtoL();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.BUCHUNGSART, false, "question-circle.png");
+    buttons.addButton(control.getZurueckButton());
+    buttons.addButton(control.getInfoButton());
+    buttons.addButton(control.getVorButton());
+    buttons.addButton(new SaveButton(control));
+    buttons.addButton(new SaveNeuButton(control));
+    buttons.paint(this.getParent());
+  }
+
+  @Override
+  protected Savable getControl()
+  {
+    return control;
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/view/BelegListeView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/BelegListeView.java
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (c) by Heiner Jostkleigrewe
+ * This program is free software: you can redistribute it and/or modify it under the terms of the 
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without 
+ *  even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See 
+ *  the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.  If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ * heiner@jverein.de
+ * www.jverein.de
+ **********************************************************************/
+package de.jost_net.JVerein.gui.view;
+
+import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.NewAction;
+import de.jost_net.JVerein.gui.control.BelegListControl;
+import de.jost_net.JVerein.gui.dialogs.AbstractPartExportDialog.ExportArt;
+import de.jost_net.JVerein.gui.util.DragnDropUtil;
+import de.jost_net.JVerein.keys.Filter;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.willuhn.jameica.gui.AbstractView;
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.parts.ButtonArea;
+import de.willuhn.jameica.gui.util.LabelGroup;
+
+public class BelegListeView extends AbstractView
+{
+
+  @Override
+  public void bind() throws Exception
+  {
+    GUI.getView().setTitle("Belege");
+
+    final BelegListControl control = new BelegListControl(this);
+
+    LabelGroup group = new LabelGroup(getParent(), "Filter");
+    group.addInput(control.getFilterInput(Filter.NUMMER));
+    group.addInput(control.getFilterInput(Filter.BEZEICHNUNG));
+    group.addLabelPair("Nicht zugeordnet",
+        control.getFilterInput(Filter.NICHT_ZUGEORDNET));
+
+    ButtonArea fbuttons = new ButtonArea();
+    fbuttons.addButton(control.getResetButton());
+    fbuttons.addButton(control.getSuchenButton());
+    group.addButtonArea(fbuttons);
+
+    control.getTablePart().paint(getParent());
+    DragnDropUtil.setDragDrop(getParent(), f -> control.addFile(f));
+
+    ButtonArea buttons = new ButtonArea();
+    buttons.addButton("Hilfe", new DokumentationAction(),
+        DokumentationUtil.DOKUMENT, false, "question-circle.png");
+    buttons.addButton("Neu",
+        new NewAction(BelegDetailView.class, BuchungDokument.class), null,
+        false, "document-new.png");
+    buttons.paint(this.getParent());
+
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.PDF));
+    GUI.getView().addPanelButton(control.exportButton(ExportArt.CSV));
+    GUI.getView().addPanelButton(control.getSpaltenPanelButton());
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/gui/view/BuchungDetailView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/BuchungDetailView.java
@@ -59,7 +59,7 @@ public class BuchungDetailView extends AbstractDetailView
     final boolean editable = control.isBuchungEditable();
     final boolean splitbuchung = control.getBuchung().isSplitbuchung();
 
-    part = new BuchungPart(control, !editable);
+    part = new BuchungPart(control);
     part.paint(this.getParent());
 
     ButtonAreaRtoL buttons = new ButtonAreaRtoL();

--- a/src/main/java/de/jost_net/JVerein/gui/view/DokumentationUtil.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/DokumentationUtil.java
@@ -96,6 +96,8 @@ public class DokumentationUtil
 
   public static final String BUCHUNGEN = BUCHF + "buchungen";
 
+  public static final String DOKUMENT = BUCHF + "dokument";
+
   public static final String ANLAGENBUCHUNGEN = BUCHF + "anlagenbuchungen";
 
   public static final String BUCHUNGSIMPORT = BUCHF + "buchungsimport";
@@ -230,5 +232,4 @@ public class DokumentationUtil
 
   // Changelog bei Update
   public static final String CHANGELOG = FUNKTIONEN + "notes";
-
 }

--- a/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -65,7 +65,6 @@ public class EinstellungenBuchfuehrungView extends AbstractView
     cont.addInput(control.getBelegNummer());
     cont.addInput(control.getBelegZaehler());
 
-    // TODO auch Buchung-Map?
     Map<String, Object> map = new AllgemeineMap().getMap(null);
     map = BelegMap.getDummyMap(map);
 

--- a/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/EinstellungenBuchfuehrungView.java
@@ -16,7 +16,12 @@
  **********************************************************************/
 package de.jost_net.JVerein.gui.view;
 
+import java.util.Map;
+
+import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.BelegMap;
 import de.jost_net.JVerein.gui.action.DokumentationAction;
+import de.jost_net.JVerein.gui.action.InsertVariableDialogAction;
 import de.jost_net.JVerein.gui.control.EinstellungControl;
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.Action;
@@ -57,11 +62,19 @@ public class EinstellungenBuchfuehrungView extends AbstractView
         "Bei automatischem Splitten den "
             + "Verwendungszweck aus den Sollbuchungspositionen übernehmen",
         control.getSplitPositionZweck());
+    cont.addInput(control.getBelegNummer());
+    cont.addInput(control.getBelegZaehler());
+
+    // TODO auch Buchung-Map?
+    Map<String, Object> map = new AllgemeineMap().getMap(null);
+    map = BelegMap.getDummyMap(map);
 
     ButtonArea buttons = new ButtonArea();
     buttons.addButton("Hilfe", new DokumentationAction(),
         DokumentationUtil.EINSTELLUNGEN_BUCHFUEHRUNG, false,
         "question-circle.png");
+    buttons.addButton("Variablen anzeigen", new InsertVariableDialogAction(map),
+        control, false, "bookmark.png");
     buttons.addButton("Speichern", new Action()
     {
 

--- a/src/main/java/de/jost_net/JVerein/io/SEPASupport.java
+++ b/src/main/java/de/jost_net/JVerein/io/SEPASupport.java
@@ -14,7 +14,6 @@ import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.MitgliedMap;
 import de.jost_net.JVerein.Variable.RechnungMap;
 import de.jost_net.JVerein.keys.VorlageTyp;
-import de.jost_net.JVerein.rmi.AbstractDokument;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.BuchungDokument;
 import de.jost_net.JVerein.rmi.Formular;
@@ -67,14 +66,15 @@ public class SEPASupport
         formular.store();
         aufbereitung.closeFormular();
 
-        AbstractDokument doc = Einstellungen.getDBService()
+        BuchungDokument doc = Einstellungen.getDBService()
             .createObject(BuchungDokument.class, null);
-        doc.setReferenz(Long.valueOf(buchung.getID()));
         doc.setBemerkung(file.getName());
         doc.setDatum(new Date());
         doc.setFile(file);
         doc.store();
         file.delete();
+
+        buchung.addBeleg(doc);
       }
       catch (IOException | DocumentException e)
       {

--- a/src/main/java/de/jost_net/JVerein/keys/Filter.java
+++ b/src/main/java/de/jost_net/JVerein/keys/Filter.java
@@ -179,6 +179,8 @@ public enum Filter
   ZUSATZFELD("filter_zusatzfelder", "Zusatzfelder", "Zusatzfeld",
       FilterArt.ZUSATZFELD),
   ZWECK("filter_zweck", "Zweck", "Zweck", FilterArt.TEXT),
+  NICHT_ZUGEORDNET("filter_nicht_zugeordnet", "Nicht zugeordnet", "0",
+      FilterArt.CHECKBOX),
 
   // Für Auswertung
   JUBELJAHR("filter_jahr", "Jahr", "2024", FilterArt.SELECT_OHNE_NULL,

--- a/src/main/java/de/jost_net/JVerein/keys/VorlageTyp.java
+++ b/src/main/java/de/jost_net/JVerein/keys/VorlageTyp.java
@@ -804,10 +804,17 @@ public enum VorlageTyp
       Vorlageart.TITEL.getKey()),
   STEUERN_SUBTITEL("steuern-subtitel", "Steuern Subtitel", "",
       Vorlageart.TITEL.getKey()),
-  BUCHUNG_DOKUMENT_PFAD("buchung-dokument-pfad", "Buchung Dokument Pfad",
-      "/$buchung_kontonummer/$buchung_id", Vorlageart.PFAD.getKey()),
+  BELEG_PFAD("Beleg-pfad", "Belegt Pfad", "$beleg_zaehler",
+      Vorlageart.PFAD.getKey()),
   MITGLIED_DOKUMENT_PFAD("mitglied-dokument-pfad", "Mitglied Dokument Pfad",
-      "/$mitglied_id", Vorlageart.PFAD.getKey());
+      "/$mitglied_id", Vorlageart.PFAD.getKey()),
+
+  BELEG_TITEL("beleg-titel", "Beleg Titel", "Belege",
+      Vorlageart.TITEL.getKey()),
+  BELEG_SUBTITEL("beleg-subtitel", "Beleg Subtitel", "",
+      Vorlageart.TITEL.getKey()),
+  BELEG_DATEINAME("beleg-dateiname", "Beleg Dateiname", "Belege",
+      Vorlageart.DATEINAME.getKey());
 
   private final String text;
 

--- a/src/main/java/de/jost_net/JVerein/rmi/AbstractBelegReferenz.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/AbstractBelegReferenz.java
@@ -1,0 +1,28 @@
+package de.jost_net.JVerein.rmi;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.rmi.Changeable;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.util.ApplicationException;
+
+public interface AbstractBelegReferenz extends JVereinDBObject, Changeable
+{
+  public BuchungDokument getDokument() throws RemoteException;
+
+  public void setDokument(BuchungDokument dokument) throws RemoteException;
+
+  public DBObject getBuchung() throws RemoteException;
+
+  public void setBuchung(DBObject buchung) throws RemoteException;
+
+  /**
+   * Prüft, ob änderungen am Beleg aus sicht der Referenz erlaubt sind, wenn
+   * nicht wird eine Exception geworfen
+   * 
+   * @throws RemoteException
+   * @throws ApplicationException
+   */
+  public void checkChangesAllowed()
+      throws RemoteException, ApplicationException;
+}

--- a/src/main/java/de/jost_net/JVerein/rmi/Buchung.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/Buchung.java
@@ -192,4 +192,10 @@ public interface Buchung extends JVereinDBObject
   public void setUnterlagenWertermittlung(Boolean unterlagenwertermittlung)
       throws RemoteException;
 
+  public AbstractBelegReferenz addBeleg(BuchungDokument document)
+      throws RemoteException, ApplicationException;
+
+  void removeBeleg(BuchungDokument dokument)
+      throws RemoteException, ApplicationException;
+
 }

--- a/src/main/java/de/jost_net/JVerein/rmi/BuchungsdokumentBuchung.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/BuchungsdokumentBuchung.java
@@ -1,0 +1,5 @@
+package de.jost_net.JVerein.rmi;
+
+public interface BuchungsdokumentBuchung extends AbstractBelegReferenz
+{
+}

--- a/src/main/java/de/jost_net/JVerein/rmi/IBeleg.java
+++ b/src/main/java/de/jost_net/JVerein/rmi/IBeleg.java
@@ -1,0 +1,20 @@
+package de.jost_net.JVerein.rmi;
+
+import java.rmi.RemoteException;
+
+import de.willuhn.datasource.rmi.Changeable;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.util.ApplicationException;
+
+public interface IBeleg extends Changeable
+{
+  public AbstractBelegReferenz addBeleg(BuchungDokument dokument)
+      throws RemoteException, ApplicationException;
+
+  public void removeBeleg(BuchungDokument dokument)
+      throws RemoteException, ApplicationException;
+
+  public String getObjektName() throws RemoteException;
+
+  public DBIterator<BuchungDokument> getBelegList() throws RemoteException;
+}

--- a/src/main/java/de/jost_net/JVerein/server/AbstractBelegReferenzImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/AbstractBelegReferenzImpl.java
@@ -1,0 +1,43 @@
+package de.jost_net.JVerein.server;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.rmi.AbstractBelegReferenz;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.willuhn.datasource.rmi.DBObject;
+
+public abstract class AbstractBelegReferenzImpl extends AbstractJVereinDBObject
+    implements AbstractBelegReferenz
+{
+
+  private static final long serialVersionUID = -1625655887687027193L;
+
+  public AbstractBelegReferenzImpl() throws RemoteException
+  {
+    super();
+  }
+
+  @Override
+  public BuchungDokument getDokument() throws RemoteException
+  {
+    return (BuchungDokument) super.getAttribute("dokument");
+  }
+
+  @Override
+  public void setDokument(BuchungDokument dokument) throws RemoteException
+  {
+    setAttribute("dokument", dokument);
+  }
+
+  @Override
+  public DBObject getBuchung() throws RemoteException
+  {
+    return (DBObject) super.getAttribute("buchung");
+  }
+
+  @Override
+  public void setBuchung(DBObject buchung) throws RemoteException
+  {
+    setAttribute("buchung", buchung);
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/server/AbstractDokumentImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/AbstractDokumentImpl.java
@@ -44,7 +44,7 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
 
   private static final long serialVersionUID = 1L;
 
-  private static String HASH_ALGORITHM = "SHA-512";
+  protected static String HASH_ALGORITHM = "SHA-512";
 
   private File file;
 
@@ -57,11 +57,6 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
   public String getPrimaryAttribute()
   {
     return "bemerkung";
-  }
-
-  @Override
-  protected void deleteCheck() throws ApplicationException
-  {
   }
 
   @Override
@@ -92,12 +87,6 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
     {
       throw new ApplicationException("Pfad darf nicht verändert werden!");
     }
-  }
-
-  @Override
-  protected Class<?> getForeignObject(String field)
-  {
-    return null;
   }
 
   @Override
@@ -134,7 +123,9 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
   public void setBemerkung(String bemerkung) throws RemoteException
   {
     setAttribute("bemerkung",
-        bemerkung.length() > 50 ? bemerkung.substring(0, 50) : bemerkung);
+        bemerkung != null && bemerkung.length() > 50
+            ? bemerkung.substring(0, 50)
+            : bemerkung);
   }
 
   @Override
@@ -238,7 +229,7 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
       setAttribute("datum", new Date());
     }
     File newFile = null;
-    if (file != null)
+    if (file != null && getPfad() == null)
     {
       if (file.isDirectory())
       {
@@ -289,7 +280,7 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
                     + " Bitte in Einstellungen korrigieren.");
           }
           QueryMessage qm = new QueryMessage(
-              getVerzeichnis() + "." + getReferenz(), fis);
+              getVerzeichnis() + "." + getNummer(), fis);
           Application.getMessagingFactory()
               .getMessagingQueue("jameica.messaging.put").sendSyncMessage(qm);
 
@@ -411,4 +402,10 @@ public abstract class AbstractDokumentImpl extends AbstractJVereinDBObject
 
   @Override
   public abstract String getRootDir() throws RemoteException;
+
+  // Wird zum Speichern per Messaging benötigt
+  public String getNummer() throws RemoteException
+  {
+    return getReferenz().toString();
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
@@ -235,8 +235,20 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
   @Override
   public String getNummer() throws RemoteException
   {
+    // Prefer explicit belegnummer if present (new behaviour),
+    // otherwise fall back to old referenz for backward compatibility.
+
     // Wird zum Speichern per Messaging benötigt
-    return getBelegnummer();
+    String nr = getBelegnummer();
+    if (nr != null && !nr.isBlank())
+    {
+      return nr;
+    }
+
+    // Alte Dokumente haben zT. keine Belegnummer (Wenn es mehrere Dokumente in
+    // einer Buchung gab), dann als Fallback die Referenz verwenden
+    Long ref = getReferenz();
+    return ref == null ? null : ref.toString();
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
@@ -75,7 +75,7 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
     }
     catch (RemoteException e)
     {
-      throw new ApplicationException("Fehler beim insertCheck");
+      throw new ApplicationException("Fehler beim updateCheck");
     }
     super.updateCheck();
   }
@@ -95,6 +95,30 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
       throw new ApplicationException("Fehler beim insertCheck");
     }
     super.insertCheck();
+  }
+
+  @Override
+  protected void deleteCheck() throws ApplicationException
+  {
+    try
+    {
+      // Alle vorhandenn erferenzen des Objects prüfen, ob sie geändert/gelöscht
+      // werden dürfen
+      for (Class<? extends AbstractBelegReferenz> c : belegReferenzList)
+      {
+        DBIterator<AbstractBelegReferenz> it = Einstellungen.getDBService()
+            .createList(c);
+        it.addFilter("dokument = ?", getID());
+        while (it.hasNext())
+        {
+          it.next().checkChangesAllowed();
+        }
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler beim insertCheck");
+    }
   }
 
   @Override

--- a/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungDokumentImpl.java
@@ -18,17 +18,33 @@ package de.jost_net.JVerein.server;
 
 import java.io.File;
 import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import de.jost_net.JVerein.Einstellungen;
+import de.jost_net.JVerein.Einstellungen.Property;
+import de.jost_net.JVerein.DBTools.DBTransaction;
+import de.jost_net.JVerein.Variable.AllgemeineMap;
+import de.jost_net.JVerein.Variable.BelegMap;
+import de.jost_net.JVerein.Variable.BelegVar;
+import de.jost_net.JVerein.io.VelocityTool;
 import de.jost_net.JVerein.keys.VorlageTyp;
-import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.AbstractBelegReferenz;
 import de.jost_net.JVerein.rmi.BuchungDokument;
 import de.jost_net.JVerein.util.VorlageUtil;
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBObject;
 import de.willuhn.util.ApplicationException;
 
 public class BuchungDokumentImpl extends AbstractDokumentImpl
     implements BuchungDokument
 {
+
+  // Hier müssen alle Implementierungen von AbstractBelegReferenz
+  // aufgelistet werden
+  private List<Class<? extends AbstractBelegReferenz>> belegReferenzList = Arrays
+      .asList(BuchungsdokumentBuchungImpl.class);
 
   private static final long serialVersionUID = 1L;
 
@@ -38,37 +54,28 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
   }
 
   @Override
-  protected void deleteCheck() throws ApplicationException
-  {
-    super.deleteCheck();
-    try
-    {
-      if (istAbgeschlossen())
-      {
-        throw new ApplicationException(
-            "Dokument kann nicht gelöscht werden, Buchung ist abgeschlossen");
-      }
-    }
-    catch (RemoteException e)
-    {
-      throw new ApplicationException("Fehler beim deleteCheck");
-    }
-  }
-
-  @Override
   protected void updateCheck() throws ApplicationException
   {
     try
     {
-      if (istAbgeschlossen())
+      for (Class<? extends AbstractBelegReferenz> c : belegReferenzList)
       {
-        throw new ApplicationException(
-            "Dokument kann nicht geändert werden, Buchung ist abgeschlossen");
+        DBIterator<AbstractBelegReferenz> it = Einstellungen.getDBService()
+            .createList(c);
+        it.addFilter("dokument = ?", getID());
+        while (it.hasNext())
+        {
+          it.next().checkChangesAllowed();
+        }
+      }
+      if (getBemerkung() == null || getBemerkung().isBlank())
+      {
+        throw new ApplicationException("Bitte Bezeichnung eingeben");
       }
     }
     catch (RemoteException e)
     {
-      throw new ApplicationException("Fehler beim updateCheck");
+      throw new ApplicationException("Fehler beim insertCheck");
     }
     super.updateCheck();
   }
@@ -78,10 +85,9 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
   {
     try
     {
-      if (istAbgeschlossen())
+      if (getBemerkung() == null || getBemerkung().isBlank())
       {
-        throw new ApplicationException(
-            "Es kann kein Dokument hinzugefügt werden, Buchung ist abgeschlossen");
+        throw new ApplicationException("Bitte Bezeichnung eingeben");
       }
     }
     catch (RemoteException e)
@@ -91,11 +97,31 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
     super.insertCheck();
   }
 
-  private boolean istAbgeschlossen() throws RemoteException
+  @Override
+  public void delete() throws RemoteException, ApplicationException
   {
-    Buchung buchung = Einstellungen.getDBService().createObject(Buchung.class,
-        getReferenz().toString());
-    return buchung.getJahresabschluss() != null;
+    try
+    {
+      // Alle vorhandenn erferenzen des Objects impliziet löschen, damit dort im
+      // deleteCheck geprüft werden kann
+      DBTransaction.starten();
+      for (Class<? extends AbstractBelegReferenz> c : belegReferenzList)
+      {
+        DBIterator<DBObject> it = Einstellungen.getDBService().createList(c);
+        it.addFilter("dokument = ?", getID());
+        while (it.hasNext())
+        {
+          it.next().delete();
+        }
+      }
+      DBTransaction.commit();
+    }
+    catch (ApplicationException | RemoteException e)
+    {
+      DBTransaction.rollback();
+      throw e;
+    }
+    super.delete();
   }
 
   @Override
@@ -119,9 +145,79 @@ public class BuchungDokumentImpl extends AbstractDokumentImpl
   @Override
   protected String getDateiPfad() throws RemoteException
   {
-    AbstractJVereinDBObject dbObject = Einstellungen.getDBService()
-        .createObject(Buchung.class, getReferenz().toString());
-    return VorlageUtil.getName(VorlageTyp.BUCHUNG_DOKUMENT_PFAD, dbObject);
+    return VorlageUtil.getName(VorlageTyp.BELEG_PFAD, this);
   }
 
+  @Override
+  public String getBelegnummer() throws RemoteException
+  {
+    return (String) getAttribute("belegnummer");
+  }
+
+  @Override
+  public void setBelegnummer(String belegnummer) throws RemoteException
+  {
+    setAttribute("belegnummer", belegnummer);
+  }
+
+  @Override
+  public void store() throws RemoteException, ApplicationException
+  {
+    if (!isNewObject())
+    {
+      super.store();
+      return;
+    }
+    try
+    {
+      transactionBegin();
+
+      // Belegnummernummer erstellen
+      Map<String, Object> map = new AllgemeineMap().getMap(null);
+      map = new BelegMap().getMap(this, map);
+      String nummer = VelocityTool.eval(map,
+          (String) Einstellungen.getEinstellung(Property.BELEGNUMMER));
+
+      if (nummer.length() > 50)
+      {
+        throw new ApplicationException(
+            "Belegnummer zu lang, maximal 50 Zeichen erlaubt!");
+      }
+      setBelegnummer(nummer);
+
+      // Prüfen, ob es schon einen Beleg mit dieser Nummer gibt
+      DBIterator<?> it = getList();
+      it.addFilter("belegnummer = ?", nummer);
+      if (it.hasNext())
+      {
+        throw new ApplicationException(
+            "Beleg mit dieser Nummer existiert bereits. Belegnummer in Einstellungen korrigieren!");
+      }
+      super.store();
+      // Belegnummer hochzählen
+      Einstellungen.setEinstellung(Property.BELEG_ZAEHLER,
+          Integer.parseInt(map.get(BelegVar.BELEG_ZAEHLER.getName()).toString())
+              + 1);
+
+      transactionCommit();
+    }
+    catch (Exception e)
+    {
+      transactionRollback();
+      throw e;
+    }
+  }
+
+  @Override
+  public String getNummer() throws RemoteException
+  {
+    // Wird zum Speichern per Messaging benötigt
+    return getBelegnummer();
+  }
+
+  @Override
+  public void setReferenz(Long referenz) throws RemoteException
+  {
+    throw new RemoteException("set Referenz bei Belegen nicht möglich!");
+  }
 }

--- a/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
@@ -1020,6 +1020,7 @@ public class BuchungImpl extends AbstractJVereinDBObject
     {
       throw new ApplicationException("Dokument bitte erst speichern");
     }
+    updateCheck();
     DBIterator<BuchungDokument> it = getBelegList();
     it.addFilter("dokument = ?", dokument.getID());
     if (it.hasNext())
@@ -1046,6 +1047,7 @@ public class BuchungImpl extends AbstractJVereinDBObject
       throw new ApplicationException(
           "Dokument existiert nicht oder wurde noch nicht gespeichert");
     }
+    updateCheck();
     DBIterator<BuchungsdokumentBuchung> it = Einstellungen.getDBService()
         .createList(BuchungsdokumentBuchung.class);
     it.addFilter("buchungsdokumentbuchung.dokument = ?", beleg.getID());

--- a/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungImpl.java
@@ -28,10 +28,13 @@ import de.jost_net.JVerein.keys.ArtBuchungsart;
 import de.jost_net.JVerein.keys.HerkunftSpende;
 import de.jost_net.JVerein.keys.Kontoart;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
+import de.jost_net.JVerein.rmi.AbstractBelegReferenz;
 import de.jost_net.JVerein.rmi.Buchung;
 import de.jost_net.JVerein.rmi.BuchungDokument;
 import de.jost_net.JVerein.rmi.Buchungsart;
+import de.jost_net.JVerein.rmi.BuchungsdokumentBuchung;
 import de.jost_net.JVerein.rmi.Buchungsklasse;
+import de.jost_net.JVerein.rmi.IBeleg;
 import de.jost_net.JVerein.rmi.Jahresabschluss;
 import de.jost_net.JVerein.rmi.Konto;
 import de.jost_net.JVerein.rmi.Projekt;
@@ -45,7 +48,7 @@ import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 public class BuchungImpl extends AbstractJVereinDBObject
-    implements Buchung, IBetrag
+    implements Buchung, IBetrag, IBeleg
 {
 
   private static final long serialVersionUID = 1L;
@@ -802,13 +805,28 @@ public class BuchungImpl extends AbstractJVereinDBObject
 
     if ("document".equals(fieldName))
     {
-      DBIterator<BuchungDokument> list = Einstellungen.getDBService()
-          .createList(BuchungDokument.class);
-      list.addFilter("referenz = ?", Long.valueOf(getID()));
+      DBIterator<BuchungDokument> list = getBelegList();
       if (list.size() > 0)
         return list.size();
       else
         return null;
+    }
+    if ("belegnummern".equals(fieldName))
+    {
+      DBIterator<BuchungDokument> list = getBelegList();
+
+      StringBuilder sb = new StringBuilder();
+      boolean first = true;
+      while (list.hasNext())
+      {
+        if (!first)
+        {
+          sb.append(", ");
+        }
+        first = false;
+        sb.append(list.next().getBelegnummer());
+      }
+      return sb.toString();
     }
 
     return super.getAttribute(fieldName);
@@ -940,19 +958,6 @@ public class BuchungImpl extends AbstractJVereinDBObject
   }
 
   @Override
-  public void delete() throws RemoteException, ApplicationException
-  {
-    DBIterator<BuchungDokument> it = Einstellungen.getDBService()
-        .createList(BuchungDokument.class);
-    it.addFilter("referenz = ?", new Object[] { this.getID() });
-    while (it.hasNext())
-    {
-      it.next().delete();
-    }
-    super.delete();
-  }
-
-  @Override
   public String getBezeichnungSachzuwendung() throws RemoteException
   {
     return (String) getAttribute("bezeichnungsachzuwendung");
@@ -1001,5 +1006,66 @@ public class BuchungImpl extends AbstractJVereinDBObject
   public String getObjektNameMehrzahl()
   {
     return "Buchungen";
+  }
+
+  @Override
+  public AbstractBelegReferenz addBeleg(BuchungDokument dokument)
+      throws RemoteException, ApplicationException
+  {
+    if (isNewObject())
+    {
+      throw new ApplicationException("Buchung bitte erst speichern");
+    }
+    if (dokument == null || dokument.isNewObject())
+    {
+      throw new ApplicationException("Dokument bitte erst speichern");
+    }
+    DBIterator<BuchungDokument> it = getBelegList();
+    it.addFilter("dokument = ?", dokument.getID());
+    if (it.hasNext())
+    {
+      throw new ApplicationException("Dokument '" + dokument.getBemerkung()
+          + "' bereits bei Buchung hinterlegt");
+    }
+
+    BuchungsdokumentBuchung budo = Einstellungen.getDBService()
+        .createObject(BuchungsdokumentBuchung.class, null);
+    budo.setBuchung(this);
+    budo.setDokument(dokument);
+    budo.store();
+
+    return budo;
+  }
+
+  @Override
+  public void removeBeleg(BuchungDokument beleg)
+      throws RemoteException, ApplicationException
+  {
+    if (beleg == null || beleg.isNewObject())
+    {
+      throw new ApplicationException(
+          "Dokument existiert nicht oder wurde noch nicht gespeichert");
+    }
+    DBIterator<BuchungsdokumentBuchung> it = Einstellungen.getDBService()
+        .createList(BuchungsdokumentBuchung.class);
+    it.addFilter("buchungsdokumentbuchung.dokument = ?", beleg.getID());
+    it.addFilter("buchungsdokumentbuchung.buchung = ?", getID());
+    if (!it.hasNext())
+    {
+      throw new ApplicationException(
+          "Dokument ist nicht bei Buchung hinterlegt");
+    }
+    it.next().delete();
+  }
+
+  @Override
+  public DBIterator<BuchungDokument> getBelegList() throws RemoteException
+  {
+    DBIterator<BuchungDokument> it = Einstellungen.getDBService()
+        .createList(BuchungDokument.class);
+    it.join("buchungsdokumentbuchung");
+    it.addFilter("buchungsdokumentbuchung.dokument = buchungdokument.id");
+    it.addFilter("buchungsdokumentbuchung.buchung = ?", getID());
+    return it;
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/BuchungsdokumentBuchungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/BuchungsdokumentBuchungImpl.java
@@ -1,0 +1,123 @@
+package de.jost_net.JVerein.server;
+
+import java.rmi.RemoteException;
+
+import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.BuchungDokument;
+import de.jost_net.JVerein.rmi.BuchungsdokumentBuchung;
+import de.willuhn.util.ApplicationException;
+
+public class BuchungsdokumentBuchungImpl extends AbstractBelegReferenzImpl
+    implements BuchungsdokumentBuchung
+{
+
+  private static final long serialVersionUID = -810016324287845770L;
+
+  public BuchungsdokumentBuchungImpl() throws RemoteException
+  {
+    super();
+  }
+
+  @Override
+  protected void deleteCheck() throws ApplicationException
+  {
+    try
+    {
+      if (istAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Dokument kann nicht entfernt werden, ist einer abgeschlossenen Buchung zugeordnet.");
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler beim deleteCheck");
+    }
+    super.deleteCheck();
+  }
+
+  @Override
+  protected void updateCheck() throws ApplicationException
+  {
+    try
+    {
+      if (istAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Dokument kann nicht geändert werden, ist einer abgeschlossenen Buchung zugeordnet.");
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler beim updateCheck");
+    }
+    super.updateCheck();
+  }
+
+  @Override
+  protected void insertCheck() throws ApplicationException
+  {
+    try
+    {
+      if (istAbgeschlossen())
+      {
+        throw new ApplicationException(
+            "Dokument kann nicht zugeordnet werden, Buchung ist abgeschlossen.");
+      }
+    }
+    catch (RemoteException e)
+    {
+      throw new ApplicationException("Fehler beim insertCheck");
+    }
+    super.insertCheck();
+  }
+
+  private boolean istAbgeschlossen() throws RemoteException
+  {
+    return ((Buchung) getBuchung()).getJahresabschluss() != null;
+  }
+
+  @Override
+  protected Class<?> getForeignObject(String field)
+  {
+    if ("dokument".equals(field))
+    {
+      return BuchungDokument.class;
+    }
+    else if ("buchung".equals(field))
+    {
+      return Buchung.class;
+    }
+    return null;
+  }
+
+  @Override
+  public String getObjektName() throws RemoteException
+  {
+    return "Buchungsdokument-Buchung";
+  }
+
+  @Override
+  public String getObjektNameMehrzahl() throws RemoteException
+  {
+    return "Buchungsdokument-Buchungen";
+  }
+
+  @Override
+  protected String getTableName()
+  {
+    return "buchungsdokumentbuchung";
+  }
+
+  @Override
+  public String getPrimaryAttribute() throws RemoteException
+  {
+    return "id";
+  }
+
+  @Override
+  public void checkChangesAllowed() throws ApplicationException
+  {
+    updateCheck();
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -41,9 +41,8 @@ public class Update0511 extends AbstractDDLUpdate
     table.add(new Column("buchung", COLTYPE.BIGINT, 4, null, true, false));
     execute(createTable(table));
 
-    execute(
-        "INSERT INTO buchungsdokumentbuchung (dokument,buchung) SELECT id,referenz FROM buchungdokument"
-            + " WHERE referenz IS NOT NULL");
+    execute("INSERT INTO buchungsdokumentbuchung (dokument,buchung) "
+        + "SELECT id, referenz FROM buchungdokument WHERE referenz IS NOT NULL");
 
     execute(
         "CREATE UNIQUE INDEX dokumentbuchung ON buchungsdokumentbuchung (dokument,buchung);");
@@ -51,23 +50,27 @@ public class Update0511 extends AbstractDDLUpdate
     execute(addColumn("buchungdokument",
         new Column("belegnummer", COLTYPE.VARCHAR, 50, null, false, false)));
 
-    // Bestehende Dokumente haben die gleiche refernz (=buchung_id) für mehrere
-    // Dokumente, durch die Migration wird dort Belegnummer = rerferenz gesetzt.
-    // Daher kann es mehrfach die gleiche "Belegnummer" für bestehende Dokumente
-    // geben. Ein Unique Key ist ohne Migration der bestehdenden Dokumente nicht
-    // möglich.
-    // TODO unique Belegnummer
-    // execute(
-    // "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
+    execute(
+        "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
 
     // Damit per messaging gespeicherte Dokumente weiterhing gefunden werden,
     // ist die referenz weiter nötig, neuerdings wird dafür die Belegnummer
-    // verwendet
-    execute("UPDATE buchungdokument SET belegnummer = referenz");
+    // verwendet.
+    // Nur das erste Dokument pro Buchung wird mit einer Belegnummer versehen,
+    // bei den anderen greift der Falback-Modus in
+    // BuchungDokumentImpl.getNummer().
 
-    // TODO Drop referenz, Sollte erst in einer späteren Version gemacht werden,
-    // falls ein Update fehlschlägt
-    // execute(dropColumn("buchungdokument", "referenz"));
+    // Temp-Tabelle mit jeweils erstem Dokument pro referenz
+    execute("CREATE TEMPORARY TABLE temp_first (id BIGINT PRIMARY KEY);");
+    execute("INSERT INTO temp_first (id) SELECT MIN(id) FROM buchungdokument"
+        + " WHERE referenz IS NOT NULL GROUP BY referenz;");
+
+    // Update nur für diese IDs: setze belegnummer = referenz (als String)
+    execute("UPDATE buchungdokument bd JOIN temp_first tf ON bd.id = tf.id"
+        + " SET bd.belegnummer = CONCAT('', bd.referenz);");
+
+    // Temp-Tabelle entfernen
+    execute("DROP TEMPORARY TABLE IF EXISTS temp_first;");
 
     execute(createForeignKey("fkBuchung", "buchungsdokumentbuchung", "buchung",
         "buchung", "id", "CASCADE", "RESTRICT"));

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -42,6 +42,9 @@ public class Update0511 extends AbstractDDLUpdate
     execute(createTable(table));
 
     execute(
+        "CREATE UNIQUE INDEX dokumentbuchung ON buchungsdokumentbuchung (dokument,buchung);");
+
+    execute(
         "INSERT INTO buchungsdokumentbuchung (dokument,buchung) SELECT id,referenz FROM buchungdokument");
 
     execute(addColumn("buchungdokument",

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -51,11 +51,12 @@ public class Update0511 extends AbstractDDLUpdate
     execute(addColumn("buchungdokument",
         new Column("belegnummer", COLTYPE.VARCHAR, 50, null, false, false)));
 
-    // Bestehende Dokumente haben die gleiche refernz (=buchung_id) für mehre
+    // Bestehende Dokumente haben die gleiche refernz (=buchung_id) für mehrere
     // Dokumente, durch die Migration wird dort Belegnummer = rerferenz gesetzt.
     // Daher kann es mehrfach die gleiche "Belegnummer" für bestehende Dokumente
-    // geben. Ein Unique Key ist daher ohne Migration der bestehdenden Dokumente
-    // nicht möglich.
+    // geben. Ein Unique Key ist ohne Migration der bestehdenden Dokumente nicht
+    // möglich.
+    // TODO unique Belegnummer
     // execute(
     // "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
 
@@ -64,7 +65,8 @@ public class Update0511 extends AbstractDDLUpdate
     // verwendet
     execute("UPDATE buchungdokument SET belegnummer = referenz");
 
-    // TODO Drop referenz
+    // TODO Drop referenz, Sollte erst in einer späteren Version gemacht werden,
+    // falls ein Update fehlschlägt
     // execute(dropColumn("buchungdokument", "referenz"));
 
     execute(createForeignKey("fkBuchung", "buchungsdokumentbuchung", "buchung",
@@ -72,5 +74,11 @@ public class Update0511 extends AbstractDDLUpdate
 
     execute(createForeignKey("fkDokument", "buchungsdokumentbuchung",
         "dokument", "buchungdokument", "id", "CASCADE", "RESTRICT"));
+
+    // Belegnummer soll erstmal von bisheriger Buchungsnummer wieterzählen,
+    // solange nicht individuell in den Einstellungen angepasst wird
+    execute("INSERT INTO einstellungneu (name, wert) "
+        + "SELECT 'beleg_zaehler', COALESCE(MAX(referenz), 0) + 1 "
+        + "FROM buchungdokument WHERE referenz IS NOT NULL;");
   }
 }

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the 
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without 
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See 
+ * the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, 
+ * see <http://www.gnu.org/licenses/>.
+ * 
+ **********************************************************************/
+package de.jost_net.JVerein.server.DDLTool.Updates;
+
+import java.sql.Connection;
+
+import de.jost_net.JVerein.server.DDLTool.AbstractDDLUpdate;
+import de.jost_net.JVerein.server.DDLTool.Column;
+import de.jost_net.JVerein.server.DDLTool.Table;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.ProgressMonitor;
+
+public class Update0511 extends AbstractDDLUpdate
+{
+  public Update0511(String driver, ProgressMonitor monitor, Connection conn)
+  {
+    super(driver, monitor, conn);
+  }
+
+  @Override
+  public void run() throws ApplicationException
+  {
+
+    Table table = new Table("buchungsdokumentbuchung");
+
+    Column id = new Column("id", COLTYPE.BIGINT, 4, null, false, true);
+    table.add(id);
+    table.setPrimaryKey(id);
+    table.add(new Column("dokument", COLTYPE.BIGINT, 4, null, true, false));
+    table.add(new Column("buchung", COLTYPE.BIGINT, 4, null, true, false));
+    execute(createTable(table));
+
+    execute(
+        "INSERT INTO buchungsdokumentbuchung (dokument,buchung) SELECT id,referenz FROM buchungdokument");
+
+    execute(addColumn("buchungdokument",
+        new Column("belegnummer", COLTYPE.VARCHAR, 50, null, false, false)));
+    execute(
+        "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
+
+    // Damit per messaging gespeicherte Dokumente weiterhing gefunden werden,
+    // ist die referenz weiter nötig, neuerdings wird dafür die Belegnummer
+    // verwendet
+    execute("UPDATE buchungdokument SET belegnummer = referenz");
+
+    // TODO Drop referenz
+    // execute(dropColumn("buchungdokument", "referenz"));
+
+    execute(createForeignKey("fkBuchung", "buchungsdokumentbuchung", "buchung",
+        "buchung", "id", "CASCADE", "RESTRICT"));
+
+    execute(createForeignKey("fkDokument", "buchungsdokumentbuchung",
+        "dokument", "buchungdokument", "id", "CASCADE", "RESTRICT"));
+  }
+}

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -50,9 +50,6 @@ public class Update0511 extends AbstractDDLUpdate
     execute(addColumn("buchungdokument",
         new Column("belegnummer", COLTYPE.VARCHAR, 50, null, false, false)));
 
-    execute(
-        "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
-
     // Damit per messaging gespeicherte Dokumente weiterhing gefunden werden,
     // ist die referenz weiter nötig, neuerdings wird dafür die Belegnummer
     // verwendet.
@@ -71,6 +68,9 @@ public class Update0511 extends AbstractDDLUpdate
 
     // Temp-Tabelle entfernen
     execute("DROP TEMPORARY TABLE IF EXISTS temp_first;");
+
+    execute(
+        "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
 
     execute(createForeignKey("fkBuchung", "buchungsdokumentbuchung", "buchung",
         "buchung", "id", "CASCADE", "RESTRICT"));

--- a/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
+++ b/src/main/java/de/jost_net/JVerein/server/DDLTool/Updates/Update0511.java
@@ -42,15 +42,22 @@ public class Update0511 extends AbstractDDLUpdate
     execute(createTable(table));
 
     execute(
-        "CREATE UNIQUE INDEX dokumentbuchung ON buchungsdokumentbuchung (dokument,buchung);");
+        "INSERT INTO buchungsdokumentbuchung (dokument,buchung) SELECT id,referenz FROM buchungdokument"
+            + " WHERE referenz IS NOT NULL");
 
     execute(
-        "INSERT INTO buchungsdokumentbuchung (dokument,buchung) SELECT id,referenz FROM buchungdokument");
+        "CREATE UNIQUE INDEX dokumentbuchung ON buchungsdokumentbuchung (dokument,buchung);");
 
     execute(addColumn("buchungdokument",
         new Column("belegnummer", COLTYPE.VARCHAR, 50, null, false, false)));
-    execute(
-        "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
+
+    // Bestehende Dokumente haben die gleiche refernz (=buchung_id) für mehre
+    // Dokumente, durch die Migration wird dort Belegnummer = rerferenz gesetzt.
+    // Daher kann es mehrfach die gleiche "Belegnummer" für bestehende Dokumente
+    // geben. Ein Unique Key ist daher ohne Migration der bestehdenden Dokumente
+    // nicht möglich.
+    // execute(
+    // "CREATE UNIQUE INDEX belegnummer ON buchungdokument (belegnummer);");
 
     // Damit per messaging gespeicherte Dokumente weiterhing gefunden werden,
     // ist die referenz weiter nötig, neuerdings wird dafür die Belegnummer

--- a/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
+++ b/src/main/java/de/jost_net/JVerein/server/RechnungImpl.java
@@ -687,7 +687,7 @@ public class RechnungImpl extends AbstractJVereinDBObject
 
         // Rechnungsnummer erstellen
         Map<String, Object> map = new AllgemeineMap().getMap(null);
-        new RechnungMap().getMap(this, map);
+        map = new RechnungMap().getMap(this, map);
         if (getMitglied() != null)
         {
           map = new MitgliedMap().getMap(getMitglied(), map);

--- a/src/main/java/de/jost_net/JVerein/util/VorlageUtil.java
+++ b/src/main/java/de/jost_net/JVerein/util/VorlageUtil.java
@@ -26,6 +26,7 @@ import de.jost_net.JVerein.Variable.AbrechnungSollbuchungenParameterMap;
 import de.jost_net.JVerein.Variable.AbrechnungslaufParameterMap;
 import de.jost_net.JVerein.Variable.AllgemeineMap;
 import de.jost_net.JVerein.Variable.AuswertungArbeitseinsatzFilterMap;
+import de.jost_net.JVerein.Variable.BelegMap;
 import de.jost_net.JVerein.Variable.BuchungMap;
 import de.jost_net.JVerein.Variable.FilterMap;
 import de.jost_net.JVerein.Variable.JahresabschlussListeFilterMap;
@@ -51,6 +52,7 @@ import de.jost_net.JVerein.keys.VorlageTyp;
 import de.jost_net.JVerein.keys.Vorlageart;
 import de.jost_net.JVerein.rmi.Abrechnungslauf;
 import de.jost_net.JVerein.rmi.Buchung;
+import de.jost_net.JVerein.rmi.BuchungDokument;
 import de.jost_net.JVerein.rmi.Lastschrift;
 import de.jost_net.JVerein.rmi.Rechnung;
 import de.jost_net.JVerein.rmi.Spendenbescheinigung;
@@ -169,6 +171,9 @@ public class VorlageUtil
         case ANLAGEN_SUMMENBUCHUNGEN_TITEL:
         case ANLAGEN_SUMMENBUCHUNGEN_SUBTITEL:
         case ANLAGEN_CSVBUCHUNGEN_DATEINAME:
+        case BELEG_TITEL:
+        case BELEG_SUBTITEL:
+        case BELEG_DATEINAME:
           map = new FilterMap().getMap((FilterControl) obj, map);
           break;
         case AUSWERTUNG_ALTERSJUBILARE_DATEINAME:
@@ -380,8 +385,10 @@ public class VorlageUtil
           break;
         case BUCHUNGSREPORT_DATEINAME:
           map.put("formular_name", name);
-        case BUCHUNG_DOKUMENT_PFAD:
           map = new BuchungMap().getMap((Buchung) obj, map);
+          break;
+        case BELEG_PFAD:
+          map = new BelegMap().getMap((BuchungDokument) obj, map);
           break;
       }
     }
@@ -410,6 +417,15 @@ public class VorlageUtil
       map = new AllgemeineMap().getMap(null);
       switch (typ)
       {
+        case BELEG_TITEL:
+        case BELEG_SUBTITEL:
+        case BELEG_DATEINAME:
+          set = new HashSet<>();
+          set.add(Filter.NUMMER);
+          set.add(Filter.BEZEICHNUNG);
+          set.add(Filter.NICHT_ZUGEORDNET);
+          map = new FilterMap().getDummyMap(set, map);
+          break;
         case ABRECHNUNGSLAEUFE_DATEINAME:
         case ABRECHNUNGSLAEUFE_SUBTITEL:
         case ABRECHNUNGSLAEUFE_TITEL:
@@ -884,8 +900,10 @@ public class VorlageUtil
           break;
         case BUCHUNGSREPORT_DATEINAME:
           map.put("formular_name", "Buchungsreport");
-        case BUCHUNG_DOKUMENT_PFAD:
           map = new BuchungMap().getMap(null, map);
+          break;
+        case BELEG_PFAD:
+          map = new BelegMap().getMap(null, map);
           break;
       }
     }


### PR DESCRIPTION
Wie besprochen hab ich die Belege überarbeitet
- Die Tabelle BuchungDokument bleibt bestehen, sie bekommt eine neue Spalte "Belegnummer"
- Die Spalte "Referenz" wird nicht mehr gebraucht, ich habe sie jedoch vorerst gelassen, falls es Probleme beim Update geben sollte.
- Mitgliedsokumente bleiben wie gehabt bestehen.
- BuchungDokumen erbt weiterhin von AbstragtDocument. getNummer hab ich hinzugefügt um die Refereznummer für Messaging zu bekommen. Bei MitgliedDokument ist weiterhin die Referenz, bei Belegen die Belegnummer.
- Die Beziehung zwischen Buchung und Dokument werden über die neue Tabelle BuchungsdokumentBuchung hergestellt. Diese erweitert AbstractBelegReferenzImpl, so können auch leicht weitere Dokumenttypen implementiert werden.
- Alle Klassen die Dokumente aufnehmen können, müssen nun IBeleg implementieren, dort wird eine addBeleg, removeBeleg und getBelegList Funktion erstellt.
- Es gibt in der Navigation einen neuen Eintrag "Belege" mit einer filterbaren Liste aller Belege. Über die Beleg-Detail-View können alle zugeordneten Dokumente angezeigt werden.
- In der BuchungDetailView gibt es einen Button "Beleg zuordnen", da öffnet sich ein Dialog mit allen Belegen (gleich wie BelegListView), und es können ein oder mehrere Belege der Buchung zugeordnet werden.
- Aus der BuchungDetailView könne Belege komplett gelöscht werden, oder auch nur aus der Buchung entfernt werden.
- Ähnlich wie bei Rechnungen gibt es jetzt in den Einstellungen auch einen Eintrag für "Belegnummer" und "Beleg Zähler". Der Zähler wird nach jeder Buchung hochgezählt.
- Für Die Belegnummer und BelegPfad (wie bestehend) gibt es die BelegMap, diese enthält bisher jedoch nur BelegZähler als Eintrag.
- Auch im GUI habe ich alle bestehenden Klassen für MitgliedDokument so gelassen. Für die meisten habe ich ähnliche, neu Klassen erstellt. Falls wir MitgliedDokument mit Belegen zusammenführen, könnten die gelöscht werden.
- Drag'n'Drop ist weiterhin möglich, auch in der BelegListeView. Um das zu vereinfachen habe ich den Drag'n'Drop code in ein Util verschoben. 
- Die Refernz Spalte bleibt in der Datenbak bestehen. Jeweils das erste bereits bestehende Dokument einer Buchung bekommt bei der Migration die Referenz als Belegnummer. Weitere Dokumente müssen weiterhin per Referenz gefunden werden, das wir in BuchungDokument getNummer() fallweise unterschieden.

Hier noch ein Paar Screenshots:
Beleg-Zuordnen-Dialog:
<img width="1198" height="400" alt="belegDialog" src="https://github.com/user-attachments/assets/1ae83ce7-d5a8-4b91-927f-ec946eff8616" />

BuchungDetailView:
<img width="1492" height="206" alt="buchungDetail" src="https://github.com/user-attachments/assets/62eed49d-b7c0-4404-af62-49a3788fc66f" />

BelegDetailView:
<img width="1095" height="395" alt="belegDetail" src="https://github.com/user-attachments/assets/ed716daa-65da-40f5-b515-9138fa44cea0" />

BelegListeView:
<img width="1101" height="400" alt="belegListe" src="https://github.com/user-attachments/assets/e1139dd6-5c46-420c-bcad-493ae995c8f5" />