### PR TITLE
Fix Splitbuchungen 1ct statt 10ct

### DIFF
--- a/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -565,7 +565,7 @@ public class SplitbuchungsContainer
         {
           betragZuordnen = buchung.getBetrag() - zugeordnet;
         }
-        if (Math.abs(betragZuordnen) < 0.1d)
+        if (Math.abs(betragZuordnen) < 0.01d)
         {
           continue;
         }


### PR DESCRIPTION
Die Grenze sollte bei 1ct und nicht bei 10ct liegen