### PR TITLE
Abstract DetailView Extension deregistrieren

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/view/AbstractDetailView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/AbstractDetailView.java
@@ -25,6 +25,7 @@ import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.extension.Extendable;
+import de.willuhn.jameica.gui.extension.Extension;
 import de.willuhn.jameica.gui.extension.ExtensionRegistry;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
@@ -44,7 +45,17 @@ public abstract class AbstractDetailView extends AbstractView
   {
     // Nach dem bind() wird extend() aufgerufen, das nutzen wir, um zu prüfen,
     // ob das bind() auch erfolgreich geklappt hat.
-    ExtensionRegistry.register(e -> bindSucessfull = true, "jverein.view");
+    ExtensionRegistry.register(new Extension()
+    {
+      @Override
+      public void extend(Extendable extendable)
+      {
+        bindSucessfull = true;
+        // jetzt wird die Extension nicht mehr gebraucht, daher entfernen wir
+        // sie wieder
+        ExtensionRegistry.getExtensions("jverein.view").remove(this);
+      }
+    }, "jverein.view");
   }
 
   /**


### PR DESCRIPTION
In der AbstractDetailView wurde für jeden DetailView aufruf eine Extension registriert (Für die Prüfung, ob die View erfolgreich geladen wurde). Die Extension wurde jedoch nie wieder entfernt, und somit waren irgendwann sehr viele unnötige aufrufe registiert.
Jetzt habe ich hier die deregistrierung realisiert.