### PR TITLE
Splitbuchung Infobox nur bei mehreren BUchungen

### DIFF
--- a/src/main/java/de/jost_net/JVerein/gui/view/SplitbuchungDetailView.java
+++ b/src/main/java/de/jost_net/JVerein/gui/view/SplitbuchungDetailView.java
@@ -44,11 +44,16 @@ public class SplitbuchungDetailView extends AbstractView
 
     final boolean editable = control.isSplitBuchungEditable();
 
-    InfoPanel info = new InfoPanel();
-    info.setText(SplitbuchungsContainer.getText());
-    info.setTitle("Info");
-    info.setIcon("gtk-info.png");
-    info.paint(getParent());
+    int anzahl = SplitbuchungsContainer.getAnzahl();
+    if (anzahl > 1)
+    {
+      InfoPanel info = new InfoPanel();
+      info.setText("Es werden " + anzahl + " Splitbuchungen erzeugt.\n"
+          + "Geänderte Zwecke oder Kommentare in Splitpositionen werden bei allen Buchungen übernommen.");
+      info.setTitle("Info");
+      info.setIcon("gtk-info.png");
+      info.paint(getParent());
+    }
     control.getSplitBuchungsList().paint(getParent());
 
     ButtonArea buttons = new ButtonArea();

--- a/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
+++ b/src/main/java/de/jost_net/JVerein/io/SplitbuchungsContainer.java
@@ -49,24 +49,11 @@ public class SplitbuchungsContainer
 
   private static int anzahl = 0;
 
-  private static String text = null;
-
   public static void init(Buchung[] bl)
       throws RemoteException, ApplicationException
   {
     anzahl = bl.length;
-    if (anzahl == 1)
-    {
-      buchungen = null;
-      text = "Es wird eine Splitbuchung erzeugt.";
-    }
-    else
-    {
-      buchungen = bl;
-      text = String.format(
-          "Es werden %s Splitbuchungen erzeugt.\nGeänderte Zwecke oder Kommentare in Splitpositionen werden bei allen Buchungen übernommen.",
-          anzahl);
-    }
+    buchungen = bl;
     initiate(bl[0]);
   }
 
@@ -75,7 +62,6 @@ public class SplitbuchungsContainer
   {
     buchungen = null;
     anzahl = 1;
-    text = "Es wird eine Splitbuchung erzeugt.";
     initiate(b);
   }
 
@@ -325,11 +311,6 @@ public class SplitbuchungsContainer
       buchungen = null;
       splitbuchungen.clear();
     }
-  }
-
-  public static String getText()
-  {
-    return text;
   }
 
   /**


### PR DESCRIPTION
Hiermit wird die Infobox in der SplitbuchungView nur noch angezeigt, wenn mehrer Buchungen gleichzeitig gesplittet werden. Ich fand es immer iritierend, wenn dort steht "Es wird eine Splitbuchung erzeugt", ja hoffentlich, was denn sonst. Die Bedeutung auf "eine" kann man da nicht rauslesen.